### PR TITLE
Add git_ci_completed trigger, PR comment regex filter, and MCP server_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ resource "cursor_platform_workflow" "example_review" {
 }
 ```
 
+Supported triggers: `git_pull_request`, `git_push`, `git_ci_completed`, `cron`, `slack`, `linear`, `webhook`, `microsoft_teams`, and `microsoft_teams_channel_created`.
+
+Supported actions: `pr_comment`, `git_pr`, `request_reviewers`, `mcp`, `slack`, `read_slack`, `microsoft_teams`, and `read_microsoft_teams`.
+
 See [`examples/`](./examples) for more, including the data source and import syntax. The resource and data source docs in [`docs/`](./docs) describe every trigger and action type.
 
 ## Development

--- a/docs/data-sources/platform_workflow.md
+++ b/docs/data-sources/platform_workflow.md
@@ -66,6 +66,7 @@ Read-Only:
 Read-Only:
 
 - `server` (String) MCP server name.
+- `server_id` (Number) Stable MCP server ID.
 
 
 <a id="nestedatt--action--microsoft_teams"></a>
@@ -121,6 +122,7 @@ Read-Only:
 Read-Only:
 
 - `cron` (Attributes) Trigger on a cron schedule. (see [below for nested schema](#nestedatt--trigger--cron))
+- `git_ci_completed` (Attributes) Trigger when all CI checks complete on a PR or a specific branch. (see [below for nested schema](#nestedatt--trigger--git_ci_completed))
 - `git_pull_request` (Attributes) Trigger on GitHub pull request events. (see [below for nested schema](#nestedatt--trigger--git_pull_request))
 - `git_push` (Attributes) Trigger on git push events. (see [below for nested schema](#nestedatt--trigger--git_push))
 - `linear` (Attributes) Trigger on Linear events. (see [below for nested schema](#nestedatt--trigger--linear))
@@ -138,12 +140,24 @@ Read-Only:
 - `schedule` (String) Cron expression.
 
 
+<a id="nestedatt--trigger--git_ci_completed"></a>
+### Nested Schema for `trigger.git_ci_completed`
+
+Read-Only:
+
+- `branch` (String) Branch watched for CI completion instead of PRs, when set.
+- `condition` (String) CI outcome that fires the trigger: "failure", "success", or "any".
+- `ignore_base_failures` (Boolean) Whether CI failures that also exist on the base branch are ignored.
+- `repos` (List of String) GitHub repos to watch.
+
+
 <a id="nestedatt--trigger--git_pull_request"></a>
 ### Nested Schema for `trigger.git_pull_request`
 
 Read-Only:
 
 - `comment_contains` (String) Comment text filter for the commented PR action.
+- `comment_contains_is_regex` (Boolean) Whether comment_contains is a regex pattern.
 - `ignore_draft_prs` (Boolean) Do not trigger on draft PRs.
 - `orgs` (List of String) GitHub orgs to watch.
 - `pr_action` (String) PR action that triggers the automation.

--- a/docs/resources/platform_workflow.md
+++ b/docs/resources/platform_workflow.md
@@ -3,12 +3,12 @@
 page_title: "cursor_platform_workflow Resource - cursor"
 subcategory: ""
 description: |-
-  Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).
+  Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).
 ---
 
 # cursor_platform_workflow (Resource)
 
-Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).
+Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).
 
 ## Example Usage
 
@@ -80,6 +80,7 @@ resource "cursor_platform_workflow" "example_review" {
 Optional:
 
 - `cron` (Attributes) Trigger on a cron schedule. (see [below for nested schema](#nestedatt--trigger--cron))
+- `git_ci_completed` (Attributes) Trigger when all CI checks complete on a PR (PR mode) or a specific branch (branch mode). (see [below for nested schema](#nestedatt--trigger--git_ci_completed))
 - `git_pull_request` (Attributes) Trigger on GitHub pull request events. (see [below for nested schema](#nestedatt--trigger--git_pull_request))
 - `git_push` (Attributes) Trigger on git push events. (see [below for nested schema](#nestedatt--trigger--git_push))
 - `linear` (Attributes) Trigger on Linear events. (see [below for nested schema](#nestedatt--trigger--linear))
@@ -97,12 +98,27 @@ Required:
 - `schedule` (String) Cron expression (e.g. 0 9 * * *).
 
 
+<a id="nestedatt--trigger--git_ci_completed"></a>
+### Nested Schema for `trigger.git_ci_completed`
+
+Required:
+
+- `repos` (List of String) GitHub repos to watch (e.g. org/repo). At least one is required.
+
+Optional:
+
+- `branch` (String) If set, trigger on CI completion for this branch (e.g. "main") instead of on PRs. user_allowlist and ignore_base_failures are ignored in branch mode.
+- `condition` (String) Which CI outcome fires the trigger: "failure", "success", or "any". Server default applies if unset.
+- `ignore_base_failures` (Boolean) If true, ignore CI failures that also exist on the base branch. Only applies in PR mode.
+
+
 <a id="nestedatt--trigger--git_pull_request"></a>
 ### Nested Schema for `trigger.git_pull_request`
 
 Optional:
 
 - `comment_contains` (String) Only trigger if the comment body contains this text (case-insensitive). Only used when pr_action is "commented".
+- `comment_contains_is_regex` (Boolean) If true, comment_contains is treated as a regex pattern (case-insensitive).
 - `ignore_draft_prs` (Boolean) Do not trigger on draft PRs.
 - `orgs` (List of String) GitHub orgs to watch (e.g. example-org).
 - `pr_action` (String) PR action to trigger on: "opened", "pushed", "merged", "commented". Triggers on opened+pushed if unset.
@@ -228,6 +244,10 @@ Optional:
 Required:
 
 - `server` (String) MCP server name.
+
+Optional:
+
+- `server_id` (Number) Stable MCP server ID. When set, the server is resolved by ID; server remains for display and backwards compatibility.
 
 
 <a id="nestedatt--action--microsoft_teams"></a>

--- a/internal/provider/data_source_platform_workflow.go
+++ b/internal/provider/data_source_platform_workflow.go
@@ -102,6 +102,10 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 									Computed:    true,
 									Description: "Comment text filter for the commented PR action.",
 								},
+								"comment_contains_is_regex": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether comment_contains is a regex pattern.",
+								},
 							},
 						},
 						"git_push": schema.SingleNestedAttribute{
@@ -115,6 +119,29 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 								"branch": schema.StringAttribute{
 									Computed:    true,
 									Description: "Branch to watch.",
+								},
+							},
+						},
+						"git_ci_completed": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger when all CI checks complete on a PR or a specific branch.",
+							Attributes: map[string]schema.Attribute{
+								"repos": schema.ListAttribute{
+									Computed:    true,
+									ElementType: types.StringType,
+									Description: "GitHub repos to watch.",
+								},
+								"condition": schema.StringAttribute{
+									Computed:    true,
+									Description: `CI outcome that fires the trigger: "failure", "success", or "any".`,
+								},
+								"ignore_base_failures": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether CI failures that also exist on the base branch are ignored.",
+								},
+								"branch": schema.StringAttribute{
+									Computed:    true,
+									Description: "Branch watched for CI completion instead of PRs, when set.",
 								},
 							},
 						},
@@ -305,6 +332,10 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 								"server": schema.StringAttribute{
 									Computed:    true,
 									Description: "MCP server name.",
+								},
+								"server_id": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Stable MCP server ID.",
 								},
 							},
 						},

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -387,6 +387,7 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								},
 								"comment_contains_is_regex": schema.BoolAttribute{
 									Optional:    true,
+									Computed:    true,
 									Description: "If true, comment_contains is treated as a regex pattern (case-insensitive).",
 								},
 							},
@@ -420,6 +421,7 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								},
 								"ignore_base_failures": schema.BoolAttribute{
 									Optional:    true,
+									Computed:    true,
 									Description: "If true, ignore CI failures that also exist on the base branch. Only applies in PR mode.",
 								},
 								"branch": schema.StringAttribute{
@@ -1699,6 +1701,14 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		if err != nil {
 			return nil, err
 		}
+		normalizedRepos := make([]string, 0, len(repos))
+		for _, repo := range repos {
+			normalizedRepo := strings.TrimSpace(repo)
+			if normalizedRepo != "" {
+				normalizedRepos = append(normalizedRepos, normalizedRepo)
+			}
+		}
+		repos = normalizedRepos
 		if len(repos) == 0 {
 			return nil, fmt.Errorf("git_ci_completed must specify at least one repo")
 		}
@@ -2175,9 +2185,10 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 		case *v1.GitTrigger_PullRequest:
 			pr := event.PullRequest
 			prModel := &gitPullRequestModel{
-				Orgs:           types.ListNull(types.StringType),
-				Repos:          types.ListNull(types.StringType),
-				IgnoreDraftPrs: types.BoolValue(pr.GetIgnoreDraftPrs()),
+				Orgs:                   types.ListNull(types.StringType),
+				Repos:                  types.ListNull(types.StringType),
+				IgnoreDraftPrs:         types.BoolValue(pr.GetIgnoreDraftPrs()),
+				CommentContainsIsRegex: types.BoolValue(pr.GetCommentContainsIsRegex()),
 			}
 			if len(pr.GetOrgs()) > 0 {
 				orgs, _ := types.ListValueFrom(ctx, types.StringType, pr.GetOrgs())
@@ -2201,11 +2212,6 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 			} else {
 				prModel.CommentContains = types.StringNull()
 			}
-			if pr.GetCommentContainsIsRegex() {
-				prModel.CommentContainsIsRegex = types.BoolValue(true)
-			} else {
-				prModel.CommentContainsIsRegex = types.BoolNull()
-			}
 			tm.GitPullRequest = prModel
 
 		case *v1.GitTrigger_Push:
@@ -2222,7 +2228,8 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 		case *v1.GitTrigger_CiCompleted:
 			ci := event.CiCompleted
 			ciModel := &gitCICompletedModel{
-				Repos: types.ListNull(types.StringType),
+				Repos:              types.ListNull(types.StringType),
+				IgnoreBaseFailures: types.BoolValue(ci.GetIgnoreBaseFailures()),
 			}
 			if len(ci.GetRepos()) > 0 {
 				repos, _ := types.ListValueFrom(ctx, types.StringType, ci.GetRepos())
@@ -2232,11 +2239,6 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 				ciModel.Condition = types.StringValue(ciCompletionConditionToString(ci.GetCondition()))
 			} else {
 				ciModel.Condition = types.StringNull()
-			}
-			if ci.GetIgnoreBaseFailures() {
-				ciModel.IgnoreBaseFailures = types.BoolValue(true)
-			} else {
-				ciModel.IgnoreBaseFailures = types.BoolNull()
 			}
 			if ci.GetBranch() != "" {
 				ciModel.Branch = types.StringValue(ci.GetBranch())

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -620,6 +620,7 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								},
 								"server_id": schema.Int64Attribute{
 									Optional:    true,
+									Computed:    true,
 									Description: "Stable MCP server ID. When set, the server is resolved by ID; server remains for display and backwards compatibility.",
 								},
 							},
@@ -768,6 +769,7 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 	preserveEquivalentGitPullRequestOrgs(ctx, &state, plan)
+	preserveEquivalentGitCICompletionConditions(&state, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -785,6 +787,7 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 			return
 		}
 		preserveEquivalentGitPullRequestOrgs(ctx, &updated, plan)
+		preserveEquivalentGitCICompletionConditions(&updated, plan)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &updated)...)
 	}
 }
@@ -825,6 +828,7 @@ func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 	preserveEquivalentGitPullRequestOrgs(ctx, &updatedState, state)
+	preserveEquivalentGitCICompletionConditions(&updatedState, state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
@@ -893,6 +897,7 @@ func (r *platformWorkflowResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 	preserveEquivalentGitPullRequestOrgs(ctx, &updatedState, plan)
+	preserveEquivalentGitCICompletionConditions(&updatedState, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
@@ -1086,6 +1091,35 @@ func gitPullRequestOrgsEqualFold(ctx context.Context, current, reference types.L
 		}
 	}
 	return true
+}
+
+// Preserve practitioner-supplied condition casing when it maps to the same
+// API enum value, avoiding post-apply state mismatches.
+func preserveEquivalentGitCICompletionConditions(state *platformWorkflowModel, reference platformWorkflowModel) {
+	if state == nil {
+		return
+	}
+
+	for i := 0; i < len(state.Triggers) && i < len(reference.Triggers); i++ {
+		stateCI := state.Triggers[i].GitCICompleted
+		referenceCI := reference.Triggers[i].GitCICompleted
+		if stateCI == nil || referenceCI == nil {
+			continue
+		}
+		if gitCICompletionConditionsEqualFold(stateCI.Condition, referenceCI.Condition) {
+			stateCI.Condition = referenceCI.Condition
+		}
+	}
+}
+
+func gitCICompletionConditionsEqualFold(current, reference types.String) bool {
+	if current.IsUnknown() || reference.IsUnknown() {
+		return false
+	}
+	if current.IsNull() || reference.IsNull() {
+		return current.IsNull() && reference.IsNull()
+	}
+	return strings.EqualFold(strings.TrimSpace(current.ValueString()), strings.TrimSpace(reference.ValueString()))
 }
 
 func validateAndNormalizeGitPullRequestTargets(rawOrgs, rawRepos []string) ([]string, []string, error) {

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -136,6 +136,7 @@ type platformWorkflowModel struct {
 type triggerModel struct {
 	GitPullRequest               *gitPullRequestModel                      `tfsdk:"git_pull_request"`
 	GitPush                      *gitPushModel                             `tfsdk:"git_push"`
+	GitCICompleted               *gitCICompletedModel                      `tfsdk:"git_ci_completed"`
 	Cron                         *cronModel                                `tfsdk:"cron"`
 	Slack                        *slackTriggerModel                        `tfsdk:"slack"`
 	Linear                       *linearTriggerModel                       `tfsdk:"linear"`
@@ -146,16 +147,24 @@ type triggerModel struct {
 }
 
 type gitPullRequestModel struct {
-	Orgs            types.List   `tfsdk:"orgs"`
-	Repos           types.List   `tfsdk:"repos"`
-	IgnoreDraftPrs  types.Bool   `tfsdk:"ignore_draft_prs"`
-	PrAction        types.String `tfsdk:"pr_action"`
-	CommentContains types.String `tfsdk:"comment_contains"`
+	Orgs                   types.List   `tfsdk:"orgs"`
+	Repos                  types.List   `tfsdk:"repos"`
+	IgnoreDraftPrs         types.Bool   `tfsdk:"ignore_draft_prs"`
+	PrAction               types.String `tfsdk:"pr_action"`
+	CommentContains        types.String `tfsdk:"comment_contains"`
+	CommentContainsIsRegex types.Bool   `tfsdk:"comment_contains_is_regex"`
 }
 
 type gitPushModel struct {
 	Repo   types.String `tfsdk:"repo"`
 	Branch types.String `tfsdk:"branch"`
+}
+
+type gitCICompletedModel struct {
+	Repos              types.List   `tfsdk:"repos"`
+	Condition          types.String `tfsdk:"condition"`
+	IgnoreBaseFailures types.Bool   `tfsdk:"ignore_base_failures"`
+	Branch             types.String `tfsdk:"branch"`
 }
 
 type cronModel struct {
@@ -236,7 +245,8 @@ type requestReviewersActionModel struct {
 }
 
 type mcpActionModel struct {
-	Server types.String `tfsdk:"server"`
+	Server   types.String `tfsdk:"server"`
+	ServerID types.Int64  `tfsdk:"server_id"`
 }
 
 type slackActionModel struct {
@@ -282,7 +292,7 @@ func (r *platformWorkflowResource) Metadata(_ context.Context, req resource.Meta
 
 func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).",
+		Description: "Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
@@ -375,6 +385,10 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 									Optional:    true,
 									Description: "Only trigger if the comment body contains this text (case-insensitive). Only used when pr_action is \"commented\".",
 								},
+								"comment_contains_is_regex": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, comment_contains is treated as a regex pattern (case-insensitive).",
+								},
 							},
 						},
 						"git_push": schema.SingleNestedAttribute{
@@ -388,6 +402,29 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								"branch": schema.StringAttribute{
 									Optional:    true,
 									Description: "Branch to watch.",
+								},
+							},
+						},
+						"git_ci_completed": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger when all CI checks complete on a PR (PR mode) or a specific branch (branch mode).",
+							Attributes: map[string]schema.Attribute{
+								"repos": schema.ListAttribute{
+									Required:    true,
+									ElementType: types.StringType,
+									Description: "GitHub repos to watch (e.g. org/repo). At least one is required.",
+								},
+								"condition": schema.StringAttribute{
+									Optional:    true,
+									Description: `Which CI outcome fires the trigger: "failure", "success", or "any". Server default applies if unset.`,
+								},
+								"ignore_base_failures": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, ignore CI failures that also exist on the base branch. Only applies in PR mode.",
+								},
+								"branch": schema.StringAttribute{
+									Optional:    true,
+									Description: `If set, trigger on CI completion for this branch (e.g. "main") instead of on PRs. user_allowlist and ignore_base_failures are ignored in branch mode.`,
 								},
 							},
 						},
@@ -580,6 +617,10 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								"server": schema.StringAttribute{
 									Required:    true,
 									Description: "MCP server name.",
+								},
+								"server_id": schema.Int64Attribute{
+									Optional:    true,
+									Description: "Stable MCP server ID. When set, the server is resolved by ID; server remains for display and backwards compatibility.",
 								},
 							},
 						},
@@ -1441,10 +1482,15 @@ func actionModelToProto(a *actionModel) (*v1.Action, error) {
 		return &v1.Action{Action: &v1.Action_RequestReviewers{RequestReviewers: &v1.RequestReviewersAction{}}}, nil
 	}
 	if a.Mcp != nil {
+		server := &v1.McpServerConfig{Name: a.Mcp.Server.ValueString()}
+		if !a.Mcp.ServerID.IsNull() && !a.Mcp.ServerID.IsUnknown() {
+			id := a.Mcp.ServerID.ValueInt64()
+			server.Id = &id
+		}
 		return &v1.Action{
 			Action: &v1.Action_Mcp{
 				Mcp: &v1.McpAction{
-					Server: &v1.McpServerConfig{Name: a.Mcp.Server.ValueString()},
+					Server: server,
 				},
 			},
 		}, nil
@@ -1516,6 +1562,9 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 	if t.GitPush != nil {
 		count++
 	}
+	if t.GitCICompleted != nil {
+		count++
+	}
 	if t.Cron != nil {
 		count++
 	}
@@ -1535,10 +1584,10 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		count++
 	}
 	if count == 0 {
-		return nil, fmt.Errorf("must specify exactly one of git_pull_request, git_push, cron, slack, linear, webhook, microsoft_teams, or microsoft_teams_channel_created")
+		return nil, fmt.Errorf("must specify exactly one of git_pull_request, git_push, git_ci_completed, cron, slack, linear, webhook, microsoft_teams, or microsoft_teams_channel_created")
 	}
 	if count > 1 {
-		return nil, fmt.Errorf("must specify exactly one of git_pull_request, git_push, cron, slack, linear, webhook, microsoft_teams, or microsoft_teams_channel_created")
+		return nil, fmt.Errorf("must specify exactly one of git_pull_request, git_push, git_ci_completed, cron, slack, linear, webhook, microsoft_teams, or microsoft_teams_channel_created")
 	}
 
 	// Git pull request
@@ -1572,6 +1621,9 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		if !pr.CommentContains.IsNull() && !pr.CommentContains.IsUnknown() {
 			event.CommentContains = pr.CommentContains.ValueString()
 		}
+		if !pr.CommentContainsIsRegex.IsNull() && !pr.CommentContainsIsRegex.IsUnknown() {
+			event.CommentContainsIsRegex = pr.CommentContainsIsRegex.ValueBool()
+		}
 
 		gitTrigger := &v1.GitTrigger{
 			Event: &v1.GitTrigger_PullRequest{PullRequest: event},
@@ -1595,6 +1647,43 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		}
 		gitTrigger := &v1.GitTrigger{
 			Event: &v1.GitTrigger_Push{Push: event},
+		}
+		if !t.UserAllowlist.IsNull() && !t.UserAllowlist.IsUnknown() {
+			var users []string
+			diags := t.UserAllowlist.ElementsAs(ctx, &users, false)
+			if diags.HasError() {
+				return nil, fmt.Errorf("failed to read user_allowlist")
+			}
+			gitTrigger.UserAllowlist = users
+		}
+		trigger.Trigger = &v1.Trigger_Git{Git: gitTrigger}
+	}
+
+	// Git CI completed
+	if ci := t.GitCICompleted; ci != nil {
+		repos, err := readStringList(ctx, ci.Repos, "git_ci_completed.repos")
+		if err != nil {
+			return nil, err
+		}
+		if len(repos) == 0 {
+			return nil, fmt.Errorf("git_ci_completed must specify at least one repo")
+		}
+		event := &v1.GitCICompletedEvent{Repos: repos}
+		if !ci.Condition.IsNull() && !ci.Condition.IsUnknown() {
+			condition, err := parseCICompletionCondition(ci.Condition.ValueString())
+			if err != nil {
+				return nil, err
+			}
+			event.Condition = condition
+		}
+		if !ci.IgnoreBaseFailures.IsNull() && !ci.IgnoreBaseFailures.IsUnknown() {
+			event.IgnoreBaseFailures = ci.IgnoreBaseFailures.ValueBool()
+		}
+		if !ci.Branch.IsNull() && !ci.Branch.IsUnknown() {
+			event.Branch = ci.Branch.ValueString()
+		}
+		gitTrigger := &v1.GitTrigger{
+			Event: &v1.GitTrigger_CiCompleted{CiCompleted: event},
 		}
 		if !t.UserAllowlist.IsNull() && !t.UserAllowlist.IsUnknown() {
 			var users []string
@@ -1836,6 +1925,32 @@ func parsePrAction(s string) (v1.GitPullRequestAction, error) {
 	}
 }
 
+func parseCICompletionCondition(s string) (v1.GitCICompletionCondition, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "failure":
+		return v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_FAILURE, nil
+	case "success":
+		return v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_SUCCESS, nil
+	case "any":
+		return v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_ANY, nil
+	default:
+		return 0, fmt.Errorf("invalid git_ci_completed.condition %q, must be failure/success/any", s)
+	}
+}
+
+func ciCompletionConditionToString(c v1.GitCICompletionCondition) string {
+	switch c {
+	case v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_FAILURE:
+		return "failure"
+	case v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_SUCCESS:
+		return "success"
+	case v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_ANY:
+		return "any"
+	default:
+		return ""
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Proto → Model conversion
 // ---------------------------------------------------------------------------
@@ -1956,9 +2071,14 @@ func protoActionToModel(a *v1.Action) actionModel {
 	case *v1.Action_RequestReviewers:
 		am.RequestReviewers = &requestReviewersActionModel{}
 	case *v1.Action_Mcp:
-		if action.Mcp.GetServer() != nil {
+		if server := action.Mcp.GetServer(); server != nil {
 			am.Mcp = &mcpActionModel{
-				Server: types.StringValue(action.Mcp.GetServer().GetName()),
+				Server: types.StringValue(server.GetName()),
+			}
+			if server.Id != nil {
+				am.Mcp.ServerID = types.Int64Value(server.GetId())
+			} else {
+				am.Mcp.ServerID = types.Int64Null()
 			}
 		}
 	case *v1.Action_Slack:
@@ -2047,6 +2167,11 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 			} else {
 				prModel.CommentContains = types.StringNull()
 			}
+			if pr.GetCommentContainsIsRegex() {
+				prModel.CommentContainsIsRegex = types.BoolValue(true)
+			} else {
+				prModel.CommentContainsIsRegex = types.BoolNull()
+			}
 			tm.GitPullRequest = prModel
 
 		case *v1.GitTrigger_Push:
@@ -2059,6 +2184,32 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 			} else {
 				tm.GitPush.Branch = types.StringNull()
 			}
+
+		case *v1.GitTrigger_CiCompleted:
+			ci := event.CiCompleted
+			ciModel := &gitCICompletedModel{
+				Repos: types.ListNull(types.StringType),
+			}
+			if len(ci.GetRepos()) > 0 {
+				repos, _ := types.ListValueFrom(ctx, types.StringType, ci.GetRepos())
+				ciModel.Repos = repos
+			}
+			if ci.GetCondition() != v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_UNSPECIFIED {
+				ciModel.Condition = types.StringValue(ciCompletionConditionToString(ci.GetCondition()))
+			} else {
+				ciModel.Condition = types.StringNull()
+			}
+			if ci.GetIgnoreBaseFailures() {
+				ciModel.IgnoreBaseFailures = types.BoolValue(true)
+			} else {
+				ciModel.IgnoreBaseFailures = types.BoolNull()
+			}
+			if ci.GetBranch() != "" {
+				ciModel.Branch = types.StringValue(ci.GetBranch())
+			} else {
+				ciModel.Branch = types.StringNull()
+			}
+			tm.GitCICompleted = ciModel
 
 		default:
 			// Unsupported git trigger sub-type; leave all nil

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -634,6 +634,33 @@ func TestGitCICompletedTriggerRoundTrip(t *testing.T) {
 	})
 }
 
+func TestPreserveEquivalentGitCICompletionConditions(t *testing.T) {
+	state := &platformWorkflowModel{
+		Triggers: []triggerModel{
+			{
+				GitCICompleted: &gitCICompletedModel{
+					Condition: types.StringValue("failure"),
+				},
+			},
+		},
+	}
+	reference := platformWorkflowModel{
+		Triggers: []triggerModel{
+			{
+				GitCICompleted: &gitCICompletedModel{
+					Condition: types.StringValue("Failure"),
+				},
+			},
+		},
+	}
+
+	preserveEquivalentGitCICompletionConditions(state, reference)
+
+	if got, want := state.Triggers[0].GitCICompleted.Condition.ValueString(), "Failure"; got != want {
+		t.Fatalf("condition = %q, want %q", got, want)
+	}
+}
+
 func TestTriggerModelToProtoRejectsMultipleTriggerTypes(t *testing.T) {
 	ctx := context.Background()
 	m := &platformWorkflowModel{
@@ -911,6 +938,44 @@ func TestMcpActionServerIDRoundTrip(t *testing.T) {
 			t.Fatal("expected server_id to be null when unset")
 		}
 	})
+}
+
+func TestMcpActionServerIDIsOptionalComputed(t *testing.T) {
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+
+	attr, ok := schemaResp.Schema.Attributes["action"]
+	if !ok {
+		t.Fatal("schema is missing action attribute")
+	}
+	actionAttr, ok := attr.(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("action is not a ListNestedAttribute, got %T", attr)
+	}
+	mcpAttrRaw, ok := actionAttr.NestedObject.Attributes["mcp"]
+	if !ok {
+		t.Fatal("schema is missing action.mcp attribute")
+	}
+	mcpAttr, ok := mcpAttrRaw.(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("action.mcp is not a SingleNestedAttribute, got %T", mcpAttrRaw)
+	}
+	serverIDAttrRaw, ok := mcpAttr.Attributes["server_id"]
+	if !ok {
+		t.Fatal("schema is missing action.mcp.server_id attribute")
+	}
+	serverIDAttr, ok := serverIDAttrRaw.(schema.Int64Attribute)
+	if !ok {
+		t.Fatalf("action.mcp.server_id is not an Int64Attribute, got %T", serverIDAttrRaw)
+	}
+
+	if !serverIDAttr.Optional {
+		t.Fatal("action.mcp.server_id should be Optional")
+	}
+	if !serverIDAttr.Computed {
+		t.Fatal("action.mcp.server_id should be Computed")
+	}
 }
 
 func TestPreserveEquivalentGitPullRequestOrgs(t *testing.T) {

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -423,6 +423,496 @@ func TestGitPullRequestTargetsRoundTrip(t *testing.T) {
 	})
 }
 
+func TestGitCICompletedTriggerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage CI failures"),
+			Triggers: []triggerModel{
+				{
+					GitCICompleted: &gitCICompletedModel{
+						Repos:              mustStringList(t, ctx, []string{"org/repo"}),
+						Condition:          types.StringValue("failure"),
+						IgnoreBaseFailures: types.BoolValue(true),
+						Branch:             types.StringNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		ci := wf.Triggers[0].GetGit().GetCiCompleted()
+		if ci == nil {
+			t.Fatal("expected ci_completed trigger in proto")
+		}
+		if got, want := ci.GetRepos(), []string{"org/repo"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("repos = %v, want %v", got, want)
+		}
+		if got, want := ci.GetCondition(), v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_FAILURE; got != want {
+			t.Fatalf("condition = %v, want %v", got, want)
+		}
+		if !ci.GetIgnoreBaseFailures() {
+			t.Error("expected ignore_base_failures=true")
+		}
+		if ci.GetBranch() != "" {
+			t.Fatalf("expected empty branch, got %q", ci.GetBranch())
+		}
+	})
+
+	t.Run("model_to_proto_branch_mode", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage CI failures on main"),
+			Triggers: []triggerModel{
+				{
+					GitCICompleted: &gitCICompletedModel{
+						Repos:              mustStringList(t, ctx, []string{"org/repo"}),
+						Condition:          types.StringNull(),
+						IgnoreBaseFailures: types.BoolNull(),
+						Branch:             types.StringValue("main"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		ci := wf.Triggers[0].GetGit().GetCiCompleted()
+		if ci == nil {
+			t.Fatal("expected ci_completed trigger in proto")
+		}
+		if got, want := ci.GetBranch(), "main"; got != want {
+			t.Fatalf("branch = %q, want %q", got, want)
+		}
+		if got, want := ci.GetCondition(), v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_UNSPECIFIED; got != want {
+			t.Fatalf("condition = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("model_to_proto_requires_repos", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage CI failures"),
+			Triggers: []triggerModel{
+				{
+					GitCICompleted: &gitCICompletedModel{
+						Repos: types.ListNull(types.StringType),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil {
+			t.Fatal("expected error for missing repos")
+		}
+		if !strings.Contains(err.Error(), "git_ci_completed must specify at least one repo") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("model_to_proto_invalid_condition", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage CI failures"),
+			Triggers: []triggerModel{
+				{
+					GitCICompleted: &gitCICompletedModel{
+						Repos:     mustStringList(t, ctx, []string{"org/repo"}),
+						Condition: types.StringValue("sometimes"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil {
+			t.Fatal("expected error for invalid condition")
+		}
+		if !strings.Contains(err.Error(), "invalid git_ci_completed.condition") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("proto_to_model", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Prompts: []*v1.Prompt{{Prompt: "triage CI failures"}},
+					Triggers: []*v1.Trigger{
+						{
+							Trigger: &v1.Trigger_Git{
+								Git: &v1.GitTrigger{
+									Event: &v1.GitTrigger_CiCompleted{
+										CiCompleted: &v1.GitCICompletedEvent{
+											Repos:              []string{"org/repo"},
+											Condition:          v1.GitCICompletionCondition_GIT_CI_COMPLETION_CONDITION_SUCCESS,
+											IgnoreBaseFailures: true,
+											Branch:             "main",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		ci := model.Triggers[0].GitCICompleted
+		if ci == nil {
+			t.Fatal("expected git_ci_completed trigger in model")
+		}
+		var repos []string
+		diags := ci.Repos.ElementsAs(ctx, &repos, false)
+		if diags.HasError() {
+			t.Fatalf("failed to read repos from model: %v", diags)
+		}
+		if got, want := repos, []string{"org/repo"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("repos = %v, want %v", got, want)
+		}
+		if got, want := ci.Condition.ValueString(), "success"; got != want {
+			t.Fatalf("condition = %q, want %q", got, want)
+		}
+		if !ci.IgnoreBaseFailures.ValueBool() {
+			t.Error("expected ignore_base_failures=true")
+		}
+		if got, want := ci.Branch.ValueString(), "main"; got != want {
+			t.Fatalf("branch = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("proto_to_model_defaults_are_null", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{
+							Trigger: &v1.Trigger_Git{
+								Git: &v1.GitTrigger{
+									Event: &v1.GitTrigger_CiCompleted{
+										CiCompleted: &v1.GitCICompletedEvent{
+											Repos: []string{"org/repo"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		ci := model.Triggers[0].GitCICompleted
+		if ci == nil {
+			t.Fatal("expected git_ci_completed trigger in model")
+		}
+		if !ci.Condition.IsNull() {
+			t.Fatalf("expected condition to be null, got %q", ci.Condition.ValueString())
+		}
+		if !ci.IgnoreBaseFailures.IsNull() {
+			t.Fatal("expected ignore_base_failures to be null")
+		}
+		if !ci.Branch.IsNull() {
+			t.Fatalf("expected branch to be null, got %q", ci.Branch.ValueString())
+		}
+	})
+}
+
+func TestTriggerModelToProtoRejectsMultipleTriggerTypes(t *testing.T) {
+	ctx := context.Background()
+	m := &platformWorkflowModel{
+		Prompt: types.StringValue("review code"),
+		Triggers: []triggerModel{
+			{
+				GitCICompleted: &gitCICompletedModel{
+					Repos: mustStringList(t, ctx, []string{"org/repo"}),
+				},
+				GitPush: &gitPushModel{
+					Repo: types.StringValue("org/repo"),
+				},
+				UserAllowlist: types.ListNull(types.StringType),
+			},
+		},
+	}
+
+	_, err := modelToWorkflow(ctx, m)
+	if err == nil {
+		t.Fatal("expected error when multiple trigger types are set")
+	}
+	if !strings.Contains(err.Error(), "must specify exactly one of git_pull_request, git_push, git_ci_completed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGitPullRequestCommentContainsIsRegexRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto_true", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to comments"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs:                   types.ListNull(types.StringType),
+						Repos:                  mustStringList(t, ctx, []string{"org/repo"}),
+						IgnoreDraftPrs:         types.BoolNull(),
+						PrAction:               types.StringValue("commented"),
+						CommentContains:        types.StringValue(`^/(review|fix)\b`),
+						CommentContainsIsRegex: types.BoolValue(true),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		pr := wf.Triggers[0].GetGit().GetPullRequest()
+		if pr == nil {
+			t.Fatal("expected pull request trigger in proto")
+		}
+		if !pr.GetCommentContainsIsRegex() {
+			t.Error("expected comment_contains_is_regex=true on proto")
+		}
+	})
+
+	t.Run("model_to_proto_false_is_omitted", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to comments"),
+			Triggers: []triggerModel{
+				{
+					GitPullRequest: &gitPullRequestModel{
+						Orgs:                   types.ListNull(types.StringType),
+						Repos:                  mustStringList(t, ctx, []string{"org/repo"}),
+						CommentContains:        types.StringValue("please review"),
+						CommentContainsIsRegex: types.BoolValue(false),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		pr := wf.Triggers[0].GetGit().GetPullRequest()
+		if pr.GetCommentContainsIsRegex() {
+			t.Error("expected comment_contains_is_regex=false on proto")
+		}
+	})
+
+	t.Run("proto_to_model_round_trip", func(t *testing.T) {
+		event := &v1.GitPullRequestEvent{
+			Repos:                  []string{"org/repo"},
+			CommentContains:        `^/(review|fix)\b`,
+			CommentContainsIsRegex: true,
+		}
+
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{
+							Trigger: &v1.Trigger_Git{
+								Git: &v1.GitTrigger{
+									Event: &v1.GitTrigger_PullRequest{PullRequest: event},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		pr := model.Triggers[0].GitPullRequest
+		if pr == nil {
+			t.Fatal("expected git_pull_request trigger in model")
+		}
+		if !pr.CommentContainsIsRegex.ValueBool() {
+			t.Error("expected comment_contains_is_regex=true in model")
+		}
+	})
+
+	t.Run("proto_to_model_unset_is_null", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{
+							Trigger: &v1.Trigger_Git{
+								Git: &v1.GitTrigger{
+									Event: &v1.GitTrigger_PullRequest{
+										PullRequest: &v1.GitPullRequestEvent{
+											Repos: []string{"org/repo"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		if !model.Triggers[0].GitPullRequest.CommentContainsIsRegex.IsNull() {
+			t.Fatal("expected comment_contains_is_regex to be null when unset")
+		}
+	})
+}
+
+func TestMcpActionServerIDRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("use mcp"),
+			Triggers: []triggerModel{
+				{
+					Cron:          &cronModel{Schedule: types.StringValue("0 9 * * *")},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+			Actions: []actionModel{
+				{
+					Mcp: &mcpActionModel{
+						Server:   types.StringValue("my-server"),
+						ServerID: types.Int64Value(42),
+					},
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		server := wf.Actions[0].GetMcp().GetServer()
+		if server == nil {
+			t.Fatal("expected mcp server config in proto")
+		}
+		if got, want := server.GetName(), "my-server"; got != want {
+			t.Fatalf("server name = %q, want %q", got, want)
+		}
+		if server.Id == nil {
+			t.Fatal("expected server id to be set on proto")
+		}
+		if got := server.GetId(); got != 42 {
+			t.Fatalf("server id = %d, want 42", got)
+		}
+	})
+
+	t.Run("model_to_proto_null_id_is_omitted", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("use mcp"),
+			Triggers: []triggerModel{
+				{
+					Cron:          &cronModel{Schedule: types.StringValue("0 9 * * *")},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+			Actions: []actionModel{
+				{
+					Mcp: &mcpActionModel{
+						Server:   types.StringValue("my-server"),
+						ServerID: types.Int64Null(),
+					},
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.Actions[0].GetMcp().GetServer().Id != nil {
+			t.Fatal("expected server id to be unset on proto")
+		}
+	})
+
+	t.Run("proto_to_model_round_trip", func(t *testing.T) {
+		id := int64(42)
+		server := &v1.McpServerConfig{Name: "my-server", Id: &id}
+
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Actions: []*v1.Action{
+						{Action: &v1.Action_Mcp{
+							Mcp: &v1.McpAction{Server: server},
+						}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		mcp := model.Actions[0].Mcp
+		if mcp == nil {
+			t.Fatal("expected mcp action in model")
+		}
+		if got, want := mcp.Server.ValueString(), "my-server"; got != want {
+			t.Fatalf("server = %q, want %q", got, want)
+		}
+		if got, want := mcp.ServerID.ValueInt64(), int64(42); got != want {
+			t.Fatalf("server_id = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("proto_to_model_unset_id_is_null", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Actions: []*v1.Action{
+						{Action: &v1.Action_Mcp{
+							Mcp: &v1.McpAction{
+								Server: &v1.McpServerConfig{Name: "my-server"},
+							},
+						}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		if !model.Actions[0].Mcp.ServerID.IsNull() {
+			t.Fatal("expected server_id to be null when unset")
+		}
+	})
+}
+
 func TestPreserveEquivalentGitPullRequestOrgs(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -496,6 +496,37 @@ func TestGitCICompletedTriggerRoundTrip(t *testing.T) {
 		}
 	})
 
+	t.Run("model_to_proto_false_round_trip", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage CI failures"),
+			Triggers: []triggerModel{
+				{
+					GitCICompleted: &gitCICompletedModel{
+						Repos:              mustStringList(t, ctx, []string{"org/repo"}),
+						IgnoreBaseFailures: types.BoolValue(false),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		model, err := protoToModel(ctx, &v1.AutomationWithOwner{Workflow: &v1.Automation{Workflow: wf}})
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		ci := model.Triggers[0].GitCICompleted
+		if ci.IgnoreBaseFailures.IsNull() {
+			t.Fatal("expected ignore_base_failures=false in model, got null")
+		}
+		if ci.IgnoreBaseFailures.ValueBool() {
+			t.Error("expected ignore_base_failures=false in model")
+		}
+	})
+
 	t.Run("model_to_proto_requires_repos", func(t *testing.T) {
 		m := &platformWorkflowModel{
 			Prompt: types.StringValue("triage CI failures"),
@@ -512,6 +543,28 @@ func TestGitCICompletedTriggerRoundTrip(t *testing.T) {
 		_, err := modelToWorkflow(ctx, m)
 		if err == nil {
 			t.Fatal("expected error for missing repos")
+		}
+		if !strings.Contains(err.Error(), "git_ci_completed must specify at least one repo") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("model_to_proto_rejects_blank_repos", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage CI failures"),
+			Triggers: []triggerModel{
+				{
+					GitCICompleted: &gitCICompletedModel{
+						Repos: mustStringList(t, ctx, []string{"", "   "}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil {
+			t.Fatal("expected error for blank repos")
 		}
 		if !strings.Contains(err.Error(), "git_ci_completed must specify at least one repo") {
 			t.Fatalf("unexpected error: %v", err)
@@ -593,7 +646,7 @@ func TestGitCICompletedTriggerRoundTrip(t *testing.T) {
 		}
 	})
 
-	t.Run("proto_to_model_defaults_are_null", func(t *testing.T) {
+	t.Run("proto_to_model_defaults", func(t *testing.T) {
 		input := &v1.AutomationWithOwner{
 			Workflow: &v1.Automation{
 				Workflow: &v1.Workflow{
@@ -625,8 +678,11 @@ func TestGitCICompletedTriggerRoundTrip(t *testing.T) {
 		if !ci.Condition.IsNull() {
 			t.Fatalf("expected condition to be null, got %q", ci.Condition.ValueString())
 		}
-		if !ci.IgnoreBaseFailures.IsNull() {
-			t.Fatal("expected ignore_base_failures to be null")
+		if ci.IgnoreBaseFailures.IsNull() {
+			t.Fatal("expected ignore_base_failures=false in model, got null")
+		}
+		if ci.IgnoreBaseFailures.ValueBool() {
+			t.Error("expected ignore_base_failures=false in model")
 		}
 		if !ci.Branch.IsNull() {
 			t.Fatalf("expected branch to be null, got %q", ci.Branch.ValueString())
@@ -721,7 +777,7 @@ func TestGitPullRequestCommentContainsIsRegexRoundTrip(t *testing.T) {
 		}
 	})
 
-	t.Run("model_to_proto_false_is_omitted", func(t *testing.T) {
+	t.Run("model_to_proto_false_round_trip", func(t *testing.T) {
 		m := &platformWorkflowModel{
 			Prompt: types.StringValue("respond to comments"),
 			Triggers: []triggerModel{
@@ -744,6 +800,17 @@ func TestGitPullRequestCommentContainsIsRegexRoundTrip(t *testing.T) {
 		pr := wf.Triggers[0].GetGit().GetPullRequest()
 		if pr.GetCommentContainsIsRegex() {
 			t.Error("expected comment_contains_is_regex=false on proto")
+		}
+		model, err := protoToModel(ctx, &v1.AutomationWithOwner{Workflow: &v1.Automation{Workflow: wf}})
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		modelPr := model.Triggers[0].GitPullRequest
+		if modelPr.CommentContainsIsRegex.IsNull() {
+			t.Fatal("expected comment_contains_is_regex=false in model, got null")
+		}
+		if modelPr.CommentContainsIsRegex.ValueBool() {
+			t.Error("expected comment_contains_is_regex=false in model")
 		}
 	})
 
@@ -783,7 +850,7 @@ func TestGitPullRequestCommentContainsIsRegexRoundTrip(t *testing.T) {
 		}
 	})
 
-	t.Run("proto_to_model_unset_is_null", func(t *testing.T) {
+	t.Run("proto_to_model_default_false", func(t *testing.T) {
 		input := &v1.AutomationWithOwner{
 			Workflow: &v1.Automation{
 				Workflow: &v1.Workflow{
@@ -808,8 +875,11 @@ func TestGitPullRequestCommentContainsIsRegexRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("protoToModel() error: %v", err)
 		}
-		if !model.Triggers[0].GitPullRequest.CommentContainsIsRegex.IsNull() {
-			t.Fatal("expected comment_contains_is_regex to be null when unset")
+		if model.Triggers[0].GitPullRequest.CommentContainsIsRegex.IsNull() {
+			t.Fatal("expected comment_contains_is_regex=false in model, got null")
+		}
+		if model.Triggers[0].GitPullRequest.CommentContainsIsRegex.ValueBool() {
+			t.Fatal("expected comment_contains_is_regex=false in model")
 		}
 	})
 }


### PR DESCRIPTION
Adds three schema features to the `cursor_platform_workflow` resource and data source. All three map onto fields already supported by the Automations API.

## `git_ci_completed` trigger

New trigger type that fires when all CI checks complete on a pull request, or — when `branch` is set — on a specific branch.

```hcl
trigger = [
  {
    git_ci_completed = {
      repos                = ["example-org/example-repo"]
      condition            = "failure"   # "failure", "success", or "any"
      ignore_base_failures = true
    }
  }
]
```

Branch mode watches CI on a branch directly instead of on PRs (`user_allowlist` and `ignore_base_failures` do not apply there):

```hcl
git_ci_completed = {
  repos  = ["example-org/example-repo"]
  branch = "main"
}
```

`repos` requires at least one entry, and the trigger participates in the existing "exactly one trigger type per trigger block" validation.

## `comment_contains_is_regex` on `git_pull_request`

When true, `comment_contains` is treated as a case-insensitive regex pattern instead of a substring match (mirrors the existing `message_contains_is_regex` on the Slack and Microsoft Teams triggers):

```hcl
git_pull_request = {
  repos                     = ["example-org/example-repo"]
  pr_action                 = "commented"
  comment_contains          = "^/(review|fix)\\b"
  comment_contains_is_regex = true
}
```

## `server_id` on the `mcp` action

Optional stable MCP server ID that can be set alongside the `server` name. When set, the server is resolved by ID; the name remains for display and backwards compatibility. The data source exposes it as a computed attribute.

```hcl
action = [
  {
    mcp = {
      server    = "example-mcp-server"
      server_id = 42
    }
  }
]
```

## Testing

- `go build ./...`, `go test ./...`, `go vet ./...`, and `gofmt -l .` all clean
- New round-trip unit tests (model → proto → model) for each field, null-vs-false state normalization, condition parsing, and the exactly-one-trigger validation
- Docs regenerated with `make docs`

Resolves TER-2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new automation trigger and filter semantics that change when workflows fire; changes are schema/API mapping with solid tests but affect production automation behavior once adopted.
> 
> **Overview**
> Extends **`cursor_platform_workflow`** (resource and data source) with three API-backed schema fields and wires them through model ↔ proto conversion.
> 
> **`git_ci_completed` trigger** runs automations when CI finishes on watched repos—either per PR (`repos`, optional `condition` failure/success/any, `ignore_base_failures`) or in **branch mode** when `branch` is set (with documented limits on `user_allowlist` / `ignore_base_failures`). Validation requires at least one non-blank repo and includes the trigger in the existing one-trigger-type-per-block rules. **`preserveEquivalentGitCICompletionConditions`** keeps practitioner `condition` casing after read/apply when it matches the API enum case-insensitively.
> 
> **`git_pull_request.comment_contains_is_regex`** treats `comment_contains` as a case-insensitive regex when true, aligned with Slack/Teams message filters.
> 
> **`mcp.server_id`** is optional/computed on the resource and computed on the data source; when set, the MCP server is resolved by ID while `server` name remains for display.
> 
> README lists the new trigger; **`docs/`** regenerated. Broad round-trip and schema tests cover the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270c9c01183ec4df7dbde904c4e2349a29db486f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

