### PR TITLE
Add Slack trigger completion reaction emoji support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each `trigger` entry must contain exactly one trigger type:
 - `git_pull_request` - Trigger on pull request events.
 - `git_push` - Trigger on git push events.
 - `cron` - Trigger on a cron schedule.
-- `slack` - Trigger on Slack messages.
+- `slack` - Trigger on Slack messages. Supports `channel`, `message_contains`, `message_contains_is_regex`, `block_unauthenticated_slack_users`, and the completion reaction settings below.
 - `linear` - Trigger on Linear events.
 - `webhook` - Trigger on generic webhook POST requests.
 - `microsoft_teams` - Trigger on Microsoft Teams messages.
@@ -123,6 +123,25 @@ trigger = [
 ```
 
 For `git_pull_request`, specify either `orgs` or `repos`, not both, in a single trigger. Use separate trigger entries if you need both org-wide and explicit repo coverage.
+
+#### Slack completion reaction
+
+A `slack` trigger can control the emoji reaction Cursor adds to the triggering Slack message when the automation completes successfully:
+
+- `completion_reaction_mode` - `on` (default Cursor reaction), `off` (no reaction), or `custom` (use `completion_reaction_custom_emoji`). Leave unset to use the Cursor default.
+- `completion_reaction_custom_emoji` - Custom Slack reaction emoji in `:emoji_name:` form. Required when `completion_reaction_mode` is `custom`, and only valid in that mode.
+
+```hcl
+trigger = [
+  {
+    slack = {
+      channel                          = "C0123456789"
+      completion_reaction_mode         = "custom"
+      completion_reaction_custom_emoji = ":white_check_mark:"
+    }
+  }
+]
+```
 
 ### Actions
 

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -167,6 +167,8 @@ type slackTriggerModel struct {
 	MessageContains                types.String `tfsdk:"message_contains"`
 	MessageContainsIsRegex         types.Bool   `tfsdk:"message_contains_is_regex"`
 	BlockUnauthenticatedSlackUsers types.Bool   `tfsdk:"block_unauthenticated_slack_users"`
+	CompletionReactionMode         types.String `tfsdk:"completion_reaction_mode"`
+	CompletionReactionCustomEmoji  types.String `tfsdk:"completion_reaction_custom_emoji"`
 }
 
 type linearTriggerModel struct {
@@ -413,6 +415,14 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								"block_unauthenticated_slack_users": schema.BoolAttribute{
 									Optional:    true,
 									Description: "If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).",
+								},
+								"completion_reaction_mode": schema.StringAttribute{
+									Optional:    true,
+									Description: `Controls the emoji reaction added to the triggering Slack message when the automation completes successfully: "on" (default Cursor reaction), "off" (no reaction), or "custom" (use completion_reaction_custom_emoji). Leave unset to use the Cursor default.`,
+								},
+								"completion_reaction_custom_emoji": schema.StringAttribute{
+									Optional:    true,
+									Description: `Custom Slack reaction emoji in ":emoji_name:" form. Only used when completion_reaction_mode is "custom".`,
 								},
 							},
 						},
@@ -1533,6 +1543,9 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		if !slack.BlockUnauthenticatedSlackUsers.IsNull() && !slack.BlockUnauthenticatedSlackUsers.IsUnknown() && slack.BlockUnauthenticatedSlackUsers.ValueBool() {
 			st.BlockUnauthenticatedSlackUsers = true
 		}
+		if err := applySlackCompletionReaction(st, slack.CompletionReactionMode, slack.CompletionReactionCustomEmoji); err != nil {
+			return nil, err
+		}
 		trigger.Trigger = &v1.Trigger_SlackTrigger{SlackTrigger: st}
 	}
 
@@ -1662,6 +1675,67 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 	}
 
 	return trigger, nil
+}
+
+// applySlackCompletionReaction translates the Terraform completion reaction
+// fields onto a SlackTrigger proto, validating the relationship between the
+// mode and the custom emoji.
+func applySlackCompletionReaction(st *v1.SlackTrigger, mode types.String, customEmoji types.String) error {
+	hasMode := !mode.IsNull() && !mode.IsUnknown()
+	hasEmoji := !customEmoji.IsNull() && !customEmoji.IsUnknown() && customEmoji.ValueString() != ""
+
+	if !hasMode {
+		if hasEmoji {
+			return fmt.Errorf("slack.completion_reaction_custom_emoji can only be set when slack.completion_reaction_mode is \"custom\"")
+		}
+		return nil
+	}
+
+	parsedMode, err := parseSlackCompletionReactionMode(mode.ValueString())
+	if err != nil {
+		return err
+	}
+
+	if parsedMode == v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_CUSTOM {
+		if !hasEmoji {
+			return fmt.Errorf("slack.completion_reaction_custom_emoji is required when slack.completion_reaction_mode is \"custom\"")
+		}
+	} else if hasEmoji {
+		return fmt.Errorf("slack.completion_reaction_custom_emoji can only be set when slack.completion_reaction_mode is \"custom\"")
+	}
+
+	st.SlackCompletionReactionMode = &parsedMode
+	if hasEmoji {
+		emoji := customEmoji.ValueString()
+		st.SlackCompletionReactionCustomEmoji = &emoji
+	}
+	return nil
+}
+
+func parseSlackCompletionReactionMode(s string) (v1.SlackCompletionReactionMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "on":
+		return v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_ON, nil
+	case "off":
+		return v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_OFF, nil
+	case "custom":
+		return v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_CUSTOM, nil
+	default:
+		return 0, fmt.Errorf("invalid slack.completion_reaction_mode %q, must be \"on\", \"off\", or \"custom\"", s)
+	}
+}
+
+func slackCompletionReactionModeToString(m v1.SlackCompletionReactionMode) string {
+	switch m {
+	case v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_ON:
+		return "on"
+	case v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_OFF:
+		return "off"
+	case v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_CUSTOM:
+		return "custom"
+	default:
+		return ""
+	}
 }
 
 func parsePrAction(s string) (v1.GitPullRequestAction, error) {
@@ -1939,6 +2013,17 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 			sm.BlockUnauthenticatedSlackUsers = types.BoolValue(true)
 		} else {
 			sm.BlockUnauthenticatedSlackUsers = types.BoolNull()
+		}
+		if slack.SlackCompletionReactionMode != nil &&
+			slack.GetSlackCompletionReactionMode() != v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_UNSPECIFIED {
+			sm.CompletionReactionMode = types.StringValue(slackCompletionReactionModeToString(slack.GetSlackCompletionReactionMode()))
+		} else {
+			sm.CompletionReactionMode = types.StringNull()
+		}
+		if slack.GetSlackCompletionReactionCustomEmoji() != "" {
+			sm.CompletionReactionCustomEmoji = types.StringValue(slack.GetSlackCompletionReactionCustomEmoji())
+		} else {
+			sm.CompletionReactionCustomEmoji = types.StringNull()
 		}
 		tm.Slack = sm
 		tm.UserAllowlist = types.ListNull(types.StringType)

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -737,6 +737,209 @@ func TestGitRepoTargetMetadata(t *testing.T) {
 	}
 }
 
+func TestSlackTriggerCompletionReactionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto_on", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to slack"),
+			Triggers: []triggerModel{
+				{
+					Slack: &slackTriggerModel{
+						Channel:                       types.StringValue("C0123456789"),
+						CompletionReactionMode:        types.StringValue("on"),
+						CompletionReactionCustomEmoji: types.StringNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		slack := wf.Triggers[0].GetSlackTrigger()
+		if slack == nil {
+			t.Fatal("expected slack trigger in proto")
+		}
+		if got, want := slack.GetSlackCompletionReactionMode(), v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_ON; got != want {
+			t.Fatalf("completion reaction mode = %v, want %v", got, want)
+		}
+		if slack.SlackCompletionReactionCustomEmoji != nil {
+			t.Fatalf("expected no custom emoji, got %q", slack.GetSlackCompletionReactionCustomEmoji())
+		}
+	})
+
+	t.Run("model_to_proto_custom", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to slack"),
+			Triggers: []triggerModel{
+				{
+					Slack: &slackTriggerModel{
+						Channel:                       types.StringValue("C0123456789"),
+						CompletionReactionMode:        types.StringValue("custom"),
+						CompletionReactionCustomEmoji: types.StringValue(":tada:"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		slack := wf.Triggers[0].GetSlackTrigger()
+		if got, want := slack.GetSlackCompletionReactionMode(), v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_CUSTOM; got != want {
+			t.Fatalf("completion reaction mode = %v, want %v", got, want)
+		}
+		if got, want := slack.GetSlackCompletionReactionCustomEmoji(), ":tada:"; got != want {
+			t.Fatalf("custom emoji = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("model_to_proto_custom_requires_emoji", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to slack"),
+			Triggers: []triggerModel{
+				{
+					Slack: &slackTriggerModel{
+						Channel:                       types.StringValue("C0123456789"),
+						CompletionReactionMode:        types.StringValue("custom"),
+						CompletionReactionCustomEmoji: types.StringNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil {
+			t.Fatal("expected error when custom mode has no emoji")
+		}
+		if !strings.Contains(err.Error(), "completion_reaction_custom_emoji is required") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("model_to_proto_emoji_requires_custom_mode", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to slack"),
+			Triggers: []triggerModel{
+				{
+					Slack: &slackTriggerModel{
+						Channel:                       types.StringValue("C0123456789"),
+						CompletionReactionMode:        types.StringValue("on"),
+						CompletionReactionCustomEmoji: types.StringValue(":tada:"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil {
+			t.Fatal("expected error when emoji set without custom mode")
+		}
+		if !strings.Contains(err.Error(), "can only be set when slack.completion_reaction_mode is \"custom\"") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("model_to_proto_invalid_mode", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to slack"),
+			Triggers: []triggerModel{
+				{
+					Slack: &slackTriggerModel{
+						Channel:                types.StringValue("C0123456789"),
+						CompletionReactionMode: types.StringValue("sometimes"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil {
+			t.Fatal("expected error for invalid completion_reaction_mode")
+		}
+		if !strings.Contains(err.Error(), "invalid slack.completion_reaction_mode") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("proto_to_model_custom", func(t *testing.T) {
+		customEmoji := ":tada:"
+		mode := v1.SlackCompletionReactionMode_SLACK_COMPLETION_REACTION_MODE_CUSTOM
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Prompts: []*v1.Prompt{{Prompt: "respond to slack"}},
+					Triggers: []*v1.Trigger{
+						{
+							Trigger: &v1.Trigger_SlackTrigger{
+								SlackTrigger: &v1.SlackTrigger{
+									Channel:                            "C0123456789",
+									SlackCompletionReactionMode:        &mode,
+									SlackCompletionReactionCustomEmoji: &customEmoji,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		if model.Triggers[0].Slack == nil {
+			t.Fatal("expected slack trigger in model")
+		}
+		if got, want := model.Triggers[0].Slack.CompletionReactionMode.ValueString(), "custom"; got != want {
+			t.Fatalf("completion_reaction_mode = %q, want %q", got, want)
+		}
+		if got, want := model.Triggers[0].Slack.CompletionReactionCustomEmoji.ValueString(), ":tada:"; got != want {
+			t.Fatalf("completion_reaction_custom_emoji = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("proto_to_model_unset_is_null", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Prompts: []*v1.Prompt{{Prompt: "respond to slack"}},
+					Triggers: []*v1.Trigger{
+						{
+							Trigger: &v1.Trigger_SlackTrigger{
+								SlackTrigger: &v1.SlackTrigger{Channel: "C0123456789"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		slack := model.Triggers[0].Slack
+		if slack == nil {
+			t.Fatal("expected slack trigger in model")
+		}
+		if !slack.CompletionReactionMode.IsNull() {
+			t.Fatalf("expected completion_reaction_mode to be null, got %q", slack.CompletionReactionMode.ValueString())
+		}
+		if !slack.CompletionReactionCustomEmoji.IsNull() {
+			t.Fatalf("expected completion_reaction_custom_emoji to be null, got %q", slack.CompletionReactionCustomEmoji.ValueString())
+		}
+	})
+}
+
 func TestLinearTriggerRoundTrip(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds support for configuring the emoji reaction Cursor adds to a triggering Slack message when an automation completes successfully. The underlying `SlackTrigger.slack_completion_reaction_mode` and `SlackTrigger.slack_completion_reaction_custom_emoji` proto fields already existed but were not exposed in the Terraform schema.

## Changes

- Added two new optional attributes to the `slack` trigger block:
  - `completion_reaction_mode` — `"on"` (default Cursor reaction), `"off"` (no reaction), or `"custom"` (use the custom emoji). Leave unset for the Cursor default.
  - `completion_reaction_custom_emoji` — custom Slack reaction in `:emoji_name:` form; required when mode is `"custom"` and only valid in that mode.
- Wired the new fields through `modelToWorkflow` (model → proto) and `protoToModel` (proto → model), including a helper that validates the relationship between the mode and the custom emoji.
- Documented the new fields in the README with an example.

## Validation

- `go build ./...`, `go vet ./...`, and `gofmt -l internal/` are clean.
- Added `TestSlackTriggerCompletionReactionRoundTrip` covering `on`/`custom` round-trips, null defaults, and the validation errors (missing emoji for custom mode, emoji set without custom mode, invalid mode). `go test ./...` passes.

## Notes

The new fields populate the `SlackTrigger`-level reaction settings (the recommended location), not the deprecated workflow-level fields.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75c84d29-815e-484d-8629-e24d605dea25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75c84d29-815e-484d-8629-e24d605dea25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

