### PR TITLE
Fix round-tripping of server-populated fields

### DIFF
--- a/docs/resources/platform_workflow.md
+++ b/docs/resources/platform_workflow.md
@@ -64,7 +64,7 @@ resource "cursor_platform_workflow" "example_review" {
 - `git_branch` (String) Git branch for non-git triggers. Defaults to main.
 - `git_repo` (String) Git repository for non-git triggers (cron, slack, linear). E.g. github.com/org/repo.
 - `memory_enabled` (Boolean) Enable the AutomationMemory tool, giving the agent persistent memory across runs.
-- `model` (String) Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o).
+- `model` (String) Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model.
 - `scope` (String) Automation ownership scope: "user", "team", "team_visible", "team_editable_user", or "team_editable". "user" is private (owner and admins only), "team" is shared (team admins can edit, runs as team service account), "team_visible" is viewable by team (team can view, only owner can edit, runs as owner), "team_editable_user" is editable by the team but still runs as the creator user, and "team_editable" is editable by the team and runs as the team service account. Defaults to "user" when unset.
 - `skip_install` (Boolean) Skip user install commands and cloud testing.
 

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -1361,13 +1361,33 @@ func gitConfigRepos(gitRepo string, triggers []*v1.Trigger) []string {
 }
 
 // gitConfigRepoKey returns a case-insensitive de-duplication key for a repo
-// target, treating different spellings of the same owner/repo (e.g. with and
-// without a host prefix) as equivalent.
+// target, treating different spellings of the same owner/repo on the same host
+// (e.g. with and without a GitHub host prefix) as equivalent.
 func gitConfigRepoKey(repo string) string {
 	if name := parseGitRepoNameFromTarget(repo); name != "" {
-		return strings.ToLower(name)
+		return gitConfigRepoKeyHost(repo) + ":" + strings.ToLower(name)
 	}
 	return strings.ToLower(repo)
+}
+
+func gitConfigRepoKeyHost(repo string) string {
+	trimmedRepo := strings.TrimSpace(repo)
+	if strings.Contains(trimmedRepo, "://") {
+		parsedURL, err := url.Parse(trimmedRepo)
+		if err == nil && parsedURL.Hostname() != "" {
+			return strings.ToLower(parsedURL.Hostname())
+		}
+	}
+
+	firstSlashIndex := strings.Index(trimmedRepo, "/")
+	if firstSlashIndex != -1 {
+		firstSegment := strings.TrimSpace(trimmedRepo[:firstSlashIndex])
+		if isKnownGitHostingDomain(firstSegment) || gitRepoProviderFromHostname(firstSegment) != "other" {
+			return strings.ToLower(firstSegment)
+		}
+	}
+
+	return "github.com"
 }
 
 func actionModelToProto(a *actionModel) (*v1.Action, error) {

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -321,7 +321,11 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 			},
 			"model": schema.StringAttribute{
 				Optional:    true,
-				Description: "Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o).",
+				Computed:    true,
+				Description: "Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"git_repo": schema.StringAttribute{
 				Optional:    true,
@@ -1263,18 +1267,6 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 		w.Model = &model
 	}
 
-	// GitConfig (for non-git triggers)
-	if (!m.GitRepo.IsNull() && !m.GitRepo.IsUnknown()) || (!m.GitBranch.IsNull() && !m.GitBranch.IsUnknown()) {
-		gc := &v1.GitConfig{}
-		if !m.GitRepo.IsNull() && !m.GitRepo.IsUnknown() {
-			gc.Repo = m.GitRepo.ValueString()
-		}
-		if !m.GitBranch.IsNull() && !m.GitBranch.IsUnknown() {
-			gc.Branch = m.GitBranch.ValueString()
-		}
-		w.GitConfig = gc
-	}
-
 	// AgentOptions
 	if !m.SkipInstall.IsNull() && !m.SkipInstall.IsUnknown() {
 		skip := m.SkipInstall.ValueBool()
@@ -1296,6 +1288,27 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 		w.Triggers = append(w.Triggers, trigger)
 	}
 
+	// GitConfig: the explicit git_repo/git_branch attributes plus the repos
+	// referenced by git triggers. Without the trigger-derived repos, an
+	// automation whose only repo references live in its triggers would be
+	// persisted with no git configuration and could never launch.
+	gitRepo := ""
+	if !m.GitRepo.IsNull() && !m.GitRepo.IsUnknown() {
+		gitRepo = m.GitRepo.ValueString()
+	}
+	gitBranch := ""
+	if !m.GitBranch.IsNull() && !m.GitBranch.IsUnknown() {
+		gitBranch = m.GitBranch.ValueString()
+	}
+	repos := gitConfigRepos(gitRepo, w.Triggers)
+	if gitRepo != "" || gitBranch != "" || len(repos) > 0 {
+		w.GitConfig = &v1.GitConfig{
+			Repo:   gitRepo,
+			Branch: gitBranch,
+			Repos:  repos,
+		}
+	}
+
 	// Actions
 	for i, a := range m.Actions {
 		action, err := actionModelToProto(&a)
@@ -1306,6 +1319,55 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 	}
 
 	return w, nil
+}
+
+// gitConfigRepos merges the top-level git_repo (first, when set) with the
+// repos referenced by the workflow's git triggers, preserving order and
+// de-duplicating equivalent targets. Org-scoped pull request triggers name a
+// whole org rather than concrete repos, so they contribute nothing here.
+func gitConfigRepos(gitRepo string, triggers []*v1.Trigger) []string {
+	var repos []string
+	seen := make(map[string]struct{})
+	add := func(repo string) {
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			return
+		}
+		key := gitConfigRepoKey(repo)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		repos = append(repos, repo)
+	}
+
+	add(gitRepo)
+	for _, t := range triggers {
+		git := t.GetGit()
+		if git == nil {
+			continue
+		}
+		if pr := git.GetPullRequest(); pr != nil {
+			for _, repo := range pr.GetRepos() {
+				add(repo)
+			}
+			add(pr.GetRepo())
+		}
+		if push := git.GetPush(); push != nil {
+			add(push.GetRepo())
+		}
+	}
+	return repos
+}
+
+// gitConfigRepoKey returns a case-insensitive de-duplication key for a repo
+// target, treating different spellings of the same owner/repo (e.g. with and
+// without a host prefix) as equivalent.
+func gitConfigRepoKey(repo string) string {
+	if name := parseGitRepoNameFromTarget(repo); name != "" {
+		return strings.ToLower(name)
+	}
+	return strings.ToLower(repo)
 }
 
 func actionModelToProto(a *actionModel) (*v1.Action, error) {

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -1413,6 +1413,40 @@ func TestGitConfigReposPopulatedFromTriggers(t *testing.T) {
 			t.Fatalf("GitConfig.Repos = %v, want %v", got, want)
 		}
 	})
+
+	t.Run("same_owner_repo_on_different_hosts_preserved", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs:  types.ListNull(types.StringType),
+						Repos: mustStringList(t, ctx, []string{"github.com/example-org/repo-one"}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+				{
+					GitPush: &gitPushModel{
+						Repo:   types.StringValue("gitlab.com/example-org/repo-one"),
+						Branch: types.StringNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.GitConfig == nil {
+			t.Fatal("expected GitConfig to be populated")
+		}
+		want := []string{"github.com/example-org/repo-one", "gitlab.com/example-org/repo-one"}
+		if got := wf.GitConfig.GetRepos(); !reflect.DeepEqual(got, want) {
+			t.Fatalf("GitConfig.Repos = %v, want %v", got, want)
+		}
+	})
 }
 
 // TestGitConfigReposRoundTripStable verifies that sending trigger-derived

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -1191,3 +1191,287 @@ func TestAutomationScopeToModelTeamEditableUser(t *testing.T) {
 		t.Fatalf("scope = %q, want %q", got.ValueString(), "team_editable_user")
 	}
 }
+
+// TestModelIsOptionalComputed verifies that the model attribute is
+// Optional+Computed with UseStateForUnknown, so a server-assigned default
+// model is legitimate state instead of an "inconsistent result after apply"
+// error followed by permanent plan drift.
+func TestModelIsOptionalComputed(t *testing.T) {
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+
+	attr, ok := schemaResp.Schema.Attributes["model"]
+	if !ok {
+		t.Fatal("schema is missing model attribute")
+	}
+
+	strAttr, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("model is not a StringAttribute, got %T", attr)
+	}
+
+	if !strAttr.Optional {
+		t.Error("model should be Optional")
+	}
+	if !strAttr.Computed {
+		t.Error("model should be Computed (the server assigns a default when unset)")
+	}
+	if len(strAttr.PlanModifiers) == 0 {
+		t.Error("model should have a UseStateForUnknown plan modifier")
+	}
+}
+
+// TestModelUnsetAcceptsServerDefault verifies that when the practitioner
+// leaves model unset, the provider sends no model to the server, and the
+// server-assigned default in the response is written to state.
+func TestModelUnsetAcceptsServerDefault(t *testing.T) {
+	ctx := context.Background()
+
+	m := &platformWorkflowModel{
+		Prompt: types.StringValue("do something"),
+		Model:  types.StringNull(),
+		Triggers: []triggerModel{
+			{
+				Cron:          &cronModel{Schedule: types.StringValue("0 9 * * *")},
+				UserAllowlist: types.ListNull(types.StringType),
+			},
+		},
+	}
+
+	wf, err := modelToWorkflow(ctx, m)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() error: %v", err)
+	}
+	if wf.Model != nil {
+		t.Fatalf("expected no model in proto when unset, got %q", wf.GetModel())
+	}
+
+	// During create the plan value is unknown (Computed with no prior state);
+	// it must not be sent either.
+	m.Model = types.StringUnknown()
+	wf, err = modelToWorkflow(ctx, m)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() error: %v", err)
+	}
+	if wf.Model != nil {
+		t.Fatalf("expected no model in proto when unknown, got %q", wf.GetModel())
+	}
+
+	// The server backfills a default model; the response value becomes state.
+	serverModel := "server-default-model"
+	response := &v1.AutomationWithOwner{
+		Workflow: &v1.Automation{
+			AutomationId: "test-id",
+			Workflow: &v1.Workflow{
+				Prompts: []*v1.Prompt{{Prompt: "do something"}},
+				Model:   &serverModel,
+			},
+		},
+	}
+	state, err := protoToModel(ctx, response)
+	if err != nil {
+		t.Fatalf("protoToModel() error: %v", err)
+	}
+	if state.Model.IsNull() || state.Model.IsUnknown() {
+		t.Fatal("expected server-assigned model in state")
+	}
+	if got := state.Model.ValueString(); got != serverModel {
+		t.Fatalf("model = %q, want %q", got, serverModel)
+	}
+}
+
+// TestGitConfigReposPopulatedFromTriggers verifies that repos referenced by
+// git triggers are mirrored into GitConfig.Repos, so automations whose only
+// repo references live in their triggers still persist git configuration.
+func TestGitConfigReposPopulatedFromTriggers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("trigger_repos_without_git_repo", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs:  types.ListNull(types.StringType),
+						Repos: mustStringList(t, ctx, []string{"example-org/repo-one", "example-org/repo-two"}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+				{
+					GitPush: &gitPushModel{
+						Repo:   types.StringValue("example-org/repo-three"),
+						Branch: types.StringNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.GitConfig == nil {
+			t.Fatal("expected GitConfig to be populated from trigger repos")
+		}
+		want := []string{"example-org/repo-one", "example-org/repo-two", "example-org/repo-three"}
+		if got := wf.GitConfig.GetRepos(); !reflect.DeepEqual(got, want) {
+			t.Fatalf("GitConfig.Repos = %v, want %v", got, want)
+		}
+		if got := wf.GitConfig.GetRepo(); got != "" {
+			t.Fatalf("GitConfig.Repo = %q, want empty (git_repo unset)", got)
+		}
+	})
+
+	t.Run("git_repo_included_first_and_deduplicated", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt:  types.StringValue("review code"),
+			GitRepo: types.StringValue("github.com/example-org/repo-one"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs: types.ListNull(types.StringType),
+						// repo-one is spelled differently but refers to the
+						// same repository as git_repo.
+						Repos: mustStringList(t, ctx, []string{"example-org/repo-one", "example-org/repo-two"}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.GitConfig == nil {
+			t.Fatal("expected GitConfig to be populated")
+		}
+		if got, want := wf.GitConfig.GetRepo(), "github.com/example-org/repo-one"; got != want {
+			t.Fatalf("GitConfig.Repo = %q, want %q", got, want)
+		}
+		want := []string{"github.com/example-org/repo-one", "example-org/repo-two"}
+		if got := wf.GitConfig.GetRepos(); !reflect.DeepEqual(got, want) {
+			t.Fatalf("GitConfig.Repos = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("org_only_trigger_sets_no_git_config", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs:  mustStringList(t, ctx, []string{"example-org"}),
+						Repos: types.ListNull(types.StringType),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.GitConfig != nil {
+			t.Fatalf("expected no GitConfig for org-only trigger, got %+v", wf.GitConfig)
+		}
+	})
+
+	t.Run("duplicate_repos_across_triggers_deduplicated", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs:  types.ListNull(types.StringType),
+						Repos: mustStringList(t, ctx, []string{"example-org/repo-one"}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+				{
+					GitPush: &gitPushModel{
+						Repo:   types.StringValue("Example-Org/Repo-One"),
+						Branch: types.StringNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.GitConfig == nil {
+			t.Fatal("expected GitConfig to be populated")
+		}
+		want := []string{"example-org/repo-one"}
+		if got := wf.GitConfig.GetRepos(); !reflect.DeepEqual(got, want) {
+			t.Fatalf("GitConfig.Repos = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestGitConfigReposRoundTripStable verifies that sending trigger-derived
+// GitConfig.Repos does not introduce drift: reading back a server response
+// that echoes those repos leaves git_repo/git_branch null, and converting the
+// resulting state again produces the same GitConfig.
+func TestGitConfigReposRoundTripStable(t *testing.T) {
+	ctx := context.Background()
+
+	m := &platformWorkflowModel{
+		Prompt: types.StringValue("review code"),
+		Triggers: []triggerModel{
+			{
+				GitPullRequest: &gitPullRequestModel{
+					Orgs:  types.ListNull(types.StringType),
+					Repos: mustStringList(t, ctx, []string{"example-org/repo-one"}),
+				},
+				UserAllowlist: types.ListNull(types.StringType),
+			},
+		},
+	}
+
+	wf, err := modelToWorkflow(ctx, m)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() error: %v", err)
+	}
+	if wf.GitConfig == nil || len(wf.GitConfig.GetRepos()) == 0 {
+		t.Fatal("expected GitConfig.Repos to be populated")
+	}
+
+	// Simulate the server echoing the stored workflow back.
+	response := &v1.AutomationWithOwner{
+		Workflow: &v1.Automation{
+			AutomationId: "test-id",
+			Workflow:     wf,
+		},
+	}
+	state, err := protoToModel(ctx, response)
+	if err != nil {
+		t.Fatalf("protoToModel() error: %v", err)
+	}
+	if !state.GitRepo.IsNull() {
+		t.Fatalf("expected git_repo to stay null, got %q", state.GitRepo.ValueString())
+	}
+	if !state.GitBranch.IsNull() {
+		t.Fatalf("expected git_branch to stay null, got %q", state.GitBranch.ValueString())
+	}
+
+	wf2, err := modelToWorkflow(ctx, &state)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() error on round-tripped state: %v", err)
+	}
+	if wf2.GitConfig == nil {
+		t.Fatal("expected GitConfig after round trip")
+	}
+	if got, want := wf2.GitConfig.GetRepos(), wf.GitConfig.GetRepos(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("GitConfig.Repos after round trip = %v, want %v", got, want)
+	}
+	if got, want := wf2.GitConfig.GetRepo(), wf.GitConfig.GetRepo(); got != want {
+		t.Fatalf("GitConfig.Repo after round trip = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Symptoms

**1. Apply error and permanent drift when `model` is unset.** When a `cursor_platform_workflow` config leaves `model` unset, the API assigns a default model and returns it in the create/update response. The provider wrote that value to state, so Terraform failed with:

```
Provider produced inconsistent result after apply: .model: was null, but now cty.StringVal("gpt-5.5-high")
```

and every subsequent plan showed drift (`model = "..." -> null`).

**2. Automations that never launch.** When git triggers (e.g. `git_pull_request` with `repos`) were configured but the top-level `git_repo` attribute was not set, the provider persisted the automation with no git configuration at all. The backend then refused to launch runs for it (missing git configuration).

## Fix

- `model` is now `Optional + Computed` with a `UseStateForUnknown` plan modifier, so a server-assigned default model is legitimate state rather than an inconsistency. When the config leaves it unset, the provider still sends no model, and the server's choice is stored.
- `modelToWorkflow` now populates `GitConfig.Repos` from the union of repos referenced by git triggers (pull request and push), preserving order and de-duplicating equivalent targets (case-insensitive, host-prefix-insensitive). When `git_repo` is set, it is included first in `Repos`. Reading state back is unchanged: `git_repo`/`git_branch` still map only from `GitConfig.Repo`/`Branch`, so the new `Repos` payload introduces no drift.

## Tests

- `TestModelIsOptionalComputed`: schema declares `model` Optional+Computed with a plan modifier.
- `TestModelUnsetAcceptsServerDefault`: unset/unknown model is not sent to the API; a server-assigned default in the response is accepted into state.
- `TestGitConfigReposPopulatedFromTriggers`: trigger repos populate `GitConfig.Repos` (with and without `git_repo`), org-only triggers set no git config, duplicates across triggers are collapsed.
- `TestGitConfigReposRoundTripStable`: converting model -> proto -> model -> proto is stable and keeps `git_repo`/`git_branch` null.

`go build ./...`, `go test ./...`, and `gofmt -l .` are all clean; docs regenerated with `make docs`.

Resolves TER-1

Made with [Cursor](https://cursor.com)