### PR TITLE
Regenerate vendored API types

### DIFF
--- a/internal/proto/v1/automations.pb.go
+++ b/internal/proto/v1/automations.pb.go
@@ -140,6 +140,61 @@ func (AutomationScope) EnumDescriptor() ([]byte, []int) {
 	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{1}
 }
 
+type AutomationCreationSource int32
+
+const (
+	AutomationCreationSource_AUTOMATION_CREATION_SOURCE_UNSPECIFIED    AutomationCreationSource = 0
+	AutomationCreationSource_AUTOMATION_CREATION_SOURCE_PORTAL_WEB     AutomationCreationSource = 1
+	AutomationCreationSource_AUTOMATION_CREATION_SOURCE_GLASS_UI       AutomationCreationSource = 2
+	AutomationCreationSource_AUTOMATION_CREATION_SOURCE_SKILL_MCP      AutomationCreationSource = 3
+	AutomationCreationSource_AUTOMATION_CREATION_SOURCE_CONFIG_AS_CODE AutomationCreationSource = 4
+)
+
+// Enum value maps for AutomationCreationSource.
+var (
+	AutomationCreationSource_name = map[int32]string{
+		0: "AUTOMATION_CREATION_SOURCE_UNSPECIFIED",
+		1: "AUTOMATION_CREATION_SOURCE_PORTAL_WEB",
+		2: "AUTOMATION_CREATION_SOURCE_GLASS_UI",
+		3: "AUTOMATION_CREATION_SOURCE_SKILL_MCP",
+		4: "AUTOMATION_CREATION_SOURCE_CONFIG_AS_CODE",
+	}
+	AutomationCreationSource_value = map[string]int32{
+		"AUTOMATION_CREATION_SOURCE_UNSPECIFIED":    0,
+		"AUTOMATION_CREATION_SOURCE_PORTAL_WEB":     1,
+		"AUTOMATION_CREATION_SOURCE_GLASS_UI":       2,
+		"AUTOMATION_CREATION_SOURCE_SKILL_MCP":      3,
+		"AUTOMATION_CREATION_SOURCE_CONFIG_AS_CODE": 4,
+	}
+)
+
+func (x AutomationCreationSource) Enum() *AutomationCreationSource {
+	p := new(AutomationCreationSource)
+	*p = x
+	return p
+}
+
+func (x AutomationCreationSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AutomationCreationSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_aiserver_v1_automations_proto_enumTypes[2].Descriptor()
+}
+
+func (AutomationCreationSource) Type() protoreflect.EnumType {
+	return &file_aiserver_v1_automations_proto_enumTypes[2]
+}
+
+func (x AutomationCreationSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AutomationCreationSource.Descriptor instead.
+func (AutomationCreationSource) EnumDescriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{2}
+}
+
 type AutomationManagedBy int32
 
 const (
@@ -177,11 +232,11 @@ func (x AutomationManagedBy) String() string {
 }
 
 func (AutomationManagedBy) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[2].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[3].Descriptor()
 }
 
 func (AutomationManagedBy) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[2]
+	return &file_aiserver_v1_automations_proto_enumTypes[3]
 }
 
 func (x AutomationManagedBy) Number() protoreflect.EnumNumber {
@@ -190,7 +245,7 @@ func (x AutomationManagedBy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AutomationManagedBy.Descriptor instead.
 func (AutomationManagedBy) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{2}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{3}
 }
 
 type PromptEffortLevel int32
@@ -226,11 +281,11 @@ func (x PromptEffortLevel) String() string {
 }
 
 func (PromptEffortLevel) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[3].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[4].Descriptor()
 }
 
 func (PromptEffortLevel) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[3]
+	return &file_aiserver_v1_automations_proto_enumTypes[4]
 }
 
 func (x PromptEffortLevel) Number() protoreflect.EnumNumber {
@@ -239,7 +294,56 @@ func (x PromptEffortLevel) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PromptEffortLevel.Descriptor instead.
 func (PromptEffortLevel) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{3}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{4}
+}
+
+type PromptRunMode int32
+
+const (
+	PromptRunMode_PROMPT_RUN_MODE_UNSPECIFIED PromptRunMode = 0
+	PromptRunMode_PROMPT_RUN_MODE_SAME_CHAT   PromptRunMode = 1
+	PromptRunMode_PROMPT_RUN_MODE_NEW_AGENT   PromptRunMode = 2
+)
+
+// Enum value maps for PromptRunMode.
+var (
+	PromptRunMode_name = map[int32]string{
+		0: "PROMPT_RUN_MODE_UNSPECIFIED",
+		1: "PROMPT_RUN_MODE_SAME_CHAT",
+		2: "PROMPT_RUN_MODE_NEW_AGENT",
+	}
+	PromptRunMode_value = map[string]int32{
+		"PROMPT_RUN_MODE_UNSPECIFIED": 0,
+		"PROMPT_RUN_MODE_SAME_CHAT":   1,
+		"PROMPT_RUN_MODE_NEW_AGENT":   2,
+	}
+)
+
+func (x PromptRunMode) Enum() *PromptRunMode {
+	p := new(PromptRunMode)
+	*p = x
+	return p
+}
+
+func (x PromptRunMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PromptRunMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_aiserver_v1_automations_proto_enumTypes[5].Descriptor()
+}
+
+func (PromptRunMode) Type() protoreflect.EnumType {
+	return &file_aiserver_v1_automations_proto_enumTypes[5]
+}
+
+func (x PromptRunMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PromptRunMode.Descriptor instead.
+func (PromptRunMode) EnumDescriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{5}
 }
 
 // Which GitHub PR action triggers this automation.
@@ -291,11 +395,11 @@ func (x GitPullRequestAction) String() string {
 }
 
 func (GitPullRequestAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[4].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[6].Descriptor()
 }
 
 func (GitPullRequestAction) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[4]
+	return &file_aiserver_v1_automations_proto_enumTypes[6]
 }
 
 func (x GitPullRequestAction) Number() protoreflect.EnumNumber {
@@ -304,7 +408,7 @@ func (x GitPullRequestAction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GitPullRequestAction.Descriptor instead.
 func (GitPullRequestAction) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{4}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{6}
 }
 
 // Condition for when CI completed trigger should fire.
@@ -344,11 +448,11 @@ func (x GitCICompletionCondition) String() string {
 }
 
 func (GitCICompletionCondition) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[5].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[7].Descriptor()
 }
 
 func (GitCICompletionCondition) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[5]
+	return &file_aiserver_v1_automations_proto_enumTypes[7]
 }
 
 func (x GitCICompletionCondition) Number() protoreflect.EnumNumber {
@@ -357,7 +461,119 @@ func (x GitCICompletionCondition) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GitCICompletionCondition.Descriptor instead.
 func (GitCICompletionCondition) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{5}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{7}
+}
+
+// Conclusion filter for GitWorkflowRunEvent.
+type GitWorkflowRunConclusion int32
+
+const (
+	GitWorkflowRunConclusion_GIT_WORKFLOW_RUN_CONCLUSION_UNSPECIFIED GitWorkflowRunConclusion = 0
+	GitWorkflowRunConclusion_GIT_WORKFLOW_RUN_CONCLUSION_ANY         GitWorkflowRunConclusion = 1
+	GitWorkflowRunConclusion_GIT_WORKFLOW_RUN_CONCLUSION_SUCCESS     GitWorkflowRunConclusion = 2
+	GitWorkflowRunConclusion_GIT_WORKFLOW_RUN_CONCLUSION_FAILURE     GitWorkflowRunConclusion = 3
+	GitWorkflowRunConclusion_GIT_WORKFLOW_RUN_CONCLUSION_CANCELLED   GitWorkflowRunConclusion = 4
+)
+
+// Enum value maps for GitWorkflowRunConclusion.
+var (
+	GitWorkflowRunConclusion_name = map[int32]string{
+		0: "GIT_WORKFLOW_RUN_CONCLUSION_UNSPECIFIED",
+		1: "GIT_WORKFLOW_RUN_CONCLUSION_ANY",
+		2: "GIT_WORKFLOW_RUN_CONCLUSION_SUCCESS",
+		3: "GIT_WORKFLOW_RUN_CONCLUSION_FAILURE",
+		4: "GIT_WORKFLOW_RUN_CONCLUSION_CANCELLED",
+	}
+	GitWorkflowRunConclusion_value = map[string]int32{
+		"GIT_WORKFLOW_RUN_CONCLUSION_UNSPECIFIED": 0,
+		"GIT_WORKFLOW_RUN_CONCLUSION_ANY":         1,
+		"GIT_WORKFLOW_RUN_CONCLUSION_SUCCESS":     2,
+		"GIT_WORKFLOW_RUN_CONCLUSION_FAILURE":     3,
+		"GIT_WORKFLOW_RUN_CONCLUSION_CANCELLED":   4,
+	}
+)
+
+func (x GitWorkflowRunConclusion) Enum() *GitWorkflowRunConclusion {
+	p := new(GitWorkflowRunConclusion)
+	*p = x
+	return p
+}
+
+func (x GitWorkflowRunConclusion) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (GitWorkflowRunConclusion) Descriptor() protoreflect.EnumDescriptor {
+	return file_aiserver_v1_automations_proto_enumTypes[8].Descriptor()
+}
+
+func (GitWorkflowRunConclusion) Type() protoreflect.EnumType {
+	return &file_aiserver_v1_automations_proto_enumTypes[8]
+}
+
+func (x GitWorkflowRunConclusion) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use GitWorkflowRunConclusion.Descriptor instead.
+func (GitWorkflowRunConclusion) EnumDescriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{8}
+}
+
+// Response wrapper that includes Automation plus user context.
+// This decouples the database model from the API response.
+// Stored-credential state of a single MCP server an automation uses. Presence,
+// not liveness (a stored token may still be expired/revoked).
+type McpAuthState int32
+
+const (
+	McpAuthState_MCP_AUTH_STATE_UNSPECIFIED   McpAuthState = 0
+	McpAuthState_MCP_AUTH_STATE_UNKNOWN       McpAuthState = 1
+	McpAuthState_MCP_AUTH_STATE_AUTHENTICATED McpAuthState = 2
+	McpAuthState_MCP_AUTH_STATE_NEEDS_AUTH    McpAuthState = 3
+)
+
+// Enum value maps for McpAuthState.
+var (
+	McpAuthState_name = map[int32]string{
+		0: "MCP_AUTH_STATE_UNSPECIFIED",
+		1: "MCP_AUTH_STATE_UNKNOWN",
+		2: "MCP_AUTH_STATE_AUTHENTICATED",
+		3: "MCP_AUTH_STATE_NEEDS_AUTH",
+	}
+	McpAuthState_value = map[string]int32{
+		"MCP_AUTH_STATE_UNSPECIFIED":   0,
+		"MCP_AUTH_STATE_UNKNOWN":       1,
+		"MCP_AUTH_STATE_AUTHENTICATED": 2,
+		"MCP_AUTH_STATE_NEEDS_AUTH":    3,
+	}
+)
+
+func (x McpAuthState) Enum() *McpAuthState {
+	p := new(McpAuthState)
+	*p = x
+	return p
+}
+
+func (x McpAuthState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (McpAuthState) Descriptor() protoreflect.EnumDescriptor {
+	return file_aiserver_v1_automations_proto_enumTypes[9].Descriptor()
+}
+
+func (McpAuthState) Type() protoreflect.EnumType {
+	return &file_aiserver_v1_automations_proto_enumTypes[9]
+}
+
+func (x McpAuthState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use McpAuthState.Descriptor instead.
+func (McpAuthState) EnumDescriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{9}
 }
 
 // The two main concepts of automations are "Triggers" and "Actions (tools/MCPs)".
@@ -375,6 +591,7 @@ type Trigger struct {
 	//	*Trigger_Sentry
 	//	*Trigger_MicrosoftTeamsTrigger
 	//	*Trigger_MicrosoftTeamsChannelCreated
+	//	*Trigger_SlackReactionAdded
 	Trigger isTrigger_Trigger `protobuf_oneof:"trigger"`
 	// Optional natural-language filter evaluated by a lightweight model before the
 	// main automation run. When empty, no filter step runs.
@@ -510,6 +727,15 @@ func (x *Trigger) GetMicrosoftTeamsChannelCreated() *MicrosoftTeamsChannelCreate
 	return nil
 }
 
+func (x *Trigger) GetSlackReactionAdded() *SlackReactionAddedTrigger {
+	if x != nil {
+		if x, ok := x.Trigger.(*Trigger_SlackReactionAdded); ok {
+			return x.SlackReactionAdded
+		}
+	}
+	return nil
+}
+
 func (x *Trigger) GetAgenticFilterPrompt() string {
 	if x != nil && x.AgenticFilterPrompt != nil {
 		return *x.AgenticFilterPrompt
@@ -561,6 +787,10 @@ type Trigger_MicrosoftTeamsChannelCreated struct {
 	MicrosoftTeamsChannelCreated *MicrosoftTeamsChannelCreatedTrigger `protobuf:"bytes,17,opt,name=microsoft_teams_channel_created,json=microsoftTeamsChannelCreated,proto3,oneof"` // Triggered when a new Microsoft Teams channel is created in a team
 }
 
+type Trigger_SlackReactionAdded struct {
+	SlackReactionAdded *SlackReactionAddedTrigger `protobuf:"bytes,18,opt,name=slack_reaction_added,json=slackReactionAdded,proto3,oneof"` // Triggered when a specific emoji reaction is added in a Slack channel
+}
+
 func (*Trigger_Cron) isTrigger_Trigger() {}
 
 func (*Trigger_Git) isTrigger_Trigger() {}
@@ -580,6 +810,8 @@ func (*Trigger_Sentry) isTrigger_Trigger() {}
 func (*Trigger_MicrosoftTeamsTrigger) isTrigger_Trigger() {}
 
 func (*Trigger_MicrosoftTeamsChannelCreated) isTrigger_Trigger() {}
+
+func (*Trigger_SlackReactionAdded) isTrigger_Trigger() {}
 
 // Each built-in action type (git_pr, pr_comment, slack, manage_check_run,
 // request_reviewers) may appear at most once per workflow.
@@ -864,7 +1096,10 @@ func (x *McpAction) GetServer() *McpServerConfig {
 // Full config (URL, headers, OAuth) is resolved at runtime — never embedded.
 type McpServerConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Server name matching the key in the user/team MCP config
+	// Stable MCP server row ID. Prefer this when present; name remains for
+	// display and backwards-compatible resolution of older workflows.
+	Id *int64 `protobuf:"varint,4,opt,name=id,proto3,oneof" json:"id,omitempty"`
+	// Server name matching the key in the user/team MCP config.
 	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -898,6 +1133,13 @@ func (x *McpServerConfig) ProtoReflect() protoreflect.Message {
 // Deprecated: Use McpServerConfig.ProtoReflect.Descriptor instead.
 func (*McpServerConfig) Descriptor() ([]byte, []int) {
 	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *McpServerConfig) GetId() int64 {
+	if x != nil && x.Id != nil {
+		return *x.Id
+	}
+	return 0
 }
 
 func (x *McpServerConfig) GetName() string {
@@ -1226,9 +1468,17 @@ type Prompt struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Prompt string                 `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
 	// Controls how much effort the agent should spend on this prompt.
-	EffortLevel   PromptEffortLevel `protobuf:"varint,2,opt,name=effort_level,json=effortLevel,proto3,enum=aiserver.v1.PromptEffortLevel" json:"effort_level,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	EffortLevel PromptEffortLevel `protobuf:"varint,2,opt,name=effort_level,json=effortLevel,proto3,enum=aiserver.v1.PromptEffortLevel" json:"effort_level,omitempty"`
+	// Per-prompt model override. Empty falls back to Workflow.model.
+	Model *string `protobuf:"bytes,3,opt,name=model,proto3,oneof" json:"model,omitempty"`
+	// When true, this prompt's output decides whether the chain continues.
+	IsFilter *bool `protobuf:"varint,4,opt,name=is_filter,json=isFilter,proto3,oneof" json:"is_filter,omitempty"`
+	// Where this prompt runs relative to the previous prompt in the chain.
+	RunMode *PromptRunMode `protobuf:"varint,5,opt,name=run_mode,json=runMode,proto3,enum=aiserver.v1.PromptRunMode,oneof" json:"run_mode,omitempty"`
+	// Skip Slack hourglass / "is reviewing" status while this prompt runs.
+	SuppressSlackReaction *bool `protobuf:"varint,6,opt,name=suppress_slack_reaction,json=suppressSlackReaction,proto3,oneof" json:"suppress_slack_reaction,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *Prompt) Reset() {
@@ -1273,6 +1523,34 @@ func (x *Prompt) GetEffortLevel() PromptEffortLevel {
 		return x.EffortLevel
 	}
 	return PromptEffortLevel_PROMPT_EFFORT_LEVEL_UNSPECIFIED
+}
+
+func (x *Prompt) GetModel() string {
+	if x != nil && x.Model != nil {
+		return *x.Model
+	}
+	return ""
+}
+
+func (x *Prompt) GetIsFilter() bool {
+	if x != nil && x.IsFilter != nil {
+		return *x.IsFilter
+	}
+	return false
+}
+
+func (x *Prompt) GetRunMode() PromptRunMode {
+	if x != nil && x.RunMode != nil {
+		return *x.RunMode
+	}
+	return PromptRunMode_PROMPT_RUN_MODE_UNSPECIFIED
+}
+
+func (x *Prompt) GetSuppressSlackReaction() bool {
+	if x != nil && x.SuppressSlackReaction != nil {
+		return *x.SuppressSlackReaction
+	}
+	return false
 }
 
 // Used in non-git triggers to define which repo to use.
@@ -1389,6 +1667,11 @@ type GitTrigger struct {
 	//	*GitTrigger_CiCompleted
 	//	*GitTrigger_IssueLabeled
 	//	*GitTrigger_Label
+	//	*GitTrigger_IssueComment
+	//	*GitTrigger_PullRequestReviewComment
+	//	*GitTrigger_PullRequestReview
+	//	*GitTrigger_ReviewThread
+	//	*GitTrigger_WorkflowRun
 	Event isGitTrigger_Event `protobuf_oneof:"event"`
 	// Optional allowlist of git usernames that can trigger this automation.
 	// If empty, all users can trigger it.
@@ -1479,6 +1762,51 @@ func (x *GitTrigger) GetLabel() *GitLabelEvent {
 	return nil
 }
 
+func (x *GitTrigger) GetIssueComment() *GitIssueCommentEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_IssueComment); ok {
+			return x.IssueComment
+		}
+	}
+	return nil
+}
+
+func (x *GitTrigger) GetPullRequestReviewComment() *GitPullRequestReviewCommentEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_PullRequestReviewComment); ok {
+			return x.PullRequestReviewComment
+		}
+	}
+	return nil
+}
+
+func (x *GitTrigger) GetPullRequestReview() *GitPullRequestReviewEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_PullRequestReview); ok {
+			return x.PullRequestReview
+		}
+	}
+	return nil
+}
+
+func (x *GitTrigger) GetReviewThread() *GitReviewThreadEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_ReviewThread); ok {
+			return x.ReviewThread
+		}
+	}
+	return nil
+}
+
+func (x *GitTrigger) GetWorkflowRun() *GitWorkflowRunEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_WorkflowRun); ok {
+			return x.WorkflowRun
+		}
+	}
+	return nil
+}
+
 func (x *GitTrigger) GetUserAllowlist() []string {
 	if x != nil {
 		return x.UserAllowlist
@@ -1510,6 +1838,26 @@ type GitTrigger_Label struct {
 	Label *GitLabelEvent `protobuf:"bytes,6,opt,name=label,proto3,oneof"`
 }
 
+type GitTrigger_IssueComment struct {
+	IssueComment *GitIssueCommentEvent `protobuf:"bytes,7,opt,name=issue_comment,json=issueComment,proto3,oneof"`
+}
+
+type GitTrigger_PullRequestReviewComment struct {
+	PullRequestReviewComment *GitPullRequestReviewCommentEvent `protobuf:"bytes,8,opt,name=pull_request_review_comment,json=pullRequestReviewComment,proto3,oneof"`
+}
+
+type GitTrigger_PullRequestReview struct {
+	PullRequestReview *GitPullRequestReviewEvent `protobuf:"bytes,9,opt,name=pull_request_review,json=pullRequestReview,proto3,oneof"`
+}
+
+type GitTrigger_ReviewThread struct {
+	ReviewThread *GitReviewThreadEvent `protobuf:"bytes,10,opt,name=review_thread,json=reviewThread,proto3,oneof"`
+}
+
+type GitTrigger_WorkflowRun struct {
+	WorkflowRun *GitWorkflowRunEvent `protobuf:"bytes,11,opt,name=workflow_run,json=workflowRun,proto3,oneof"`
+}
+
 func (*GitTrigger_PullRequest) isGitTrigger_Event() {}
 
 func (*GitTrigger_Push) isGitTrigger_Event() {}
@@ -1519,6 +1867,16 @@ func (*GitTrigger_CiCompleted) isGitTrigger_Event() {}
 func (*GitTrigger_IssueLabeled) isGitTrigger_Event() {}
 
 func (*GitTrigger_Label) isGitTrigger_Event() {}
+
+func (*GitTrigger_IssueComment) isGitTrigger_Event() {}
+
+func (*GitTrigger_PullRequestReviewComment) isGitTrigger_Event() {}
+
+func (*GitTrigger_PullRequestReview) isGitTrigger_Event() {}
+
+func (*GitTrigger_ReviewThread) isGitTrigger_Event() {}
+
+func (*GitTrigger_WorkflowRun) isGitTrigger_Event() {}
 
 type GitPullRequestEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1538,6 +1896,8 @@ type GitPullRequestEvent struct {
 	// Optional filter: only trigger if the comment body contains this text (case-insensitive).
 	// Only used when pr_action = COMMENTED.
 	CommentContains string `protobuf:"bytes,7,opt,name=comment_contains,json=commentContains,proto3" json:"comment_contains,omitempty"`
+	// If true, comment_contains is treated as a regex pattern (case-insensitive).
+	CommentContainsIsRegex bool `protobuf:"varint,10,opt,name=comment_contains_is_regex,json=commentContainsIsRegex,proto3" json:"comment_contains_is_regex,omitempty"`
 	// Deprecated: use GitLabelEvent instead. Kept for backwards compatibility.
 	LabelName string `protobuf:"bytes,8,opt,name=label_name,json=labelName,proto3" json:"label_name,omitempty"`
 	// Optional GitHub orgs to watch. Matches all current and future repos
@@ -1624,6 +1984,13 @@ func (x *GitPullRequestEvent) GetCommentContains() string {
 		return x.CommentContains
 	}
 	return ""
+}
+
+func (x *GitPullRequestEvent) GetCommentContainsIsRegex() bool {
+	if x != nil {
+		return x.CommentContainsIsRegex
+	}
+	return false
 }
 
 func (x *GitPullRequestEvent) GetLabelName() string {
@@ -1834,6 +2201,370 @@ func (x *GitIssueLabeledEvent) GetUnlabeled() bool {
 	return false
 }
 
+// Trigger when a comment is created on an issue (GitHub only).
+// PR comments are handled by GitPullRequestEvent with prAction = COMMENTED;
+// this event covers comments on non-PR issues.
+type GitIssueCommentEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Repos []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	// Optional allowlist of commenter usernames. If empty, comments from all
+	// users trigger the automation.
+	CommenterAllowlist []string `protobuf:"bytes,2,rep,name=commenter_allowlist,json=commenterAllowlist,proto3" json:"commenter_allowlist,omitempty"`
+	// Optional filter: only trigger if the comment body contains this text
+	// (case-insensitive). If empty, any comment triggers.
+	CommentContains string `protobuf:"bytes,3,opt,name=comment_contains,json=commentContains,proto3" json:"comment_contains,omitempty"`
+	// If true, comment_contains is treated as a regex pattern (case-insensitive).
+	CommentContainsIsRegex bool `protobuf:"varint,4,opt,name=comment_contains_is_regex,json=commentContainsIsRegex,proto3" json:"comment_contains_is_regex,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *GitIssueCommentEvent) Reset() {
+	*x = GitIssueCommentEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitIssueCommentEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitIssueCommentEvent) ProtoMessage() {}
+
+func (x *GitIssueCommentEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitIssueCommentEvent.ProtoReflect.Descriptor instead.
+func (*GitIssueCommentEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GitIssueCommentEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
+func (x *GitIssueCommentEvent) GetCommenterAllowlist() []string {
+	if x != nil {
+		return x.CommenterAllowlist
+	}
+	return nil
+}
+
+func (x *GitIssueCommentEvent) GetCommentContains() string {
+	if x != nil {
+		return x.CommentContains
+	}
+	return ""
+}
+
+func (x *GitIssueCommentEvent) GetCommentContainsIsRegex() bool {
+	if x != nil {
+		return x.CommentContainsIsRegex
+	}
+	return false
+}
+
+// Trigger when an inline review comment is created on a pull request
+// (GitHub `pull_request_review_comment` event, action=created). Distinct from
+// GitPullRequestEvent + COMMENTED, which fires on top-level PR conversation
+// comments. Inline review comments are anchored to a line in the diff.
+type GitPullRequestReviewCommentEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Repos []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	// Optional allowlist of commenter usernames. If empty, comments from all
+	// users trigger the automation.
+	CommenterAllowlist []string `protobuf:"bytes,2,rep,name=commenter_allowlist,json=commenterAllowlist,proto3" json:"commenter_allowlist,omitempty"`
+	// Optional filter: only trigger if the comment body contains this text
+	// (case-insensitive). If empty, any comment triggers.
+	CommentContains string `protobuf:"bytes,3,opt,name=comment_contains,json=commentContains,proto3" json:"comment_contains,omitempty"`
+	// If true, comment_contains is treated as a regex pattern (case-insensitive).
+	CommentContainsIsRegex bool `protobuf:"varint,4,opt,name=comment_contains_is_regex,json=commentContainsIsRegex,proto3" json:"comment_contains_is_regex,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *GitPullRequestReviewCommentEvent) Reset() {
+	*x = GitPullRequestReviewCommentEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitPullRequestReviewCommentEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitPullRequestReviewCommentEvent) ProtoMessage() {}
+
+func (x *GitPullRequestReviewCommentEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitPullRequestReviewCommentEvent.ProtoReflect.Descriptor instead.
+func (*GitPullRequestReviewCommentEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GitPullRequestReviewCommentEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
+func (x *GitPullRequestReviewCommentEvent) GetCommenterAllowlist() []string {
+	if x != nil {
+		return x.CommenterAllowlist
+	}
+	return nil
+}
+
+func (x *GitPullRequestReviewCommentEvent) GetCommentContains() string {
+	if x != nil {
+		return x.CommentContains
+	}
+	return ""
+}
+
+func (x *GitPullRequestReviewCommentEvent) GetCommentContainsIsRegex() bool {
+	if x != nil {
+		return x.CommentContainsIsRegex
+	}
+	return false
+}
+
+// Trigger when a pull request review is submitted (GitHub only).
+// Inline comments inside the review are handled by GitPullRequestReviewCommentEvent.
+type GitPullRequestReviewEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Repos []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	// Fire when a review is submitted with state APPROVED.
+	OnApproved bool `protobuf:"varint,2,opt,name=on_approved,json=onApproved,proto3" json:"on_approved,omitempty"`
+	// Fire when a review is submitted with state CHANGES_REQUESTED.
+	OnChangesRequested bool `protobuf:"varint,3,opt,name=on_changes_requested,json=onChangesRequested,proto3" json:"on_changes_requested,omitempty"`
+	// Fire when a review is submitted with state COMMENTED.
+	OnCommented   bool `protobuf:"varint,4,opt,name=on_commented,json=onCommented,proto3" json:"on_commented,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GitPullRequestReviewEvent) Reset() {
+	*x = GitPullRequestReviewEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitPullRequestReviewEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitPullRequestReviewEvent) ProtoMessage() {}
+
+func (x *GitPullRequestReviewEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitPullRequestReviewEvent.ProtoReflect.Descriptor instead.
+func (*GitPullRequestReviewEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GitPullRequestReviewEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
+func (x *GitPullRequestReviewEvent) GetOnApproved() bool {
+	if x != nil {
+		return x.OnApproved
+	}
+	return false
+}
+
+func (x *GitPullRequestReviewEvent) GetOnChangesRequested() bool {
+	if x != nil {
+		return x.OnChangesRequested
+	}
+	return false
+}
+
+func (x *GitPullRequestReviewEvent) GetOnCommented() bool {
+	if x != nil {
+		return x.OnCommented
+	}
+	return false
+}
+
+// Trigger when a PR review thread is marked resolved or unresolved (GitHub only).
+type GitReviewThreadEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Repos []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	// Fire when a thread is marked resolved.
+	OnResolved bool `protobuf:"varint,2,opt,name=on_resolved,json=onResolved,proto3" json:"on_resolved,omitempty"`
+	// Fire when a thread is marked unresolved.
+	OnUnresolved  bool `protobuf:"varint,3,opt,name=on_unresolved,json=onUnresolved,proto3" json:"on_unresolved,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GitReviewThreadEvent) Reset() {
+	*x = GitReviewThreadEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitReviewThreadEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitReviewThreadEvent) ProtoMessage() {}
+
+func (x *GitReviewThreadEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitReviewThreadEvent.ProtoReflect.Descriptor instead.
+func (*GitReviewThreadEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *GitReviewThreadEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
+func (x *GitReviewThreadEvent) GetOnResolved() bool {
+	if x != nil {
+		return x.OnResolved
+	}
+	return false
+}
+
+func (x *GitReviewThreadEvent) GetOnUnresolved() bool {
+	if x != nil {
+		return x.OnUnresolved
+	}
+	return false
+}
+
+// Trigger when a GitHub Actions workflow run completes (GitHub only).
+// Distinct from GitCICompletedEvent (check_suite-based): targets a named
+// workflow file rather than the aggregate check suite.
+type GitWorkflowRunEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Repos []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	// Optional list of workflow file names to filter by (e.g. "deploy.yml").
+	// When empty, fires for any workflow run completion.
+	WorkflowNames []string `protobuf:"bytes,2,rep,name=workflow_names,json=workflowNames,proto3" json:"workflow_names,omitempty"`
+	// Optional branch filter: when set, only fires on completions for this branch.
+	Branch string `protobuf:"bytes,3,opt,name=branch,proto3" json:"branch,omitempty"`
+	// Conclusion to fire on. UNSPECIFIED is treated as ANY.
+	Conclusion    GitWorkflowRunConclusion `protobuf:"varint,4,opt,name=conclusion,proto3,enum=aiserver.v1.GitWorkflowRunConclusion" json:"conclusion,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GitWorkflowRunEvent) Reset() {
+	*x = GitWorkflowRunEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitWorkflowRunEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitWorkflowRunEvent) ProtoMessage() {}
+
+func (x *GitWorkflowRunEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitWorkflowRunEvent.ProtoReflect.Descriptor instead.
+func (*GitWorkflowRunEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *GitWorkflowRunEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
+func (x *GitWorkflowRunEvent) GetWorkflowNames() []string {
+	if x != nil {
+		return x.WorkflowNames
+	}
+	return nil
+}
+
+func (x *GitWorkflowRunEvent) GetBranch() string {
+	if x != nil {
+		return x.Branch
+	}
+	return ""
+}
+
+func (x *GitWorkflowRunEvent) GetConclusion() GitWorkflowRunConclusion {
+	if x != nil {
+		return x.Conclusion
+	}
+	return GitWorkflowRunConclusion_GIT_WORKFLOW_RUN_CONCLUSION_UNSPECIFIED
+}
+
 // Unified label trigger for PRs and issues (GitHub only).
 // Fires when a label is added to or removed from a PR or issue.
 type GitLabelEvent struct {
@@ -1855,7 +2586,7 @@ type GitLabelEvent struct {
 
 func (x *GitLabelEvent) Reset() {
 	*x = GitLabelEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1867,7 +2598,7 @@ func (x *GitLabelEvent) String() string {
 func (*GitLabelEvent) ProtoMessage() {}
 
 func (x *GitLabelEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1880,7 +2611,7 @@ func (x *GitLabelEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitLabelEvent.ProtoReflect.Descriptor instead.
 func (*GitLabelEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{16}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GitLabelEvent) GetRepos() []string {
@@ -1943,13 +2674,18 @@ type SlackTrigger struct {
 	// Custom Slack reaction in ":emoji_name:" form when
 	// slack_completion_reaction_mode = CUSTOM.
 	SlackCompletionReactionCustomEmoji *string `protobuf:"bytes,8,opt,name=slack_completion_reaction_custom_emoji,json=slackCompletionReactionCustomEmoji,proto3,oneof" json:"slack_completion_reaction_custom_emoji,omitempty"`
-	unknownFields                      protoimpl.UnknownFields
-	sizeCache                          protoimpl.SizeCache
+	// If true, only top-level channel messages fire this trigger; thread replies are ignored.
+	// When unset, legacy defaults apply: true for broad triggers (empty message_contains)
+	// and false for keyword/regex-filtered triggers. New saves materialize the default
+	// (true for broad triggers) at save time.
+	TopLevelOnly  *bool `protobuf:"varint,9,opt,name=top_level_only,json=topLevelOnly,proto3,oneof" json:"top_level_only,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SlackTrigger) Reset() {
 	*x = SlackTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1961,7 +2697,7 @@ func (x *SlackTrigger) String() string {
 func (*SlackTrigger) ProtoMessage() {}
 
 func (x *SlackTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1974,7 +2710,7 @@ func (x *SlackTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackTrigger.ProtoReflect.Descriptor instead.
 func (*SlackTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{17}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SlackTrigger) GetChannel() string {
@@ -2026,6 +2762,13 @@ func (x *SlackTrigger) GetSlackCompletionReactionCustomEmoji() string {
 	return ""
 }
 
+func (x *SlackTrigger) GetTopLevelOnly() bool {
+	if x != nil && x.TopLevelOnly != nil {
+		return *x.TopLevelOnly
+	}
+	return false
+}
+
 // SlackChannelCreatedTrigger fires when a public Slack channel is created.
 type SlackChannelCreatedTrigger struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2037,7 +2780,7 @@ type SlackChannelCreatedTrigger struct {
 
 func (x *SlackChannelCreatedTrigger) Reset() {
 	*x = SlackChannelCreatedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2049,7 +2792,7 @@ func (x *SlackChannelCreatedTrigger) String() string {
 func (*SlackChannelCreatedTrigger) ProtoMessage() {}
 
 func (x *SlackChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2062,7 +2805,7 @@ func (x *SlackChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackChannelCreatedTrigger.ProtoReflect.Descriptor instead.
 func (*SlackChannelCreatedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{18}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SlackChannelCreatedTrigger) GetChannelNameContains() string {
@@ -2070,6 +2813,81 @@ func (x *SlackChannelCreatedTrigger) GetChannelNameContains() string {
 		return x.ChannelNameContains
 	}
 	return ""
+}
+
+// SlackReactionAddedTrigger fires when a configured emoji reaction is added to a message
+// in a specific Slack channel (or one of several channels). Field layout mirrors SlackTrigger
+// where fields share the same meaning.
+type SlackReactionAddedTrigger struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Channel string                 `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"` // Slack channel ID (e.g., C0123456789). Channel names are resolved to IDs at save time.
+	// Slack emoji "short name" without leading/trailing colons (e.g. "thumbsup", not ":thumbsup:").
+	// Unicode emoji should be stored as Slack's alias name; server normalizes on save and when matching events.
+	EmojiName string   `protobuf:"bytes,3,opt,name=emoji_name,json=emojiName,proto3" json:"emoji_name,omitempty"`
+	Channels  []string `protobuf:"bytes,5,rep,name=channels,proto3" json:"channels,omitempty"`
+	// If true, only Slack users who linked Cursor can trigger (bots/unknown blocked).
+	// Omitted/false = anyone in the channel can trigger (default).
+	BlockUnauthenticatedSlackUsers bool `protobuf:"varint,6,opt,name=block_unauthenticated_slack_users,json=blockUnauthenticatedSlackUsers,proto3" json:"block_unauthenticated_slack_users,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
+}
+
+func (x *SlackReactionAddedTrigger) Reset() {
+	*x = SlackReactionAddedTrigger{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SlackReactionAddedTrigger) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SlackReactionAddedTrigger) ProtoMessage() {}
+
+func (x *SlackReactionAddedTrigger) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SlackReactionAddedTrigger.ProtoReflect.Descriptor instead.
+func (*SlackReactionAddedTrigger) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *SlackReactionAddedTrigger) GetChannel() string {
+	if x != nil {
+		return x.Channel
+	}
+	return ""
+}
+
+func (x *SlackReactionAddedTrigger) GetEmojiName() string {
+	if x != nil {
+		return x.EmojiName
+	}
+	return ""
+}
+
+func (x *SlackReactionAddedTrigger) GetChannels() []string {
+	if x != nil {
+		return x.Channels
+	}
+	return nil
+}
+
+func (x *SlackReactionAddedTrigger) GetBlockUnauthenticatedSlackUsers() bool {
+	if x != nil {
+		return x.BlockUnauthenticatedSlackUsers
+	}
+	return false
 }
 
 // LinearTrigger fires when Linear events occur.
@@ -2093,7 +2911,7 @@ type LinearTrigger struct {
 
 func (x *LinearTrigger) Reset() {
 	*x = LinearTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2105,7 +2923,7 @@ func (x *LinearTrigger) String() string {
 func (*LinearTrigger) ProtoMessage() {}
 
 func (x *LinearTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2118,7 +2936,7 @@ func (x *LinearTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearTrigger.ProtoReflect.Descriptor instead.
 func (*LinearTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{19}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *LinearTrigger) GetEvent() isLinearTrigger_Event {
@@ -2199,7 +3017,7 @@ type LinearIssueCreatedEvent struct {
 
 func (x *LinearIssueCreatedEvent) Reset() {
 	*x = LinearIssueCreatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2211,7 +3029,7 @@ func (x *LinearIssueCreatedEvent) String() string {
 func (*LinearIssueCreatedEvent) ProtoMessage() {}
 
 func (x *LinearIssueCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2224,7 +3042,7 @@ func (x *LinearIssueCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearIssueCreatedEvent.ProtoReflect.Descriptor instead.
 func (*LinearIssueCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{20}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{26}
 }
 
 type LinearStatusChangedEvent struct {
@@ -2237,7 +3055,7 @@ type LinearStatusChangedEvent struct {
 
 func (x *LinearStatusChangedEvent) Reset() {
 	*x = LinearStatusChangedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2249,7 +3067,7 @@ func (x *LinearStatusChangedEvent) String() string {
 func (*LinearStatusChangedEvent) ProtoMessage() {}
 
 func (x *LinearStatusChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2262,7 +3080,7 @@ func (x *LinearStatusChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearStatusChangedEvent.ProtoReflect.Descriptor instead.
 func (*LinearStatusChangedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{21}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LinearStatusChangedEvent) GetStatusIds() []string {
@@ -2282,7 +3100,7 @@ type LinearEndOfCycleEvent struct {
 
 func (x *LinearEndOfCycleEvent) Reset() {
 	*x = LinearEndOfCycleEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2294,7 +3112,7 @@ func (x *LinearEndOfCycleEvent) String() string {
 func (*LinearEndOfCycleEvent) ProtoMessage() {}
 
 func (x *LinearEndOfCycleEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2307,7 +3125,7 @@ func (x *LinearEndOfCycleEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearEndOfCycleEvent.ProtoReflect.Descriptor instead.
 func (*LinearEndOfCycleEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{22}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LinearEndOfCycleEvent) GetCycleIds() []string {
@@ -2326,7 +3144,7 @@ type WebhookTrigger struct {
 
 func (x *WebhookTrigger) Reset() {
 	*x = WebhookTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2338,7 +3156,7 @@ func (x *WebhookTrigger) String() string {
 func (*WebhookTrigger) ProtoMessage() {}
 
 func (x *WebhookTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2351,7 +3169,7 @@ func (x *WebhookTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebhookTrigger.ProtoReflect.Descriptor instead.
 func (*WebhookTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{23}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{29}
 }
 
 // PagerDutyTrigger fires when PagerDuty incident events occur.
@@ -2374,7 +3192,7 @@ type PagerDutyTrigger struct {
 
 func (x *PagerDutyTrigger) Reset() {
 	*x = PagerDutyTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2386,7 +3204,7 @@ func (x *PagerDutyTrigger) String() string {
 func (*PagerDutyTrigger) ProtoMessage() {}
 
 func (x *PagerDutyTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2399,7 +3217,7 @@ func (x *PagerDutyTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyTrigger.ProtoReflect.Descriptor instead.
 func (*PagerDutyTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{24}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PagerDutyTrigger) GetEvent() isPagerDutyTrigger_Event {
@@ -2503,7 +3321,7 @@ type PagerDutyIncidentTriggeredEvent struct {
 
 func (x *PagerDutyIncidentTriggeredEvent) Reset() {
 	*x = PagerDutyIncidentTriggeredEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2515,7 +3333,7 @@ func (x *PagerDutyIncidentTriggeredEvent) String() string {
 func (*PagerDutyIncidentTriggeredEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentTriggeredEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2528,7 +3346,7 @@ func (x *PagerDutyIncidentTriggeredEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentTriggeredEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentTriggeredEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{25}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{31}
 }
 
 type PagerDutyIncidentAcknowledgedEvent struct {
@@ -2539,7 +3357,7 @@ type PagerDutyIncidentAcknowledgedEvent struct {
 
 func (x *PagerDutyIncidentAcknowledgedEvent) Reset() {
 	*x = PagerDutyIncidentAcknowledgedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2551,7 +3369,7 @@ func (x *PagerDutyIncidentAcknowledgedEvent) String() string {
 func (*PagerDutyIncidentAcknowledgedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentAcknowledgedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2564,7 +3382,7 @@ func (x *PagerDutyIncidentAcknowledgedEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use PagerDutyIncidentAcknowledgedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentAcknowledgedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{26}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{32}
 }
 
 type PagerDutyIncidentResolvedEvent struct {
@@ -2575,7 +3393,7 @@ type PagerDutyIncidentResolvedEvent struct {
 
 func (x *PagerDutyIncidentResolvedEvent) Reset() {
 	*x = PagerDutyIncidentResolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2587,7 +3405,7 @@ func (x *PagerDutyIncidentResolvedEvent) String() string {
 func (*PagerDutyIncidentResolvedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentResolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2600,7 +3418,7 @@ func (x *PagerDutyIncidentResolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentResolvedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentResolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{27}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{33}
 }
 
 type PagerDutyIncidentEscalatedEvent struct {
@@ -2611,7 +3429,7 @@ type PagerDutyIncidentEscalatedEvent struct {
 
 func (x *PagerDutyIncidentEscalatedEvent) Reset() {
 	*x = PagerDutyIncidentEscalatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2623,7 +3441,7 @@ func (x *PagerDutyIncidentEscalatedEvent) String() string {
 func (*PagerDutyIncidentEscalatedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentEscalatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2636,7 +3454,7 @@ func (x *PagerDutyIncidentEscalatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentEscalatedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentEscalatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{28}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{34}
 }
 
 // Matches any incident event type (triggered, acknowledged, resolved, escalated).
@@ -2648,7 +3466,7 @@ type PagerDutyIncidentAnyEvent struct {
 
 func (x *PagerDutyIncidentAnyEvent) Reset() {
 	*x = PagerDutyIncidentAnyEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2660,7 +3478,7 @@ func (x *PagerDutyIncidentAnyEvent) String() string {
 func (*PagerDutyIncidentAnyEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentAnyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2673,7 +3491,7 @@ func (x *PagerDutyIncidentAnyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentAnyEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentAnyEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{29}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{35}
 }
 
 // SentryTrigger fires when Sentry issue webhooks are delivered to the Integration Platform
@@ -2699,7 +3517,7 @@ type SentryTrigger struct {
 
 func (x *SentryTrigger) Reset() {
 	*x = SentryTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2711,7 +3529,7 @@ func (x *SentryTrigger) String() string {
 func (*SentryTrigger) ProtoMessage() {}
 
 func (x *SentryTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2724,7 +3542,7 @@ func (x *SentryTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryTrigger.ProtoReflect.Descriptor instead.
 func (*SentryTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{30}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SentryTrigger) GetEvent() isSentryTrigger_Event {
@@ -2843,7 +3661,7 @@ type SentryIssueCreatedEvent struct {
 
 func (x *SentryIssueCreatedEvent) Reset() {
 	*x = SentryIssueCreatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2855,7 +3673,7 @@ func (x *SentryIssueCreatedEvent) String() string {
 func (*SentryIssueCreatedEvent) ProtoMessage() {}
 
 func (x *SentryIssueCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2868,7 +3686,7 @@ func (x *SentryIssueCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueCreatedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{31}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{37}
 }
 
 type SentryIssueResolvedEvent struct {
@@ -2879,7 +3697,7 @@ type SentryIssueResolvedEvent struct {
 
 func (x *SentryIssueResolvedEvent) Reset() {
 	*x = SentryIssueResolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2891,7 +3709,7 @@ func (x *SentryIssueResolvedEvent) String() string {
 func (*SentryIssueResolvedEvent) ProtoMessage() {}
 
 func (x *SentryIssueResolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2904,7 +3722,7 @@ func (x *SentryIssueResolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueResolvedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueResolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{32}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{38}
 }
 
 type SentryIssueAssignedEvent struct {
@@ -2915,7 +3733,7 @@ type SentryIssueAssignedEvent struct {
 
 func (x *SentryIssueAssignedEvent) Reset() {
 	*x = SentryIssueAssignedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2927,7 +3745,7 @@ func (x *SentryIssueAssignedEvent) String() string {
 func (*SentryIssueAssignedEvent) ProtoMessage() {}
 
 func (x *SentryIssueAssignedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2940,7 +3758,7 @@ func (x *SentryIssueAssignedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueAssignedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueAssignedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{33}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{39}
 }
 
 type SentryIssueArchivedEvent struct {
@@ -2951,7 +3769,7 @@ type SentryIssueArchivedEvent struct {
 
 func (x *SentryIssueArchivedEvent) Reset() {
 	*x = SentryIssueArchivedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2963,7 +3781,7 @@ func (x *SentryIssueArchivedEvent) String() string {
 func (*SentryIssueArchivedEvent) ProtoMessage() {}
 
 func (x *SentryIssueArchivedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2976,7 +3794,7 @@ func (x *SentryIssueArchivedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueArchivedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueArchivedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{34}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{40}
 }
 
 type SentryIssueUnresolvedEvent struct {
@@ -2987,7 +3805,7 @@ type SentryIssueUnresolvedEvent struct {
 
 func (x *SentryIssueUnresolvedEvent) Reset() {
 	*x = SentryIssueUnresolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2999,7 +3817,7 @@ func (x *SentryIssueUnresolvedEvent) String() string {
 func (*SentryIssueUnresolvedEvent) ProtoMessage() {}
 
 func (x *SentryIssueUnresolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3012,7 +3830,7 @@ func (x *SentryIssueUnresolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueUnresolvedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueUnresolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{35}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{41}
 }
 
 type SentryIssueAnyEvent struct {
@@ -3023,7 +3841,7 @@ type SentryIssueAnyEvent struct {
 
 func (x *SentryIssueAnyEvent) Reset() {
 	*x = SentryIssueAnyEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3035,7 +3853,7 @@ func (x *SentryIssueAnyEvent) String() string {
 func (*SentryIssueAnyEvent) ProtoMessage() {}
 
 func (x *SentryIssueAnyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3048,7 +3866,7 @@ func (x *SentryIssueAnyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueAnyEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueAnyEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{36}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{42}
 }
 
 // MicrosoftTeamsTrigger fires when messages are posted in a configured
@@ -3087,7 +3905,7 @@ type MicrosoftTeamsTrigger struct {
 
 func (x *MicrosoftTeamsTrigger) Reset() {
 	*x = MicrosoftTeamsTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3099,7 +3917,7 @@ func (x *MicrosoftTeamsTrigger) String() string {
 func (*MicrosoftTeamsTrigger) ProtoMessage() {}
 
 func (x *MicrosoftTeamsTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3112,7 +3930,7 @@ func (x *MicrosoftTeamsTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosoftTeamsTrigger.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{37}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *MicrosoftTeamsTrigger) GetTenantId() string {
@@ -3181,7 +3999,7 @@ type MicrosoftTeamsChannelCreatedTrigger struct {
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) Reset() {
 	*x = MicrosoftTeamsChannelCreatedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3193,7 +4011,7 @@ func (x *MicrosoftTeamsChannelCreatedTrigger) String() string {
 func (*MicrosoftTeamsChannelCreatedTrigger) ProtoMessage() {}
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3206,7 +4024,7 @@ func (x *MicrosoftTeamsChannelCreatedTrigger) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use MicrosoftTeamsChannelCreatedTrigger.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsChannelCreatedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{38}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) GetTenantId() string {
@@ -3239,7 +4057,7 @@ type GitPrAction struct {
 
 func (x *GitPrAction) Reset() {
 	*x = GitPrAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3251,7 +4069,7 @@ func (x *GitPrAction) String() string {
 func (*GitPrAction) ProtoMessage() {}
 
 func (x *GitPrAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3264,10 +4082,13 @@ func (x *GitPrAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPrAction.ProtoReflect.Descriptor instead.
 func (*GitPrAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{39}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{45}
 }
 
-// Action: posts a comment on a PR. Only works with Git Pull Request triggers.
+// Action: posts a comment/review on a PR. Defaults to the pull request from a
+// Git Pull Request trigger, but works on any trigger type: the agent targets a
+// pull request via the tool's pr_url parameter (any repo the GitHub
+// installation can access).
 type PrCommentAction struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Legacy: treated as resolve_stale_threads at runtime.
@@ -3284,7 +4105,7 @@ type PrCommentAction struct {
 
 func (x *PrCommentAction) Reset() {
 	*x = PrCommentAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3296,7 +4117,7 @@ func (x *PrCommentAction) String() string {
 func (*PrCommentAction) ProtoMessage() {}
 
 func (x *PrCommentAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3309,7 +4130,7 @@ func (x *PrCommentAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrCommentAction.ProtoReflect.Descriptor instead.
 func (*PrCommentAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{40}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{46}
 }
 
 // Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
@@ -3357,7 +4178,7 @@ type ManageCheckRunAction struct {
 
 func (x *ManageCheckRunAction) Reset() {
 	*x = ManageCheckRunAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3369,7 +4190,7 @@ func (x *ManageCheckRunAction) String() string {
 func (*ManageCheckRunAction) ProtoMessage() {}
 
 func (x *ManageCheckRunAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3382,7 +4203,7 @@ func (x *ManageCheckRunAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManageCheckRunAction.ProtoReflect.Descriptor instead.
 func (*ManageCheckRunAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{41}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{47}
 }
 
 // Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
@@ -3393,8 +4214,10 @@ func (x *ManageCheckRunAction) GetDeterministic() bool {
 	return false
 }
 
-// Action: requests reviewers on the PR.
-// Only relevant for Git Pull Request triggers.
+// Action: requests reviewers on a PR. Defaults to the pull request from a Git
+// Pull Request trigger, but works on any trigger type: the agent targets a pull
+// request via the tool's pr_url parameter (any repo the GitHub installation can
+// access).
 type RequestReviewersAction struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -3403,7 +4226,7 @@ type RequestReviewersAction struct {
 
 func (x *RequestReviewersAction) Reset() {
 	*x = RequestReviewersAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3415,7 +4238,7 @@ func (x *RequestReviewersAction) String() string {
 func (*RequestReviewersAction) ProtoMessage() {}
 
 func (x *RequestReviewersAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3428,7 +4251,7 @@ func (x *RequestReviewersAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestReviewersAction.ProtoReflect.Descriptor instead.
 func (*RequestReviewersAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{42}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{48}
 }
 
 // Deprecated: approve capability is now a field on PrCommentAction.allow_approve.
@@ -3443,7 +4266,7 @@ type ApprovePrAction struct {
 
 func (x *ApprovePrAction) Reset() {
 	*x = ApprovePrAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3455,7 +4278,7 @@ func (x *ApprovePrAction) String() string {
 func (*ApprovePrAction) ProtoMessage() {}
 
 func (x *ApprovePrAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3468,7 +4291,7 @@ func (x *ApprovePrAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApprovePrAction.ProtoReflect.Descriptor instead.
 func (*ApprovePrAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{43}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{49}
 }
 
 // Action: gives the agent read-only access to public Slack channels the user belongs to.
@@ -3481,7 +4304,7 @@ type ReadSlackAction struct {
 
 func (x *ReadSlackAction) Reset() {
 	*x = ReadSlackAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3493,7 +4316,7 @@ func (x *ReadSlackAction) String() string {
 func (*ReadSlackAction) ProtoMessage() {}
 
 func (x *ReadSlackAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3506,14 +4329,14 @@ func (x *ReadSlackAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSlackAction.ProtoReflect.Descriptor instead.
 func (*ReadSlackAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{44}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{50}
 }
 
-// Action: lets the automation mark its own prior PR review threads as addressed and
-// resolve them on GitHub. Adds the ResolveReviewThreads tool; the executor
-// pre-fetches the automation's still-open threads on the current PR and injects
-// them into the agent context so the model can emit one verdict per thread.
-// Only meaningful for Git Pull Request triggers.
+// Action: lets the automation mark its own prior PR review threads as addressed
+// and resolve them on GitHub. Adds the ResolveReviewThreads tool. Defaults to
+// the pull request from a Git Pull Request trigger, but works on any trigger
+// type: the agent targets a pull request via the tool's pr_url parameter (any
+// repo the GitHub installation can access).
 type ResolveReviewThreadsAction struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -3522,7 +4345,7 @@ type ResolveReviewThreadsAction struct {
 
 func (x *ResolveReviewThreadsAction) Reset() {
 	*x = ResolveReviewThreadsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3534,7 +4357,7 @@ func (x *ResolveReviewThreadsAction) String() string {
 func (*ResolveReviewThreadsAction) ProtoMessage() {}
 
 func (x *ResolveReviewThreadsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3547,7 +4370,7 @@ func (x *ResolveReviewThreadsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveReviewThreadsAction.ProtoReflect.Descriptor instead.
 func (*ResolveReviewThreadsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{45}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{51}
 }
 
 type SlackAction struct {
@@ -3568,7 +4391,7 @@ type SlackAction struct {
 
 func (x *SlackAction) Reset() {
 	*x = SlackAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3580,7 +4403,7 @@ func (x *SlackAction) String() string {
 func (*SlackAction) ProtoMessage() {}
 
 func (x *SlackAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3593,7 +4416,7 @@ func (x *SlackAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackAction.ProtoReflect.Descriptor instead.
 func (*SlackAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{46}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *SlackAction) GetChannel() string {
@@ -3664,7 +4487,7 @@ type MicrosoftTeamsAction struct {
 
 func (x *MicrosoftTeamsAction) Reset() {
 	*x = MicrosoftTeamsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3676,7 +4499,7 @@ func (x *MicrosoftTeamsAction) String() string {
 func (*MicrosoftTeamsAction) ProtoMessage() {}
 
 func (x *MicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3689,7 +4512,7 @@ func (x *MicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosoftTeamsAction.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{47}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *MicrosoftTeamsAction) GetTenantId() string {
@@ -3752,7 +4575,7 @@ type ReadMicrosoftTeamsAction struct {
 
 func (x *ReadMicrosoftTeamsAction) Reset() {
 	*x = ReadMicrosoftTeamsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3764,7 +4587,7 @@ func (x *ReadMicrosoftTeamsAction) String() string {
 func (*ReadMicrosoftTeamsAction) ProtoMessage() {}
 
 func (x *ReadMicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3777,7 +4600,7 @@ func (x *ReadMicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadMicrosoftTeamsAction.ProtoReflect.Descriptor instead.
 func (*ReadMicrosoftTeamsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{48}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{54}
 }
 
 type CreateAutomationRequest struct {
@@ -3792,14 +4615,17 @@ type CreateAutomationRequest struct {
 	Hidden      *bool            `protobuf:"varint,7,opt,name=hidden,proto3,oneof" json:"hidden,omitempty"`
 	// Optional selected team to create the automation under.
 	// Omitted by older clients, which keeps the legacy authenticated-team behavior.
-	TeamId        *int32 `protobuf:"varint,8,opt,name=team_id,json=teamId,proto3,oneof" json:"team_id,omitempty"`
+	TeamId         *int32                   `protobuf:"varint,8,opt,name=team_id,json=teamId,proto3,oneof" json:"team_id,omitempty"`
+	CreationSource AutomationCreationSource `protobuf:"varint,9,opt,name=creation_source,json=creationSource,proto3,enum=aiserver.v1.AutomationCreationSource" json:"creation_source,omitempty"`
+	// Defaults to true when omitted.
+	Enabled       *bool `protobuf:"varint,10,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateAutomationRequest) Reset() {
 	*x = CreateAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3811,7 +4637,7 @@ func (x *CreateAutomationRequest) String() string {
 func (*CreateAutomationRequest) ProtoMessage() {}
 
 func (x *CreateAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3824,7 +4650,7 @@ func (x *CreateAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAutomationRequest.ProtoReflect.Descriptor instead.
 func (*CreateAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{49}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *CreateAutomationRequest) GetName() string {
@@ -3883,6 +4709,20 @@ func (x *CreateAutomationRequest) GetTeamId() int32 {
 	return 0
 }
 
+func (x *CreateAutomationRequest) GetCreationSource() AutomationCreationSource {
+	if x != nil {
+		return x.CreationSource
+	}
+	return AutomationCreationSource_AUTOMATION_CREATION_SOURCE_UNSPECIFIED
+}
+
+func (x *CreateAutomationRequest) GetEnabled() bool {
+	if x != nil && x.Enabled != nil {
+		return *x.Enabled
+	}
+	return false
+}
+
 type CreateAutomationResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Workflow      *AutomationWithOwner   `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
@@ -3892,7 +4732,7 @@ type CreateAutomationResponse struct {
 
 func (x *CreateAutomationResponse) Reset() {
 	*x = CreateAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3904,7 +4744,7 @@ func (x *CreateAutomationResponse) String() string {
 func (*CreateAutomationResponse) ProtoMessage() {}
 
 func (x *CreateAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3917,7 +4757,7 @@ func (x *CreateAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAutomationResponse.ProtoReflect.Descriptor instead.
 func (*CreateAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{50}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CreateAutomationResponse) GetWorkflow() *AutomationWithOwner {
@@ -3937,7 +4777,7 @@ type GetAutomationRequest struct {
 
 func (x *GetAutomationRequest) Reset() {
 	*x = GetAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3949,7 +4789,7 @@ func (x *GetAutomationRequest) String() string {
 func (*GetAutomationRequest) ProtoMessage() {}
 
 func (x *GetAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3962,7 +4802,7 @@ func (x *GetAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAutomationRequest.ProtoReflect.Descriptor instead.
 func (*GetAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{51}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetAutomationRequest) GetAutomationId() string {
@@ -3986,7 +4826,7 @@ type RestrictedAutomationSummary struct {
 
 func (x *RestrictedAutomationSummary) Reset() {
 	*x = RestrictedAutomationSummary{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3998,7 +4838,7 @@ func (x *RestrictedAutomationSummary) String() string {
 func (*RestrictedAutomationSummary) ProtoMessage() {}
 
 func (x *RestrictedAutomationSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4011,7 +4851,7 @@ func (x *RestrictedAutomationSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestrictedAutomationSummary.ProtoReflect.Descriptor instead.
 func (*RestrictedAutomationSummary) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{52}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *RestrictedAutomationSummary) GetAutomationId() string {
@@ -4055,7 +4895,7 @@ type GetAutomationResponse struct {
 
 func (x *GetAutomationResponse) Reset() {
 	*x = GetAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4067,7 +4907,7 @@ func (x *GetAutomationResponse) String() string {
 func (*GetAutomationResponse) ProtoMessage() {}
 
 func (x *GetAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4080,7 +4920,7 @@ func (x *GetAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAutomationResponse.ProtoReflect.Descriptor instead.
 func (*GetAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{53}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *GetAutomationResponse) GetResult() isGetAutomationResponse_Result {
@@ -4142,7 +4982,7 @@ type UpdateAutomationRequest struct {
 
 func (x *UpdateAutomationRequest) Reset() {
 	*x = UpdateAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4154,7 +4994,7 @@ func (x *UpdateAutomationRequest) String() string {
 func (*UpdateAutomationRequest) ProtoMessage() {}
 
 func (x *UpdateAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4167,7 +5007,7 @@ func (x *UpdateAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAutomationRequest.ProtoReflect.Descriptor instead.
 func (*UpdateAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{54}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UpdateAutomationRequest) GetName() string {
@@ -4235,7 +5075,7 @@ type UpdateAutomationResponse struct {
 
 func (x *UpdateAutomationResponse) Reset() {
 	*x = UpdateAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4247,7 +5087,7 @@ func (x *UpdateAutomationResponse) String() string {
 func (*UpdateAutomationResponse) ProtoMessage() {}
 
 func (x *UpdateAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4260,7 +5100,7 @@ func (x *UpdateAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAutomationResponse.ProtoReflect.Descriptor instead.
 func (*UpdateAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{55}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *UpdateAutomationResponse) GetWorkflow() *AutomationWithOwner {
@@ -4280,7 +5120,7 @@ type DeleteAutomationRequest struct {
 
 func (x *DeleteAutomationRequest) Reset() {
 	*x = DeleteAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4292,7 +5132,7 @@ func (x *DeleteAutomationRequest) String() string {
 func (*DeleteAutomationRequest) ProtoMessage() {}
 
 func (x *DeleteAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4305,7 +5145,7 @@ func (x *DeleteAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAutomationRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{56}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *DeleteAutomationRequest) GetAutomationId() string {
@@ -4323,7 +5163,7 @@ type DeleteAutomationResponse struct {
 
 func (x *DeleteAutomationResponse) Reset() {
 	*x = DeleteAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4335,7 +5175,7 @@ func (x *DeleteAutomationResponse) String() string {
 func (*DeleteAutomationResponse) ProtoMessage() {}
 
 func (x *DeleteAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4348,7 +5188,7 @@ func (x *DeleteAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAutomationResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{57}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{63}
 }
 
 type Automation struct {
@@ -4371,13 +5211,14 @@ type Automation struct {
 	DeployLastApplyError *string             `protobuf:"bytes,14,opt,name=deploy_last_apply_error,json=deployLastApplyError,proto3,oneof" json:"deploy_last_apply_error,omitempty"`
 	ManagedType          *string             `protobuf:"bytes,15,opt,name=managed_type,json=managedType,proto3,oneof" json:"managed_type,omitempty"`
 	Hidden               *bool               `protobuf:"varint,16,opt,name=hidden,proto3,oneof" json:"hidden,omitempty"`
+	TemplateId           *string             `protobuf:"bytes,17,opt,name=template_id,json=templateId,proto3,oneof" json:"template_id,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Automation) Reset() {
 	*x = Automation{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4389,7 +5230,7 @@ func (x *Automation) String() string {
 func (*Automation) ProtoMessage() {}
 
 func (x *Automation) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4402,7 +5243,7 @@ func (x *Automation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Automation.ProtoReflect.Descriptor instead.
 func (*Automation) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{58}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *Automation) GetName() string {
@@ -4510,22 +5351,92 @@ func (x *Automation) GetHidden() bool {
 	return false
 }
 
-// Response wrapper that includes Automation plus user context.
-// This decouples the database model from the API response.
+func (x *Automation) GetTemplateId() string {
+	if x != nil && x.TemplateId != nil {
+		return *x.TemplateId
+	}
+	return ""
+}
+
+type AutomationMcpAuthState struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ServerId      *int64                 `protobuf:"varint,1,opt,name=server_id,json=serverId,proto3,oneof" json:"server_id,omitempty"`
+	ServerName    string                 `protobuf:"bytes,2,opt,name=server_name,json=serverName,proto3" json:"server_name,omitempty"`
+	AuthState     McpAuthState           `protobuf:"varint,3,opt,name=auth_state,json=authState,proto3,enum=aiserver.v1.McpAuthState" json:"auth_state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AutomationMcpAuthState) Reset() {
+	*x = AutomationMcpAuthState{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AutomationMcpAuthState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AutomationMcpAuthState) ProtoMessage() {}
+
+func (x *AutomationMcpAuthState) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AutomationMcpAuthState.ProtoReflect.Descriptor instead.
+func (*AutomationMcpAuthState) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *AutomationMcpAuthState) GetServerId() int64 {
+	if x != nil && x.ServerId != nil {
+		return *x.ServerId
+	}
+	return 0
+}
+
+func (x *AutomationMcpAuthState) GetServerName() string {
+	if x != nil {
+		return x.ServerName
+	}
+	return ""
+}
+
+func (x *AutomationMcpAuthState) GetAuthState() McpAuthState {
+	if x != nil {
+		return x.AuthState
+	}
+	return McpAuthState_MCP_AUTH_STATE_UNSPECIFIED
+}
+
 type AutomationWithOwner struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Workflow *Automation            `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
 	// User ID of the automation owner (who created it)
 	UserId int32 `protobuf:"varint,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
 	// Display name of the automation owner (firstName lastName or email)
-	OwnerName     string `protobuf:"bytes,3,opt,name=owner_name,json=ownerName,proto3" json:"owner_name,omitempty"`
+	OwnerName string `protobuf:"bytes,3,opt,name=owner_name,json=ownerName,proto3" json:"owner_name,omitempty"`
+	// Per-MCP-server auth state; only resolved HTTP servers. Empty when the
+	// enrichment is disabled or the automation uses no MCP.
+	McpAuthStates []*AutomationMcpAuthState `protobuf:"bytes,4,rep,name=mcp_auth_states,json=mcpAuthStates,proto3" json:"mcp_auth_states,omitempty"`
+	// Team that owns this automation, when it is team-scoped.
+	TeamId        *int32 `protobuf:"varint,5,opt,name=team_id,json=teamId,proto3,oneof" json:"team_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AutomationWithOwner) Reset() {
 	*x = AutomationWithOwner{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4537,7 +5448,7 @@ func (x *AutomationWithOwner) String() string {
 func (*AutomationWithOwner) ProtoMessage() {}
 
 func (x *AutomationWithOwner) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4550,7 +5461,7 @@ func (x *AutomationWithOwner) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AutomationWithOwner.ProtoReflect.Descriptor instead.
 func (*AutomationWithOwner) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{59}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *AutomationWithOwner) GetWorkflow() *Automation {
@@ -4574,11 +5485,25 @@ func (x *AutomationWithOwner) GetOwnerName() string {
 	return ""
 }
 
+func (x *AutomationWithOwner) GetMcpAuthStates() []*AutomationMcpAuthState {
+	if x != nil {
+		return x.McpAuthStates
+	}
+	return nil
+}
+
+func (x *AutomationWithOwner) GetTeamId() int32 {
+	if x != nil && x.TeamId != nil {
+		return *x.TeamId
+	}
+	return 0
+}
+
 var File_aiserver_v1_automations_proto protoreflect.FileDescriptor
 
 const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\n" +
-	"\x1daiserver/v1/automations.proto\x12\vaiserver.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xa8\x06\n" +
+	"\x1daiserver/v1/automations.proto\x12\vaiserver.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x84\a\n" +
 	"\aTrigger\x12.\n" +
 	"\x04cron\x18\x01 \x01(\v2\x18.aiserver.v1.CronTriggerH\x00R\x04cron\x12+\n" +
 	"\x03git\x18\x02 \x01(\v2\x17.aiserver.v1.GitTriggerH\x00R\x03git\x12@\n" +
@@ -4589,7 +5514,8 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\tpagerduty\x18\r \x01(\v2\x1d.aiserver.v1.PagerDutyTriggerH\x00R\tpagerduty\x124\n" +
 	"\x06sentry\x18\x0f \x01(\v2\x1a.aiserver.v1.SentryTriggerH\x00R\x06sentry\x12\\\n" +
 	"\x17microsoft_teams_trigger\x18\x10 \x01(\v2\".aiserver.v1.MicrosoftTeamsTriggerH\x00R\x15microsoftTeamsTrigger\x12y\n" +
-	"\x1fmicrosoft_teams_channel_created\x18\x11 \x01(\v20.aiserver.v1.MicrosoftTeamsChannelCreatedTriggerH\x00R\x1cmicrosoftTeamsChannelCreated\x127\n" +
+	"\x1fmicrosoft_teams_channel_created\x18\x11 \x01(\v20.aiserver.v1.MicrosoftTeamsChannelCreatedTriggerH\x00R\x1cmicrosoftTeamsChannelCreated\x12Z\n" +
+	"\x14slack_reaction_added\x18\x12 \x01(\v2&.aiserver.v1.SlackReactionAddedTriggerH\x00R\x12slackReactionAdded\x127\n" +
 	"\x15agentic_filter_prompt\x18\x0e \x01(\tH\x01R\x13agenticFilterPrompt\x88\x01\x01B\t\n" +
 	"\atriggerB\x18\n" +
 	"\x16_agentic_filter_promptJ\x04\b\n" +
@@ -4612,9 +5538,11 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x14read_microsoft_teams\x18\x0e \x01(\v2%.aiserver.v1.ReadMicrosoftTeamsActionH\x00R\x12readMicrosoftTeamsB\b\n" +
 	"\x06action\"A\n" +
 	"\tMcpAction\x124\n" +
-	"\x06server\x18\x01 \x01(\v2\x1c.aiserver.v1.McpServerConfigR\x06server\"1\n" +
-	"\x0fMcpServerConfig\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04nameJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04\"A\n" +
+	"\x06server\x18\x01 \x01(\v2\x1c.aiserver.v1.McpServerConfigR\x06server\"M\n" +
+	"\x0fMcpServerConfig\x12\x13\n" +
+	"\x02id\x18\x04 \x01(\x03H\x00R\x02id\x88\x01\x01\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04nameB\x05\n" +
+	"\x03_idJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04\"A\n" +
 	"\x17AgentPrivateWorkerLabel\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\"X\n" +
@@ -4648,25 +5576,40 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x1f_slack_completion_reaction_modeB)\n" +
 	"'_slack_completion_reaction_custom_emojiB\x11\n" +
 	"\x0f_managed_configJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
-	"\"c\n" +
+	"\"\xda\x02\n" +
 	"\x06Prompt\x12\x16\n" +
 	"\x06prompt\x18\x01 \x01(\tR\x06prompt\x12A\n" +
-	"\feffort_level\x18\x02 \x01(\x0e2\x1e.aiserver.v1.PromptEffortLevelR\veffortLevel\"Y\n" +
+	"\feffort_level\x18\x02 \x01(\x0e2\x1e.aiserver.v1.PromptEffortLevelR\veffortLevel\x12\x19\n" +
+	"\x05model\x18\x03 \x01(\tH\x00R\x05model\x88\x01\x01\x12 \n" +
+	"\tis_filter\x18\x04 \x01(\bH\x01R\bisFilter\x88\x01\x01\x12:\n" +
+	"\brun_mode\x18\x05 \x01(\x0e2\x1a.aiserver.v1.PromptRunModeH\x02R\arunMode\x88\x01\x01\x12;\n" +
+	"\x17suppress_slack_reaction\x18\x06 \x01(\bH\x03R\x15suppressSlackReaction\x88\x01\x01B\b\n" +
+	"\x06_modelB\f\n" +
+	"\n" +
+	"_is_filterB\v\n" +
+	"\t_run_modeB\x1a\n" +
+	"\x18_suppress_slack_reaction\"Y\n" +
 	"\tGitConfig\x12\x12\n" +
 	"\x04repo\x18\x03 \x01(\tR\x04repo\x12\x16\n" +
 	"\x06branch\x18\x04 \x01(\tR\x06branch\x12\x14\n" +
 	"\x05repos\x18\x05 \x03(\tR\x05reposJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03\"'\n" +
 	"\vCronTrigger\x12\x12\n" +
-	"\x04cron\x18\x01 \x01(\tR\x04cronJ\x04\b\x02\x10\x03\"\xf9\x02\n" +
+	"\x04cron\x18\x01 \x01(\tR\x04cronJ\x04\b\x02\x10\x03\"\x9e\x06\n" +
 	"\n" +
 	"GitTrigger\x12E\n" +
 	"\fpull_request\x18\x01 \x01(\v2 .aiserver.v1.GitPullRequestEventH\x00R\vpullRequest\x12/\n" +
 	"\x04push\x18\x02 \x01(\v2\x19.aiserver.v1.GitPushEventH\x00R\x04push\x12E\n" +
 	"\fci_completed\x18\x04 \x01(\v2 .aiserver.v1.GitCICompletedEventH\x00R\vciCompleted\x12H\n" +
 	"\rissue_labeled\x18\x05 \x01(\v2!.aiserver.v1.GitIssueLabeledEventH\x00R\fissueLabeled\x122\n" +
-	"\x05label\x18\x06 \x01(\v2\x1a.aiserver.v1.GitLabelEventH\x00R\x05label\x12%\n" +
+	"\x05label\x18\x06 \x01(\v2\x1a.aiserver.v1.GitLabelEventH\x00R\x05label\x12H\n" +
+	"\rissue_comment\x18\a \x01(\v2!.aiserver.v1.GitIssueCommentEventH\x00R\fissueComment\x12n\n" +
+	"\x1bpull_request_review_comment\x18\b \x01(\v2-.aiserver.v1.GitPullRequestReviewCommentEventH\x00R\x18pullRequestReviewComment\x12X\n" +
+	"\x13pull_request_review\x18\t \x01(\v2&.aiserver.v1.GitPullRequestReviewEventH\x00R\x11pullRequestReview\x12H\n" +
+	"\rreview_thread\x18\n" +
+	" \x01(\v2!.aiserver.v1.GitReviewThreadEventH\x00R\freviewThread\x12E\n" +
+	"\fworkflow_run\x18\v \x01(\v2 .aiserver.v1.GitWorkflowRunEventH\x00R\vworkflowRun\x12%\n" +
 	"\x0euser_allowlist\x18\x03 \x03(\tR\ruserAllowlistB\a\n" +
-	"\x05event\"\xd5\x02\n" +
+	"\x05event\"\x90\x03\n" +
 	"\x13GitPullRequestEvent\x12\x12\n" +
 	"\x04repo\x18\x01 \x01(\tR\x04repo\x12\x14\n" +
 	"\x05repos\x18\x02 \x03(\tR\x05repos\x12(\n" +
@@ -4674,7 +5617,9 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\tonly_once\x18\x04 \x01(\bR\bonlyOnce\x12>\n" +
 	"\tpr_action\x18\x05 \x01(\x0e2!.aiserver.v1.GitPullRequestActionR\bprAction\x12/\n" +
 	"\x13commenter_allowlist\x18\x06 \x03(\tR\x12commenterAllowlist\x12)\n" +
-	"\x10comment_contains\x18\a \x01(\tR\x0fcommentContains\x12\x1d\n" +
+	"\x10comment_contains\x18\a \x01(\tR\x0fcommentContains\x129\n" +
+	"\x19comment_contains_is_regex\x18\n" +
+	" \x01(\bR\x16commentContainsIsRegex\x12\x1d\n" +
 	"\n" +
 	"label_name\x18\b \x01(\tR\tlabelName\x12\x12\n" +
 	"\x04orgs\x18\t \x03(\tR\x04orgs\"P\n" +
@@ -4691,7 +5636,35 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x05repos\x18\x01 \x03(\tR\x05repos\x12\x1d\n" +
 	"\n" +
 	"label_name\x18\x02 \x01(\tR\tlabelName\x12\x1c\n" +
-	"\tunlabeled\x18\x03 \x01(\bR\tunlabeled\"\xbb\x01\n" +
+	"\tunlabeled\x18\x03 \x01(\bR\tunlabeled\"\xc3\x01\n" +
+	"\x14GitIssueCommentEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\x12/\n" +
+	"\x13commenter_allowlist\x18\x02 \x03(\tR\x12commenterAllowlist\x12)\n" +
+	"\x10comment_contains\x18\x03 \x01(\tR\x0fcommentContains\x129\n" +
+	"\x19comment_contains_is_regex\x18\x04 \x01(\bR\x16commentContainsIsRegex\"\xcf\x01\n" +
+	" GitPullRequestReviewCommentEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\x12/\n" +
+	"\x13commenter_allowlist\x18\x02 \x03(\tR\x12commenterAllowlist\x12)\n" +
+	"\x10comment_contains\x18\x03 \x01(\tR\x0fcommentContains\x129\n" +
+	"\x19comment_contains_is_regex\x18\x04 \x01(\bR\x16commentContainsIsRegex\"\xa7\x01\n" +
+	"\x19GitPullRequestReviewEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\x12\x1f\n" +
+	"\von_approved\x18\x02 \x01(\bR\n" +
+	"onApproved\x120\n" +
+	"\x14on_changes_requested\x18\x03 \x01(\bR\x12onChangesRequested\x12!\n" +
+	"\fon_commented\x18\x04 \x01(\bR\vonCommented\"r\n" +
+	"\x14GitReviewThreadEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\x12\x1f\n" +
+	"\von_resolved\x18\x02 \x01(\bR\n" +
+	"onResolved\x12#\n" +
+	"\ron_unresolved\x18\x03 \x01(\bR\fonUnresolved\"\xb1\x01\n" +
+	"\x13GitWorkflowRunEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\x12%\n" +
+	"\x0eworkflow_names\x18\x02 \x03(\tR\rworkflowNames\x12\x16\n" +
+	"\x06branch\x18\x03 \x01(\tR\x06branch\x12E\n" +
+	"\n" +
+	"conclusion\x18\x04 \x01(\x0e2%.aiserver.v1.GitWorkflowRunConclusionR\n" +
+	"conclusion\"\xbb\x01\n" +
 	"\rGitLabelEvent\x12\x14\n" +
 	"\x05repos\x18\x01 \x03(\tR\x05repos\x12\x1d\n" +
 	"\n" +
@@ -4700,7 +5673,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\n" +
 	"on_removed\x18\x04 \x01(\bR\tonRemoved\x12#\n" +
 	"\rpull_requests\x18\x05 \x01(\bR\fpullRequests\x12\x16\n" +
-	"\x06issues\x18\x06 \x01(\bR\x06issues\"\x96\x04\n" +
+	"\x06issues\x18\x06 \x01(\bR\x06issues\"\xd4\x04\n" +
 	"\fSlackTrigger\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12)\n" +
 	"\x10message_contains\x18\x03 \x01(\tR\x0fmessageContains\x129\n" +
@@ -4708,11 +5681,19 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\bchannels\x18\x05 \x03(\tR\bchannels\x12I\n" +
 	"!block_unauthenticated_slack_users\x18\x06 \x01(\bR\x1eblockUnauthenticatedSlackUsers\x12r\n" +
 	"\x1eslack_completion_reaction_mode\x18\a \x01(\x0e2(.aiserver.v1.SlackCompletionReactionModeH\x00R\x1bslackCompletionReactionMode\x88\x01\x01\x12W\n" +
-	"&slack_completion_reaction_custom_emoji\x18\b \x01(\tH\x01R\"slackCompletionReactionCustomEmoji\x88\x01\x01B!\n" +
+	"&slack_completion_reaction_custom_emoji\x18\b \x01(\tH\x01R\"slackCompletionReactionCustomEmoji\x88\x01\x01\x12)\n" +
+	"\x0etop_level_only\x18\t \x01(\bH\x02R\ftopLevelOnly\x88\x01\x01B!\n" +
 	"\x1f_slack_completion_reaction_modeB)\n" +
-	"'_slack_completion_reaction_custom_emojiJ\x04\b\x02\x10\x03\"P\n" +
+	"'_slack_completion_reaction_custom_emojiB\x11\n" +
+	"\x0f_top_level_onlyJ\x04\b\x02\x10\x03\"P\n" +
 	"\x1aSlackChannelCreatedTrigger\x122\n" +
-	"\x15channel_name_contains\x18\x01 \x01(\tR\x13channelNameContains\"\xbf\x02\n" +
+	"\x15channel_name_contains\x18\x01 \x01(\tR\x13channelNameContains\"\x9b\x02\n" +
+	"\x19SlackReactionAddedTrigger\x12\x18\n" +
+	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1d\n" +
+	"\n" +
+	"emoji_name\x18\x03 \x01(\tR\temojiName\x12\x1a\n" +
+	"\bchannels\x18\x05 \x03(\tR\bchannels\x12I\n" +
+	"!block_unauthenticated_slack_users\x18\x06 \x01(\bR\x1eblockUnauthenticatedSlackUsersJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\b\x10\tR\x1eslack_completion_reaction_modeR&slack_completion_reaction_custom_emoji\"\xbf\x02\n" +
 	"\rLinearTrigger\x12K\n" +
 	"\rissue_created\x18\x01 \x01(\v2$.aiserver.v1.LinearIssueCreatedEventH\x00R\fissueCreated\x12N\n" +
 	"\x0estatus_changed\x18\x02 \x01(\v2%.aiserver.v1.LinearStatusChangedEventH\x00R\rstatusChanged\x12F\n" +
@@ -4800,7 +5781,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\vgeneralized\x18\x05 \x01(\bR\vgeneralized\x12*\n" +
 	"\x11respond_in_thread\x18\x06 \x01(\bR\x0frespondInThread\x12$\n" +
 	"\x0epost_as_thread\x18\a \x01(\bR\fpostAsThread\"\x1a\n" +
-	"\x18ReadMicrosoftTeamsAction\"\x9b\x03\n" +
+	"\x18ReadMicrosoftTeamsAction\"\x96\x04\n" +
 	"\x17CreateAutomationRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\bworkflow\x18\x02 \x01(\v2\x15.aiserver.v1.WorkflowR\bworkflow\x12%\n" +
@@ -4810,14 +5791,19 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"templateId\x88\x01\x01\x12&\n" +
 	"\fmanaged_type\x18\x06 \x01(\tH\x03R\vmanagedType\x88\x01\x01\x12\x1b\n" +
 	"\x06hidden\x18\a \x01(\bH\x04R\x06hidden\x88\x01\x01\x12\x1c\n" +
-	"\ateam_id\x18\b \x01(\x05H\x05R\x06teamId\x88\x01\x01B\x0e\n" +
+	"\ateam_id\x18\b \x01(\x05H\x05R\x06teamId\x88\x01\x01\x12N\n" +
+	"\x0fcreation_source\x18\t \x01(\x0e2%.aiserver.v1.AutomationCreationSourceR\x0ecreationSource\x12\x1d\n" +
+	"\aenabled\x18\n" +
+	" \x01(\bH\x06R\aenabled\x88\x01\x01B\x0e\n" +
 	"\f_descriptionB\b\n" +
 	"\x06_scopeB\x0e\n" +
 	"\f_template_idB\x0f\n" +
 	"\r_managed_typeB\t\n" +
 	"\a_hiddenB\n" +
 	"\n" +
-	"\b_team_id\"X\n" +
+	"\b_team_idB\n" +
+	"\n" +
+	"\b_enabled\"X\n" +
 	"\x18CreateAutomationResponse\x12<\n" +
 	"\bworkflow\x18\x01 \x01(\v2 .aiserver.v1.AutomationWithOwnerR\bworkflow\"A\n" +
 	"\x14GetAutomationRequest\x12#\n" +
@@ -4853,7 +5839,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\bworkflow\x18\x01 \x01(\v2 .aiserver.v1.AutomationWithOwnerR\bworkflow\"D\n" +
 	"\x17DeleteAutomationRequest\x12#\n" +
 	"\rautomation_id\x18\x02 \x01(\tR\fautomationIdJ\x04\b\x01\x10\x02\"\x1a\n" +
-	"\x18DeleteAutomationResponse\"\x8d\x06\n" +
+	"\x18DeleteAutomationResponse\"\xc3\x06\n" +
 	"\n" +
 	"Automation\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -4875,19 +5861,34 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x16deploy_last_applied_at\x18\r \x01(\x03H\x03R\x13deployLastAppliedAt\x88\x01\x01\x12:\n" +
 	"\x17deploy_last_apply_error\x18\x0e \x01(\tH\x04R\x14deployLastApplyError\x88\x01\x01\x12&\n" +
 	"\fmanaged_type\x18\x0f \x01(\tH\x05R\vmanagedType\x88\x01\x01\x12\x1b\n" +
-	"\x06hidden\x18\x10 \x01(\bH\x06R\x06hidden\x88\x01\x01B\x0e\n" +
+	"\x06hidden\x18\x10 \x01(\bH\x06R\x06hidden\x88\x01\x01\x12$\n" +
+	"\vtemplate_id\x18\x11 \x01(\tH\aR\n" +
+	"templateId\x88\x01\x01B\x0e\n" +
 	"\f_descriptionB\x15\n" +
 	"\x13_service_account_idB\r\n" +
 	"\v_deploy_keyB\x19\n" +
 	"\x17_deploy_last_applied_atB\x1a\n" +
 	"\x18_deploy_last_apply_errorB\x0f\n" +
 	"\r_managed_typeB\t\n" +
-	"\a_hiddenJ\x04\b\x01\x10\x02\"\x82\x01\n" +
+	"\a_hiddenB\x0e\n" +
+	"\f_template_idJ\x04\b\x01\x10\x02\"\xa3\x01\n" +
+	"\x16AutomationMcpAuthState\x12 \n" +
+	"\tserver_id\x18\x01 \x01(\x03H\x00R\bserverId\x88\x01\x01\x12\x1f\n" +
+	"\vserver_name\x18\x02 \x01(\tR\n" +
+	"serverName\x128\n" +
+	"\n" +
+	"auth_state\x18\x03 \x01(\x0e2\x19.aiserver.v1.McpAuthStateR\tauthStateB\f\n" +
+	"\n" +
+	"_server_id\"\xf9\x01\n" +
 	"\x13AutomationWithOwner\x123\n" +
 	"\bworkflow\x18\x01 \x01(\v2\x17.aiserver.v1.AutomationR\bworkflow\x12\x17\n" +
 	"\auser_id\x18\x02 \x01(\x05R\x06userId\x12\x1d\n" +
 	"\n" +
-	"owner_name\x18\x03 \x01(\tR\townerName*\xc7\x01\n" +
+	"owner_name\x18\x03 \x01(\tR\townerName\x12K\n" +
+	"\x0fmcp_auth_states\x18\x04 \x03(\v2#.aiserver.v1.AutomationMcpAuthStateR\rmcpAuthStates\x12\x1c\n" +
+	"\ateam_id\x18\x05 \x01(\x05H\x00R\x06teamId\x88\x01\x01B\n" +
+	"\n" +
+	"\b_team_id*\xc7\x01\n" +
 	"\x1bSlackCompletionReactionMode\x12.\n" +
 	"*SLACK_COMPLETION_REACTION_MODE_UNSPECIFIED\x10\x00\x12%\n" +
 	"!SLACK_COMPLETION_REACTION_MODE_ON\x10\x01\x12&\n" +
@@ -4899,7 +5900,13 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x15AUTOMATION_SCOPE_TEAM\x10\x02\x12!\n" +
 	"\x1dAUTOMATION_SCOPE_TEAM_VISIBLE\x10\x03\x12\"\n" +
 	"\x1eAUTOMATION_SCOPE_TEAM_EDITABLE\x10\x04\x12'\n" +
-	"#AUTOMATION_SCOPE_TEAM_EDITABLE_USER\x10\x05*\x9b\x01\n" +
+	"#AUTOMATION_SCOPE_TEAM_EDITABLE_USER\x10\x05*\xf3\x01\n" +
+	"\x18AutomationCreationSource\x12*\n" +
+	"&AUTOMATION_CREATION_SOURCE_UNSPECIFIED\x10\x00\x12)\n" +
+	"%AUTOMATION_CREATION_SOURCE_PORTAL_WEB\x10\x01\x12'\n" +
+	"#AUTOMATION_CREATION_SOURCE_GLASS_UI\x10\x02\x12(\n" +
+	"$AUTOMATION_CREATION_SOURCE_SKILL_MCP\x10\x03\x12-\n" +
+	")AUTOMATION_CREATION_SOURCE_CONFIG_AS_CODE\x10\x04*\x9b\x01\n" +
 	"\x13AutomationManagedBy\x12%\n" +
 	"!AUTOMATION_MANAGED_BY_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18AUTOMATION_MANAGED_BY_UI\x10\x01\x12 \n" +
@@ -4909,7 +5916,11 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x1fPROMPT_EFFORT_LEVEL_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cPROMPT_EFFORT_LEVEL_STANDARD\x10\x01\x12\x1c\n" +
 	"\x18PROMPT_EFFORT_LEVEL_HARD\x10\n" +
-	"*\xc8\x02\n" +
+	"*n\n" +
+	"\rPromptRunMode\x12\x1f\n" +
+	"\x1bPROMPT_RUN_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19PROMPT_RUN_MODE_SAME_CHAT\x10\x01\x12\x1d\n" +
+	"\x19PROMPT_RUN_MODE_NEW_AGENT\x10\x02*\xc8\x02\n" +
 	"\x14GitPullRequestAction\x12'\n" +
 	"#GIT_PULL_REQUEST_ACTION_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eGIT_PULL_REQUEST_ACTION_OPENED\x10\x01\x12\"\n" +
@@ -4923,13 +5934,23 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"'GIT_CI_COMPLETION_CONDITION_UNSPECIFIED\x10\x00\x12'\n" +
 	"#GIT_CI_COMPLETION_CONDITION_FAILURE\x10\x01\x12'\n" +
 	"#GIT_CI_COMPLETION_CONDITION_SUCCESS\x10\x02\x12#\n" +
-	"\x1fGIT_CI_COMPLETION_CONDITION_ANY\x10\x032\x8f\x03\n" +
+	"\x1fGIT_CI_COMPLETION_CONDITION_ANY\x10\x03*\xe9\x01\n" +
+	"\x18GitWorkflowRunConclusion\x12+\n" +
+	"'GIT_WORKFLOW_RUN_CONCLUSION_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fGIT_WORKFLOW_RUN_CONCLUSION_ANY\x10\x01\x12'\n" +
+	"#GIT_WORKFLOW_RUN_CONCLUSION_SUCCESS\x10\x02\x12'\n" +
+	"#GIT_WORKFLOW_RUN_CONCLUSION_FAILURE\x10\x03\x12)\n" +
+	"%GIT_WORKFLOW_RUN_CONCLUSION_CANCELLED\x10\x04*\x8b\x01\n" +
+	"\fMcpAuthState\x12\x1e\n" +
+	"\x1aMCP_AUTH_STATE_UNSPECIFIED\x10\x00\x12\x1a\n" +
+	"\x16MCP_AUTH_STATE_UNKNOWN\x10\x01\x12 \n" +
+	"\x1cMCP_AUTH_STATE_AUTHENTICATED\x10\x02\x12\x1d\n" +
+	"\x19MCP_AUTH_STATE_NEEDS_AUTH\x10\x032\x8f\x03\n" +
 	"\x12AutomationsService\x12_\n" +
 	"\x10CreateAutomation\x12$.aiserver.v1.CreateAutomationRequest\x1a%.aiserver.v1.CreateAutomationResponse\x12V\n" +
 	"\rGetAutomation\x12!.aiserver.v1.GetAutomationRequest\x1a\".aiserver.v1.GetAutomationResponse\x12_\n" +
 	"\x10UpdateAutomation\x12$.aiserver.v1.UpdateAutomationRequest\x1a%.aiserver.v1.UpdateAutomationResponse\x12_\n" +
-	"\x10DeleteAutomation\x12$.aiserver.v1.DeleteAutomationRequest\x1a%.aiserver.v1.DeleteAutomationResponseB\xb2\x01\n" +
-	"\x0fcom.aiserver.v1B\x10AutomationsProtoP\x01Z@github.com/cursor/terraform-provider-cursor/internal/proto/v1;v1\xa2\x02\x03AXX\xaa\x02\vAiserver.V1\xca\x02\vAiserver\\V1\xe2\x02\x17Aiserver\\V1\\GPBMetadata\xea\x02\fAiserver::V1b\x06proto3"
+	"\x10DeleteAutomation\x12$.aiserver.v1.DeleteAutomationRequest\x1a%.aiserver.v1.DeleteAutomationResponseB?Z=github.com/cursor/terraform-provider-cursor/internal/proto/v1b\x06proto3"
 
 var (
 	file_aiserver_v1_automations_proto_rawDescOnce sync.Once
@@ -4943,157 +5964,179 @@ func file_aiserver_v1_automations_proto_rawDescGZIP() []byte {
 	return file_aiserver_v1_automations_proto_rawDescData
 }
 
-var file_aiserver_v1_automations_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_aiserver_v1_automations_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
+var file_aiserver_v1_automations_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_aiserver_v1_automations_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_aiserver_v1_automations_proto_goTypes = []any{
 	(SlackCompletionReactionMode)(0),            // 0: aiserver.v1.SlackCompletionReactionMode
 	(AutomationScope)(0),                        // 1: aiserver.v1.AutomationScope
-	(AutomationManagedBy)(0),                    // 2: aiserver.v1.AutomationManagedBy
-	(PromptEffortLevel)(0),                      // 3: aiserver.v1.PromptEffortLevel
-	(GitPullRequestAction)(0),                   // 4: aiserver.v1.GitPullRequestAction
-	(GitCICompletionCondition)(0),               // 5: aiserver.v1.GitCICompletionCondition
-	(*Trigger)(nil),                             // 6: aiserver.v1.Trigger
-	(*Action)(nil),                              // 7: aiserver.v1.Action
-	(*McpAction)(nil),                           // 8: aiserver.v1.McpAction
-	(*McpServerConfig)(nil),                     // 9: aiserver.v1.McpServerConfig
-	(*AgentPrivateWorkerLabel)(nil),             // 10: aiserver.v1.AgentPrivateWorkerLabel
-	(*AgentPrivateWorkerConfig)(nil),            // 11: aiserver.v1.AgentPrivateWorkerConfig
-	(*AgentOptions)(nil),                        // 12: aiserver.v1.AgentOptions
-	(*Workflow)(nil),                            // 13: aiserver.v1.Workflow
-	(*Prompt)(nil),                              // 14: aiserver.v1.Prompt
-	(*GitConfig)(nil),                           // 15: aiserver.v1.GitConfig
-	(*CronTrigger)(nil),                         // 16: aiserver.v1.CronTrigger
-	(*GitTrigger)(nil),                          // 17: aiserver.v1.GitTrigger
-	(*GitPullRequestEvent)(nil),                 // 18: aiserver.v1.GitPullRequestEvent
-	(*GitPushEvent)(nil),                        // 19: aiserver.v1.GitPushEvent
-	(*GitCICompletedEvent)(nil),                 // 20: aiserver.v1.GitCICompletedEvent
-	(*GitIssueLabeledEvent)(nil),                // 21: aiserver.v1.GitIssueLabeledEvent
-	(*GitLabelEvent)(nil),                       // 22: aiserver.v1.GitLabelEvent
-	(*SlackTrigger)(nil),                        // 23: aiserver.v1.SlackTrigger
-	(*SlackChannelCreatedTrigger)(nil),          // 24: aiserver.v1.SlackChannelCreatedTrigger
-	(*LinearTrigger)(nil),                       // 25: aiserver.v1.LinearTrigger
-	(*LinearIssueCreatedEvent)(nil),             // 26: aiserver.v1.LinearIssueCreatedEvent
-	(*LinearStatusChangedEvent)(nil),            // 27: aiserver.v1.LinearStatusChangedEvent
-	(*LinearEndOfCycleEvent)(nil),               // 28: aiserver.v1.LinearEndOfCycleEvent
-	(*WebhookTrigger)(nil),                      // 29: aiserver.v1.WebhookTrigger
-	(*PagerDutyTrigger)(nil),                    // 30: aiserver.v1.PagerDutyTrigger
-	(*PagerDutyIncidentTriggeredEvent)(nil),     // 31: aiserver.v1.PagerDutyIncidentTriggeredEvent
-	(*PagerDutyIncidentAcknowledgedEvent)(nil),  // 32: aiserver.v1.PagerDutyIncidentAcknowledgedEvent
-	(*PagerDutyIncidentResolvedEvent)(nil),      // 33: aiserver.v1.PagerDutyIncidentResolvedEvent
-	(*PagerDutyIncidentEscalatedEvent)(nil),     // 34: aiserver.v1.PagerDutyIncidentEscalatedEvent
-	(*PagerDutyIncidentAnyEvent)(nil),           // 35: aiserver.v1.PagerDutyIncidentAnyEvent
-	(*SentryTrigger)(nil),                       // 36: aiserver.v1.SentryTrigger
-	(*SentryIssueCreatedEvent)(nil),             // 37: aiserver.v1.SentryIssueCreatedEvent
-	(*SentryIssueResolvedEvent)(nil),            // 38: aiserver.v1.SentryIssueResolvedEvent
-	(*SentryIssueAssignedEvent)(nil),            // 39: aiserver.v1.SentryIssueAssignedEvent
-	(*SentryIssueArchivedEvent)(nil),            // 40: aiserver.v1.SentryIssueArchivedEvent
-	(*SentryIssueUnresolvedEvent)(nil),          // 41: aiserver.v1.SentryIssueUnresolvedEvent
-	(*SentryIssueAnyEvent)(nil),                 // 42: aiserver.v1.SentryIssueAnyEvent
-	(*MicrosoftTeamsTrigger)(nil),               // 43: aiserver.v1.MicrosoftTeamsTrigger
-	(*MicrosoftTeamsChannelCreatedTrigger)(nil), // 44: aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
-	(*GitPrAction)(nil),                         // 45: aiserver.v1.GitPrAction
-	(*PrCommentAction)(nil),                     // 46: aiserver.v1.PrCommentAction
-	(*ManageCheckRunAction)(nil),                // 47: aiserver.v1.ManageCheckRunAction
-	(*RequestReviewersAction)(nil),              // 48: aiserver.v1.RequestReviewersAction
-	(*ApprovePrAction)(nil),                     // 49: aiserver.v1.ApprovePrAction
-	(*ReadSlackAction)(nil),                     // 50: aiserver.v1.ReadSlackAction
-	(*ResolveReviewThreadsAction)(nil),          // 51: aiserver.v1.ResolveReviewThreadsAction
-	(*SlackAction)(nil),                         // 52: aiserver.v1.SlackAction
-	(*MicrosoftTeamsAction)(nil),                // 53: aiserver.v1.MicrosoftTeamsAction
-	(*ReadMicrosoftTeamsAction)(nil),            // 54: aiserver.v1.ReadMicrosoftTeamsAction
-	(*CreateAutomationRequest)(nil),             // 55: aiserver.v1.CreateAutomationRequest
-	(*CreateAutomationResponse)(nil),            // 56: aiserver.v1.CreateAutomationResponse
-	(*GetAutomationRequest)(nil),                // 57: aiserver.v1.GetAutomationRequest
-	(*RestrictedAutomationSummary)(nil),         // 58: aiserver.v1.RestrictedAutomationSummary
-	(*GetAutomationResponse)(nil),               // 59: aiserver.v1.GetAutomationResponse
-	(*UpdateAutomationRequest)(nil),             // 60: aiserver.v1.UpdateAutomationRequest
-	(*UpdateAutomationResponse)(nil),            // 61: aiserver.v1.UpdateAutomationResponse
-	(*DeleteAutomationRequest)(nil),             // 62: aiserver.v1.DeleteAutomationRequest
-	(*DeleteAutomationResponse)(nil),            // 63: aiserver.v1.DeleteAutomationResponse
-	(*Automation)(nil),                          // 64: aiserver.v1.Automation
-	(*AutomationWithOwner)(nil),                 // 65: aiserver.v1.AutomationWithOwner
-	(*structpb.Struct)(nil),                     // 66: google.protobuf.Struct
+	(AutomationCreationSource)(0),               // 2: aiserver.v1.AutomationCreationSource
+	(AutomationManagedBy)(0),                    // 3: aiserver.v1.AutomationManagedBy
+	(PromptEffortLevel)(0),                      // 4: aiserver.v1.PromptEffortLevel
+	(PromptRunMode)(0),                          // 5: aiserver.v1.PromptRunMode
+	(GitPullRequestAction)(0),                   // 6: aiserver.v1.GitPullRequestAction
+	(GitCICompletionCondition)(0),               // 7: aiserver.v1.GitCICompletionCondition
+	(GitWorkflowRunConclusion)(0),               // 8: aiserver.v1.GitWorkflowRunConclusion
+	(McpAuthState)(0),                           // 9: aiserver.v1.McpAuthState
+	(*Trigger)(nil),                             // 10: aiserver.v1.Trigger
+	(*Action)(nil),                              // 11: aiserver.v1.Action
+	(*McpAction)(nil),                           // 12: aiserver.v1.McpAction
+	(*McpServerConfig)(nil),                     // 13: aiserver.v1.McpServerConfig
+	(*AgentPrivateWorkerLabel)(nil),             // 14: aiserver.v1.AgentPrivateWorkerLabel
+	(*AgentPrivateWorkerConfig)(nil),            // 15: aiserver.v1.AgentPrivateWorkerConfig
+	(*AgentOptions)(nil),                        // 16: aiserver.v1.AgentOptions
+	(*Workflow)(nil),                            // 17: aiserver.v1.Workflow
+	(*Prompt)(nil),                              // 18: aiserver.v1.Prompt
+	(*GitConfig)(nil),                           // 19: aiserver.v1.GitConfig
+	(*CronTrigger)(nil),                         // 20: aiserver.v1.CronTrigger
+	(*GitTrigger)(nil),                          // 21: aiserver.v1.GitTrigger
+	(*GitPullRequestEvent)(nil),                 // 22: aiserver.v1.GitPullRequestEvent
+	(*GitPushEvent)(nil),                        // 23: aiserver.v1.GitPushEvent
+	(*GitCICompletedEvent)(nil),                 // 24: aiserver.v1.GitCICompletedEvent
+	(*GitIssueLabeledEvent)(nil),                // 25: aiserver.v1.GitIssueLabeledEvent
+	(*GitIssueCommentEvent)(nil),                // 26: aiserver.v1.GitIssueCommentEvent
+	(*GitPullRequestReviewCommentEvent)(nil),    // 27: aiserver.v1.GitPullRequestReviewCommentEvent
+	(*GitPullRequestReviewEvent)(nil),           // 28: aiserver.v1.GitPullRequestReviewEvent
+	(*GitReviewThreadEvent)(nil),                // 29: aiserver.v1.GitReviewThreadEvent
+	(*GitWorkflowRunEvent)(nil),                 // 30: aiserver.v1.GitWorkflowRunEvent
+	(*GitLabelEvent)(nil),                       // 31: aiserver.v1.GitLabelEvent
+	(*SlackTrigger)(nil),                        // 32: aiserver.v1.SlackTrigger
+	(*SlackChannelCreatedTrigger)(nil),          // 33: aiserver.v1.SlackChannelCreatedTrigger
+	(*SlackReactionAddedTrigger)(nil),           // 34: aiserver.v1.SlackReactionAddedTrigger
+	(*LinearTrigger)(nil),                       // 35: aiserver.v1.LinearTrigger
+	(*LinearIssueCreatedEvent)(nil),             // 36: aiserver.v1.LinearIssueCreatedEvent
+	(*LinearStatusChangedEvent)(nil),            // 37: aiserver.v1.LinearStatusChangedEvent
+	(*LinearEndOfCycleEvent)(nil),               // 38: aiserver.v1.LinearEndOfCycleEvent
+	(*WebhookTrigger)(nil),                      // 39: aiserver.v1.WebhookTrigger
+	(*PagerDutyTrigger)(nil),                    // 40: aiserver.v1.PagerDutyTrigger
+	(*PagerDutyIncidentTriggeredEvent)(nil),     // 41: aiserver.v1.PagerDutyIncidentTriggeredEvent
+	(*PagerDutyIncidentAcknowledgedEvent)(nil),  // 42: aiserver.v1.PagerDutyIncidentAcknowledgedEvent
+	(*PagerDutyIncidentResolvedEvent)(nil),      // 43: aiserver.v1.PagerDutyIncidentResolvedEvent
+	(*PagerDutyIncidentEscalatedEvent)(nil),     // 44: aiserver.v1.PagerDutyIncidentEscalatedEvent
+	(*PagerDutyIncidentAnyEvent)(nil),           // 45: aiserver.v1.PagerDutyIncidentAnyEvent
+	(*SentryTrigger)(nil),                       // 46: aiserver.v1.SentryTrigger
+	(*SentryIssueCreatedEvent)(nil),             // 47: aiserver.v1.SentryIssueCreatedEvent
+	(*SentryIssueResolvedEvent)(nil),            // 48: aiserver.v1.SentryIssueResolvedEvent
+	(*SentryIssueAssignedEvent)(nil),            // 49: aiserver.v1.SentryIssueAssignedEvent
+	(*SentryIssueArchivedEvent)(nil),            // 50: aiserver.v1.SentryIssueArchivedEvent
+	(*SentryIssueUnresolvedEvent)(nil),          // 51: aiserver.v1.SentryIssueUnresolvedEvent
+	(*SentryIssueAnyEvent)(nil),                 // 52: aiserver.v1.SentryIssueAnyEvent
+	(*MicrosoftTeamsTrigger)(nil),               // 53: aiserver.v1.MicrosoftTeamsTrigger
+	(*MicrosoftTeamsChannelCreatedTrigger)(nil), // 54: aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
+	(*GitPrAction)(nil),                         // 55: aiserver.v1.GitPrAction
+	(*PrCommentAction)(nil),                     // 56: aiserver.v1.PrCommentAction
+	(*ManageCheckRunAction)(nil),                // 57: aiserver.v1.ManageCheckRunAction
+	(*RequestReviewersAction)(nil),              // 58: aiserver.v1.RequestReviewersAction
+	(*ApprovePrAction)(nil),                     // 59: aiserver.v1.ApprovePrAction
+	(*ReadSlackAction)(nil),                     // 60: aiserver.v1.ReadSlackAction
+	(*ResolveReviewThreadsAction)(nil),          // 61: aiserver.v1.ResolveReviewThreadsAction
+	(*SlackAction)(nil),                         // 62: aiserver.v1.SlackAction
+	(*MicrosoftTeamsAction)(nil),                // 63: aiserver.v1.MicrosoftTeamsAction
+	(*ReadMicrosoftTeamsAction)(nil),            // 64: aiserver.v1.ReadMicrosoftTeamsAction
+	(*CreateAutomationRequest)(nil),             // 65: aiserver.v1.CreateAutomationRequest
+	(*CreateAutomationResponse)(nil),            // 66: aiserver.v1.CreateAutomationResponse
+	(*GetAutomationRequest)(nil),                // 67: aiserver.v1.GetAutomationRequest
+	(*RestrictedAutomationSummary)(nil),         // 68: aiserver.v1.RestrictedAutomationSummary
+	(*GetAutomationResponse)(nil),               // 69: aiserver.v1.GetAutomationResponse
+	(*UpdateAutomationRequest)(nil),             // 70: aiserver.v1.UpdateAutomationRequest
+	(*UpdateAutomationResponse)(nil),            // 71: aiserver.v1.UpdateAutomationResponse
+	(*DeleteAutomationRequest)(nil),             // 72: aiserver.v1.DeleteAutomationRequest
+	(*DeleteAutomationResponse)(nil),            // 73: aiserver.v1.DeleteAutomationResponse
+	(*Automation)(nil),                          // 74: aiserver.v1.Automation
+	(*AutomationMcpAuthState)(nil),              // 75: aiserver.v1.AutomationMcpAuthState
+	(*AutomationWithOwner)(nil),                 // 76: aiserver.v1.AutomationWithOwner
+	(*structpb.Struct)(nil),                     // 77: google.protobuf.Struct
 }
 var file_aiserver_v1_automations_proto_depIdxs = []int32{
-	16, // 0: aiserver.v1.Trigger.cron:type_name -> aiserver.v1.CronTrigger
-	17, // 1: aiserver.v1.Trigger.git:type_name -> aiserver.v1.GitTrigger
-	23, // 2: aiserver.v1.Trigger.slack_trigger:type_name -> aiserver.v1.SlackTrigger
-	25, // 3: aiserver.v1.Trigger.linear:type_name -> aiserver.v1.LinearTrigger
-	29, // 4: aiserver.v1.Trigger.webhook:type_name -> aiserver.v1.WebhookTrigger
-	24, // 5: aiserver.v1.Trigger.slack_channel_created:type_name -> aiserver.v1.SlackChannelCreatedTrigger
-	30, // 6: aiserver.v1.Trigger.pagerduty:type_name -> aiserver.v1.PagerDutyTrigger
-	36, // 7: aiserver.v1.Trigger.sentry:type_name -> aiserver.v1.SentryTrigger
-	43, // 8: aiserver.v1.Trigger.microsoft_teams_trigger:type_name -> aiserver.v1.MicrosoftTeamsTrigger
-	44, // 9: aiserver.v1.Trigger.microsoft_teams_channel_created:type_name -> aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
-	45, // 10: aiserver.v1.Action.git_pr:type_name -> aiserver.v1.GitPrAction
-	46, // 11: aiserver.v1.Action.pr_comment:type_name -> aiserver.v1.PrCommentAction
-	52, // 12: aiserver.v1.Action.slack:type_name -> aiserver.v1.SlackAction
-	8,  // 13: aiserver.v1.Action.mcp:type_name -> aiserver.v1.McpAction
-	47, // 14: aiserver.v1.Action.manage_check_run:type_name -> aiserver.v1.ManageCheckRunAction
-	48, // 15: aiserver.v1.Action.request_reviewers:type_name -> aiserver.v1.RequestReviewersAction
-	50, // 16: aiserver.v1.Action.read_slack:type_name -> aiserver.v1.ReadSlackAction
-	49, // 17: aiserver.v1.Action.approve_pr:type_name -> aiserver.v1.ApprovePrAction
-	51, // 18: aiserver.v1.Action.resolve_review_threads:type_name -> aiserver.v1.ResolveReviewThreadsAction
-	53, // 19: aiserver.v1.Action.microsoft_teams:type_name -> aiserver.v1.MicrosoftTeamsAction
-	54, // 20: aiserver.v1.Action.read_microsoft_teams:type_name -> aiserver.v1.ReadMicrosoftTeamsAction
-	9,  // 21: aiserver.v1.McpAction.server:type_name -> aiserver.v1.McpServerConfig
-	10, // 22: aiserver.v1.AgentPrivateWorkerConfig.labels:type_name -> aiserver.v1.AgentPrivateWorkerLabel
-	11, // 23: aiserver.v1.AgentOptions.private_worker:type_name -> aiserver.v1.AgentPrivateWorkerConfig
-	6,  // 24: aiserver.v1.Workflow.triggers:type_name -> aiserver.v1.Trigger
-	7,  // 25: aiserver.v1.Workflow.actions:type_name -> aiserver.v1.Action
-	14, // 26: aiserver.v1.Workflow.prompts:type_name -> aiserver.v1.Prompt
-	15, // 27: aiserver.v1.Workflow.git_config:type_name -> aiserver.v1.GitConfig
-	12, // 28: aiserver.v1.Workflow.agent_options:type_name -> aiserver.v1.AgentOptions
-	0,  // 29: aiserver.v1.Workflow.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
-	66, // 30: aiserver.v1.Workflow.managed_config:type_name -> google.protobuf.Struct
-	3,  // 31: aiserver.v1.Prompt.effort_level:type_name -> aiserver.v1.PromptEffortLevel
-	18, // 32: aiserver.v1.GitTrigger.pull_request:type_name -> aiserver.v1.GitPullRequestEvent
-	19, // 33: aiserver.v1.GitTrigger.push:type_name -> aiserver.v1.GitPushEvent
-	20, // 34: aiserver.v1.GitTrigger.ci_completed:type_name -> aiserver.v1.GitCICompletedEvent
-	21, // 35: aiserver.v1.GitTrigger.issue_labeled:type_name -> aiserver.v1.GitIssueLabeledEvent
-	22, // 36: aiserver.v1.GitTrigger.label:type_name -> aiserver.v1.GitLabelEvent
-	4,  // 37: aiserver.v1.GitPullRequestEvent.pr_action:type_name -> aiserver.v1.GitPullRequestAction
-	5,  // 38: aiserver.v1.GitCICompletedEvent.condition:type_name -> aiserver.v1.GitCICompletionCondition
-	0,  // 39: aiserver.v1.SlackTrigger.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
-	26, // 40: aiserver.v1.LinearTrigger.issue_created:type_name -> aiserver.v1.LinearIssueCreatedEvent
-	27, // 41: aiserver.v1.LinearTrigger.status_changed:type_name -> aiserver.v1.LinearStatusChangedEvent
-	28, // 42: aiserver.v1.LinearTrigger.end_of_cycle:type_name -> aiserver.v1.LinearEndOfCycleEvent
-	31, // 43: aiserver.v1.PagerDutyTrigger.incident_triggered:type_name -> aiserver.v1.PagerDutyIncidentTriggeredEvent
-	32, // 44: aiserver.v1.PagerDutyTrigger.incident_acknowledged:type_name -> aiserver.v1.PagerDutyIncidentAcknowledgedEvent
-	33, // 45: aiserver.v1.PagerDutyTrigger.incident_resolved:type_name -> aiserver.v1.PagerDutyIncidentResolvedEvent
-	34, // 46: aiserver.v1.PagerDutyTrigger.incident_escalated:type_name -> aiserver.v1.PagerDutyIncidentEscalatedEvent
-	35, // 47: aiserver.v1.PagerDutyTrigger.incident_any:type_name -> aiserver.v1.PagerDutyIncidentAnyEvent
-	37, // 48: aiserver.v1.SentryTrigger.issue_created:type_name -> aiserver.v1.SentryIssueCreatedEvent
-	38, // 49: aiserver.v1.SentryTrigger.issue_resolved:type_name -> aiserver.v1.SentryIssueResolvedEvent
-	39, // 50: aiserver.v1.SentryTrigger.issue_assigned:type_name -> aiserver.v1.SentryIssueAssignedEvent
-	40, // 51: aiserver.v1.SentryTrigger.issue_archived:type_name -> aiserver.v1.SentryIssueArchivedEvent
-	41, // 52: aiserver.v1.SentryTrigger.issue_unresolved:type_name -> aiserver.v1.SentryIssueUnresolvedEvent
-	42, // 53: aiserver.v1.SentryTrigger.issue_any:type_name -> aiserver.v1.SentryIssueAnyEvent
-	13, // 54: aiserver.v1.CreateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
-	1,  // 55: aiserver.v1.CreateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
-	65, // 56: aiserver.v1.CreateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	65, // 57: aiserver.v1.GetAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	58, // 58: aiserver.v1.GetAutomationResponse.restricted_summary:type_name -> aiserver.v1.RestrictedAutomationSummary
-	13, // 59: aiserver.v1.UpdateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
-	1,  // 60: aiserver.v1.UpdateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
-	65, // 61: aiserver.v1.UpdateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	13, // 62: aiserver.v1.Automation.workflow:type_name -> aiserver.v1.Workflow
-	1,  // 63: aiserver.v1.Automation.scope:type_name -> aiserver.v1.AutomationScope
-	2,  // 64: aiserver.v1.Automation.managed_by:type_name -> aiserver.v1.AutomationManagedBy
-	64, // 65: aiserver.v1.AutomationWithOwner.workflow:type_name -> aiserver.v1.Automation
-	55, // 66: aiserver.v1.AutomationsService.CreateAutomation:input_type -> aiserver.v1.CreateAutomationRequest
-	57, // 67: aiserver.v1.AutomationsService.GetAutomation:input_type -> aiserver.v1.GetAutomationRequest
-	60, // 68: aiserver.v1.AutomationsService.UpdateAutomation:input_type -> aiserver.v1.UpdateAutomationRequest
-	62, // 69: aiserver.v1.AutomationsService.DeleteAutomation:input_type -> aiserver.v1.DeleteAutomationRequest
-	56, // 70: aiserver.v1.AutomationsService.CreateAutomation:output_type -> aiserver.v1.CreateAutomationResponse
-	59, // 71: aiserver.v1.AutomationsService.GetAutomation:output_type -> aiserver.v1.GetAutomationResponse
-	61, // 72: aiserver.v1.AutomationsService.UpdateAutomation:output_type -> aiserver.v1.UpdateAutomationResponse
-	63, // 73: aiserver.v1.AutomationsService.DeleteAutomation:output_type -> aiserver.v1.DeleteAutomationResponse
-	70, // [70:74] is the sub-list for method output_type
-	66, // [66:70] is the sub-list for method input_type
-	66, // [66:66] is the sub-list for extension type_name
-	66, // [66:66] is the sub-list for extension extendee
-	0,  // [0:66] is the sub-list for field type_name
+	20, // 0: aiserver.v1.Trigger.cron:type_name -> aiserver.v1.CronTrigger
+	21, // 1: aiserver.v1.Trigger.git:type_name -> aiserver.v1.GitTrigger
+	32, // 2: aiserver.v1.Trigger.slack_trigger:type_name -> aiserver.v1.SlackTrigger
+	35, // 3: aiserver.v1.Trigger.linear:type_name -> aiserver.v1.LinearTrigger
+	39, // 4: aiserver.v1.Trigger.webhook:type_name -> aiserver.v1.WebhookTrigger
+	33, // 5: aiserver.v1.Trigger.slack_channel_created:type_name -> aiserver.v1.SlackChannelCreatedTrigger
+	40, // 6: aiserver.v1.Trigger.pagerduty:type_name -> aiserver.v1.PagerDutyTrigger
+	46, // 7: aiserver.v1.Trigger.sentry:type_name -> aiserver.v1.SentryTrigger
+	53, // 8: aiserver.v1.Trigger.microsoft_teams_trigger:type_name -> aiserver.v1.MicrosoftTeamsTrigger
+	54, // 9: aiserver.v1.Trigger.microsoft_teams_channel_created:type_name -> aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
+	34, // 10: aiserver.v1.Trigger.slack_reaction_added:type_name -> aiserver.v1.SlackReactionAddedTrigger
+	55, // 11: aiserver.v1.Action.git_pr:type_name -> aiserver.v1.GitPrAction
+	56, // 12: aiserver.v1.Action.pr_comment:type_name -> aiserver.v1.PrCommentAction
+	62, // 13: aiserver.v1.Action.slack:type_name -> aiserver.v1.SlackAction
+	12, // 14: aiserver.v1.Action.mcp:type_name -> aiserver.v1.McpAction
+	57, // 15: aiserver.v1.Action.manage_check_run:type_name -> aiserver.v1.ManageCheckRunAction
+	58, // 16: aiserver.v1.Action.request_reviewers:type_name -> aiserver.v1.RequestReviewersAction
+	60, // 17: aiserver.v1.Action.read_slack:type_name -> aiserver.v1.ReadSlackAction
+	59, // 18: aiserver.v1.Action.approve_pr:type_name -> aiserver.v1.ApprovePrAction
+	61, // 19: aiserver.v1.Action.resolve_review_threads:type_name -> aiserver.v1.ResolveReviewThreadsAction
+	63, // 20: aiserver.v1.Action.microsoft_teams:type_name -> aiserver.v1.MicrosoftTeamsAction
+	64, // 21: aiserver.v1.Action.read_microsoft_teams:type_name -> aiserver.v1.ReadMicrosoftTeamsAction
+	13, // 22: aiserver.v1.McpAction.server:type_name -> aiserver.v1.McpServerConfig
+	14, // 23: aiserver.v1.AgentPrivateWorkerConfig.labels:type_name -> aiserver.v1.AgentPrivateWorkerLabel
+	15, // 24: aiserver.v1.AgentOptions.private_worker:type_name -> aiserver.v1.AgentPrivateWorkerConfig
+	10, // 25: aiserver.v1.Workflow.triggers:type_name -> aiserver.v1.Trigger
+	11, // 26: aiserver.v1.Workflow.actions:type_name -> aiserver.v1.Action
+	18, // 27: aiserver.v1.Workflow.prompts:type_name -> aiserver.v1.Prompt
+	19, // 28: aiserver.v1.Workflow.git_config:type_name -> aiserver.v1.GitConfig
+	16, // 29: aiserver.v1.Workflow.agent_options:type_name -> aiserver.v1.AgentOptions
+	0,  // 30: aiserver.v1.Workflow.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
+	77, // 31: aiserver.v1.Workflow.managed_config:type_name -> google.protobuf.Struct
+	4,  // 32: aiserver.v1.Prompt.effort_level:type_name -> aiserver.v1.PromptEffortLevel
+	5,  // 33: aiserver.v1.Prompt.run_mode:type_name -> aiserver.v1.PromptRunMode
+	22, // 34: aiserver.v1.GitTrigger.pull_request:type_name -> aiserver.v1.GitPullRequestEvent
+	23, // 35: aiserver.v1.GitTrigger.push:type_name -> aiserver.v1.GitPushEvent
+	24, // 36: aiserver.v1.GitTrigger.ci_completed:type_name -> aiserver.v1.GitCICompletedEvent
+	25, // 37: aiserver.v1.GitTrigger.issue_labeled:type_name -> aiserver.v1.GitIssueLabeledEvent
+	31, // 38: aiserver.v1.GitTrigger.label:type_name -> aiserver.v1.GitLabelEvent
+	26, // 39: aiserver.v1.GitTrigger.issue_comment:type_name -> aiserver.v1.GitIssueCommentEvent
+	27, // 40: aiserver.v1.GitTrigger.pull_request_review_comment:type_name -> aiserver.v1.GitPullRequestReviewCommentEvent
+	28, // 41: aiserver.v1.GitTrigger.pull_request_review:type_name -> aiserver.v1.GitPullRequestReviewEvent
+	29, // 42: aiserver.v1.GitTrigger.review_thread:type_name -> aiserver.v1.GitReviewThreadEvent
+	30, // 43: aiserver.v1.GitTrigger.workflow_run:type_name -> aiserver.v1.GitWorkflowRunEvent
+	6,  // 44: aiserver.v1.GitPullRequestEvent.pr_action:type_name -> aiserver.v1.GitPullRequestAction
+	7,  // 45: aiserver.v1.GitCICompletedEvent.condition:type_name -> aiserver.v1.GitCICompletionCondition
+	8,  // 46: aiserver.v1.GitWorkflowRunEvent.conclusion:type_name -> aiserver.v1.GitWorkflowRunConclusion
+	0,  // 47: aiserver.v1.SlackTrigger.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
+	36, // 48: aiserver.v1.LinearTrigger.issue_created:type_name -> aiserver.v1.LinearIssueCreatedEvent
+	37, // 49: aiserver.v1.LinearTrigger.status_changed:type_name -> aiserver.v1.LinearStatusChangedEvent
+	38, // 50: aiserver.v1.LinearTrigger.end_of_cycle:type_name -> aiserver.v1.LinearEndOfCycleEvent
+	41, // 51: aiserver.v1.PagerDutyTrigger.incident_triggered:type_name -> aiserver.v1.PagerDutyIncidentTriggeredEvent
+	42, // 52: aiserver.v1.PagerDutyTrigger.incident_acknowledged:type_name -> aiserver.v1.PagerDutyIncidentAcknowledgedEvent
+	43, // 53: aiserver.v1.PagerDutyTrigger.incident_resolved:type_name -> aiserver.v1.PagerDutyIncidentResolvedEvent
+	44, // 54: aiserver.v1.PagerDutyTrigger.incident_escalated:type_name -> aiserver.v1.PagerDutyIncidentEscalatedEvent
+	45, // 55: aiserver.v1.PagerDutyTrigger.incident_any:type_name -> aiserver.v1.PagerDutyIncidentAnyEvent
+	47, // 56: aiserver.v1.SentryTrigger.issue_created:type_name -> aiserver.v1.SentryIssueCreatedEvent
+	48, // 57: aiserver.v1.SentryTrigger.issue_resolved:type_name -> aiserver.v1.SentryIssueResolvedEvent
+	49, // 58: aiserver.v1.SentryTrigger.issue_assigned:type_name -> aiserver.v1.SentryIssueAssignedEvent
+	50, // 59: aiserver.v1.SentryTrigger.issue_archived:type_name -> aiserver.v1.SentryIssueArchivedEvent
+	51, // 60: aiserver.v1.SentryTrigger.issue_unresolved:type_name -> aiserver.v1.SentryIssueUnresolvedEvent
+	52, // 61: aiserver.v1.SentryTrigger.issue_any:type_name -> aiserver.v1.SentryIssueAnyEvent
+	17, // 62: aiserver.v1.CreateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
+	1,  // 63: aiserver.v1.CreateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
+	2,  // 64: aiserver.v1.CreateAutomationRequest.creation_source:type_name -> aiserver.v1.AutomationCreationSource
+	76, // 65: aiserver.v1.CreateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	76, // 66: aiserver.v1.GetAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	68, // 67: aiserver.v1.GetAutomationResponse.restricted_summary:type_name -> aiserver.v1.RestrictedAutomationSummary
+	17, // 68: aiserver.v1.UpdateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
+	1,  // 69: aiserver.v1.UpdateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
+	76, // 70: aiserver.v1.UpdateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	17, // 71: aiserver.v1.Automation.workflow:type_name -> aiserver.v1.Workflow
+	1,  // 72: aiserver.v1.Automation.scope:type_name -> aiserver.v1.AutomationScope
+	3,  // 73: aiserver.v1.Automation.managed_by:type_name -> aiserver.v1.AutomationManagedBy
+	9,  // 74: aiserver.v1.AutomationMcpAuthState.auth_state:type_name -> aiserver.v1.McpAuthState
+	74, // 75: aiserver.v1.AutomationWithOwner.workflow:type_name -> aiserver.v1.Automation
+	75, // 76: aiserver.v1.AutomationWithOwner.mcp_auth_states:type_name -> aiserver.v1.AutomationMcpAuthState
+	65, // 77: aiserver.v1.AutomationsService.CreateAutomation:input_type -> aiserver.v1.CreateAutomationRequest
+	67, // 78: aiserver.v1.AutomationsService.GetAutomation:input_type -> aiserver.v1.GetAutomationRequest
+	70, // 79: aiserver.v1.AutomationsService.UpdateAutomation:input_type -> aiserver.v1.UpdateAutomationRequest
+	72, // 80: aiserver.v1.AutomationsService.DeleteAutomation:input_type -> aiserver.v1.DeleteAutomationRequest
+	66, // 81: aiserver.v1.AutomationsService.CreateAutomation:output_type -> aiserver.v1.CreateAutomationResponse
+	69, // 82: aiserver.v1.AutomationsService.GetAutomation:output_type -> aiserver.v1.GetAutomationResponse
+	71, // 83: aiserver.v1.AutomationsService.UpdateAutomation:output_type -> aiserver.v1.UpdateAutomationResponse
+	73, // 84: aiserver.v1.AutomationsService.DeleteAutomation:output_type -> aiserver.v1.DeleteAutomationResponse
+	81, // [81:85] is the sub-list for method output_type
+	77, // [77:81] is the sub-list for method input_type
+	77, // [77:77] is the sub-list for extension type_name
+	77, // [77:77] is the sub-list for extension extendee
+	0,  // [0:77] is the sub-list for field type_name
 }
 
 func init() { file_aiserver_v1_automations_proto_init() }
@@ -5112,6 +6155,7 @@ func file_aiserver_v1_automations_proto_init() {
 		(*Trigger_Sentry)(nil),
 		(*Trigger_MicrosoftTeamsTrigger)(nil),
 		(*Trigger_MicrosoftTeamsChannelCreated)(nil),
+		(*Trigger_SlackReactionAdded)(nil),
 	}
 	file_aiserver_v1_automations_proto_msgTypes[1].OneofWrappers = []any{
 		(*Action_GitPr)(nil),
@@ -5126,29 +6170,36 @@ func file_aiserver_v1_automations_proto_init() {
 		(*Action_MicrosoftTeams)(nil),
 		(*Action_ReadMicrosoftTeams)(nil),
 	}
+	file_aiserver_v1_automations_proto_msgTypes[3].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[6].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[7].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[8].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[11].OneofWrappers = []any{
 		(*GitTrigger_PullRequest)(nil),
 		(*GitTrigger_Push)(nil),
 		(*GitTrigger_CiCompleted)(nil),
 		(*GitTrigger_IssueLabeled)(nil),
 		(*GitTrigger_Label)(nil),
+		(*GitTrigger_IssueComment)(nil),
+		(*GitTrigger_PullRequestReviewComment)(nil),
+		(*GitTrigger_PullRequestReview)(nil),
+		(*GitTrigger_ReviewThread)(nil),
+		(*GitTrigger_WorkflowRun)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[17].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[19].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[22].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[25].OneofWrappers = []any{
 		(*LinearTrigger_IssueCreated)(nil),
 		(*LinearTrigger_StatusChanged)(nil),
 		(*LinearTrigger_EndOfCycle)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[24].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[30].OneofWrappers = []any{
 		(*PagerDutyTrigger_IncidentTriggered)(nil),
 		(*PagerDutyTrigger_IncidentAcknowledged)(nil),
 		(*PagerDutyTrigger_IncidentResolved)(nil),
 		(*PagerDutyTrigger_IncidentEscalated)(nil),
 		(*PagerDutyTrigger_IncidentAny)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[30].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[36].OneofWrappers = []any{
 		(*SentryTrigger_IssueCreated)(nil),
 		(*SentryTrigger_IssueResolved)(nil),
 		(*SentryTrigger_IssueAssigned)(nil),
@@ -5156,20 +6207,22 @@ func file_aiserver_v1_automations_proto_init() {
 		(*SentryTrigger_IssueUnresolved)(nil),
 		(*SentryTrigger_IssueAny)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[49].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[53].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[55].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[59].OneofWrappers = []any{
 		(*GetAutomationResponse_Workflow)(nil),
 		(*GetAutomationResponse_RestrictedSummary)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[54].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[58].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[60].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[64].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[65].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[66].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_aiserver_v1_automations_proto_rawDesc), len(file_aiserver_v1_automations_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   60,
+			NumEnums:      10,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
Refreshes the vendored generated protobuf/Connect code from the current automations API schema. No hand-written code changes.

- Same service surface as before (Create/Get/Update/Delete automation RPCs only)
- Picks up new schema fields and messages added since the original vendoring, including `GitPullRequestEvent.comment_contains_is_regex`, the CI-completed trigger event types, and `McpServerConfig.id`
- Newer protoc-gen-go, hence the large mechanical diff

Verified: `go build ./...` and `go test ./...` pass. Unblocks #6, which currently works around the missing fields.

Made with [Cursor](https://cursor.com)