### PR TITLE
Fix slack completion_reaction_mode round-trip on unset configs

### DIFF
--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -461,7 +461,11 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 									Description: "If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).",
 								},
 								"completion_reaction_mode": schema.StringAttribute{
-									Optional:    true,
+									Optional: true,
+									// Computed: the API reports the default ("on") even when
+									// unset; without Computed, applies fail with an
+									// inconsistent-result error and unset configs drift.
+									Computed:    true,
 									Description: `Controls the emoji reaction added to the triggering Slack message when the automation completes successfully: "on" (default Cursor reaction), "off" (no reaction), or "custom" (use completion_reaction_custom_emoji). Leave unset to use the Cursor default.`,
 								},
 								"completion_reaction_custom_emoji": schema.StringAttribute{

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -1847,6 +1847,50 @@ func TestModelIsOptionalComputed(t *testing.T) {
 	}
 }
 
+// TestSlackCompletionReactionModeIsOptionalComputed guards against the
+// round-trip bug where the API reports the default mode ("on") for configs
+// that leave completion_reaction_mode unset: without Computed, applies fail
+// with "Provider produced inconsistent result after apply" and the field
+// drifts on every subsequent plan.
+func TestSlackCompletionReactionModeIsOptionalComputed(t *testing.T) {
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+
+	trigger, ok := schemaResp.Schema.Attributes["trigger"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatal("schema is missing trigger list attribute")
+	}
+	slack, ok := trigger.NestedObject.Attributes["slack"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("trigger schema is missing slack attribute")
+	}
+	mode, ok := slack.Attributes["completion_reaction_mode"].(schema.StringAttribute)
+	if !ok {
+		t.Fatal("slack trigger schema is missing completion_reaction_mode")
+	}
+
+	if !mode.Optional {
+		t.Error("completion_reaction_mode should be Optional")
+	}
+	if !mode.Computed {
+		t.Error("completion_reaction_mode should be Computed (the server reports the default \"on\" when unset)")
+	}
+}
+
+// TestSlackCompletionReactionUnknownModeSkipped verifies that an unknown
+// (computed, not yet decided) mode does not get sent to the API and does not
+// fail validation.
+func TestSlackCompletionReactionUnknownModeSkipped(t *testing.T) {
+	st := &v1.SlackTrigger{}
+	if err := applySlackCompletionReaction(st, types.StringUnknown(), types.StringNull()); err != nil {
+		t.Fatalf("unknown mode should be skipped, got error: %v", err)
+	}
+	if st.SlackCompletionReactionMode != nil {
+		t.Error("unknown mode should not set SlackCompletionReactionMode on the proto")
+	}
+}
+
 // TestModelUnsetAcceptsServerDefault verifies that when the practitioner
 // leaves model unset, the provider sends no model to the server, and the
 // server-assigned default in the response is written to state.


### PR DESCRIPTION
When a config leaves `trigger[*].slack.completion_reaction_mode` unset, the API reports the default mode ("on") back. The provider wrote that into state unconditionally while the plan promised null, so applies failed with:

```
Error: Provider produced inconsistent result after apply
.trigger[0].slack.completion_reaction_mode: was null, but now cty.StringVal("on")
```

and the field showed `"on" -> null` drift on every subsequent plan.

Fix: mark the attribute `Computed` (the same treatment `model` and `mcp.server_id` already have), making a server-reported default legitimate state. `applySlackCompletionReaction` already skips unknown planned values, so nothing is sent to the API when the config is unset. Explicit `on`/`off`/`custom` configs behave as before.

Tests: schema guard for Optional+Computed, and a regression test that unknown modes are skipped on the wire. Full suite passes; docs unchanged (`make docs` produced no diff).

Resolves TER-3

Made with [Cursor](https://cursor.com)