### PR TITLE
Add environment_public_id to cursor_platform_workflow

### DIFF
--- a/docs/data-sources/platform_workflow.md
+++ b/docs/data-sources/platform_workflow.md
@@ -31,6 +31,7 @@ data "cursor_platform_workflow" "existing" {
 - `created_at` (Number) Unix timestamp (seconds) when the automation was created.
 - `effort_level` (String) Effort level: standard or hard.
 - `enabled` (Boolean) Whether the automation is enabled.
+- `environment_public_id` (String) Public ID of the Cloud Agent environment this automation runs in.
 - `git_branch` (String) Git branch for non-git triggers.
 - `git_repo` (String) Git repository for non-git triggers.
 - `memory_enabled` (Boolean) Whether the AutomationMemory tool is enabled for persistent memory across runs.

--- a/docs/resources/platform_workflow.md
+++ b/docs/resources/platform_workflow.md
@@ -61,6 +61,7 @@ resource "cursor_platform_workflow" "example_review" {
 - `action` (Attributes List) Actions the automation can perform. Each action block specifies one action type. (see [below for nested schema](#nestedatt--action))
 - `effort_level` (String) Effort level for the prompt: "standard" or "hard". Defaults to standard if unset.
 - `enabled` (Boolean) Whether the automation is enabled.
+- `environment_public_id` (String) Public ID of the Cloud Agent environment this automation should run in.
 - `git_branch` (String) Git branch for non-git triggers. Defaults to main.
 - `git_repo` (String) Git repository for non-git triggers (cron, slack, linear). E.g. github.com/org/repo.
 - `memory_enabled` (Boolean) Enable the AutomationMemory tool, giving the agent persistent memory across runs.

--- a/internal/provider/data_source_platform_workflow.go
+++ b/internal/provider/data_source_platform_workflow.go
@@ -67,6 +67,10 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 				Computed:    true,
 				Description: "Whether to skip install commands.",
 			},
+			"environment_public_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Public ID of the Cloud Agent environment this automation runs in.",
+			},
 			"memory_enabled": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Whether the AutomationMemory tool is enabled for persistent memory across runs.",

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -116,21 +116,22 @@ func parseCustomErrorDetailsTitleDetail(b []byte) (string, string) {
 // ---------------------------------------------------------------------------
 
 type platformWorkflowModel struct {
-	ID            types.String   `tfsdk:"id"`
-	Name          types.String   `tfsdk:"name"`
-	Scope         types.String   `tfsdk:"scope"`
-	Enabled       types.Bool     `tfsdk:"enabled"`
-	Prompt        types.String   `tfsdk:"prompt"`
-	EffortLevel   types.String   `tfsdk:"effort_level"`
-	Model         types.String   `tfsdk:"model"`
-	GitRepo       types.String   `tfsdk:"git_repo"`
-	GitBranch     types.String   `tfsdk:"git_branch"`
-	SkipInstall   types.Bool     `tfsdk:"skip_install"`
-	MemoryEnabled types.Bool     `tfsdk:"memory_enabled"`
-	Triggers      []triggerModel `tfsdk:"trigger"`
-	Actions       []actionModel  `tfsdk:"action"`
-	CreatedAt     types.Int64    `tfsdk:"created_at"`
-	UpdatedAt     types.Int64    `tfsdk:"updated_at"`
+	ID                  types.String   `tfsdk:"id"`
+	Name                types.String   `tfsdk:"name"`
+	Scope               types.String   `tfsdk:"scope"`
+	Enabled             types.Bool     `tfsdk:"enabled"`
+	Prompt              types.String   `tfsdk:"prompt"`
+	EffortLevel         types.String   `tfsdk:"effort_level"`
+	Model               types.String   `tfsdk:"model"`
+	GitRepo             types.String   `tfsdk:"git_repo"`
+	GitBranch           types.String   `tfsdk:"git_branch"`
+	SkipInstall         types.Bool     `tfsdk:"skip_install"`
+	EnvironmentPublicID types.String   `tfsdk:"environment_public_id"`
+	MemoryEnabled       types.Bool     `tfsdk:"memory_enabled"`
+	Triggers            []triggerModel `tfsdk:"trigger"`
+	Actions             []actionModel  `tfsdk:"action"`
+	CreatedAt           types.Int64    `tfsdk:"created_at"`
+	UpdatedAt           types.Int64    `tfsdk:"updated_at"`
 }
 
 type triggerModel struct {
@@ -348,6 +349,10 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 			"skip_install": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Skip user install commands and cloud testing.",
+			},
+			"environment_public_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "Public ID of the Cloud Agent environment this automation should run in.",
 			},
 			"memory_enabled": schema.BoolAttribute{
 				Optional:    true,
@@ -776,6 +781,7 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 	}
 	preserveEquivalentGitPullRequestOrgs(ctx, &state, plan)
 	preserveEquivalentGitCICompletionConditions(&state, plan)
+	preserveEquivalentEnvironmentPublicID(&state, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -794,6 +800,7 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 		}
 		preserveEquivalentGitPullRequestOrgs(ctx, &updated, plan)
 		preserveEquivalentGitCICompletionConditions(&updated, plan)
+		preserveEquivalentEnvironmentPublicID(&updated, plan)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &updated)...)
 	}
 }
@@ -835,6 +842,7 @@ func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 	}
 	preserveEquivalentGitPullRequestOrgs(ctx, &updatedState, state)
 	preserveEquivalentGitCICompletionConditions(&updatedState, state)
+	preserveEquivalentEnvironmentPublicID(&updatedState, state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
@@ -904,6 +912,7 @@ func (r *platformWorkflowResource) Update(ctx context.Context, req resource.Upda
 	}
 	preserveEquivalentGitPullRequestOrgs(ctx, &updatedState, plan)
 	preserveEquivalentGitCICompletionConditions(&updatedState, plan)
+	preserveEquivalentEnvironmentPublicID(&updatedState, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
@@ -1070,6 +1079,30 @@ func preserveEquivalentGitPullRequestOrgs(ctx context.Context, state *platformWo
 			statePr.Orgs = referencePr.Orgs
 		}
 	}
+}
+
+// Preserve practitioner-supplied environment_public_id formatting when the API
+// returns an equivalent trimmed value, avoiding perpetual state/config diffs.
+func preserveEquivalentEnvironmentPublicID(state *platformWorkflowModel, reference platformWorkflowModel) {
+	if state == nil {
+		return
+	}
+	if state.EnvironmentPublicID.IsNull() || state.EnvironmentPublicID.IsUnknown() {
+		return
+	}
+	if reference.EnvironmentPublicID.IsNull() || reference.EnvironmentPublicID.IsUnknown() {
+		return
+	}
+
+	referenceValue := reference.EnvironmentPublicID.ValueString()
+	if referenceValue == "" {
+		return
+	}
+	if strings.TrimSpace(referenceValue) != state.EnvironmentPublicID.ValueString() {
+		return
+	}
+
+	state.EnvironmentPublicID = reference.EnvironmentPublicID
 }
 
 func gitPullRequestOrgsEqualFold(ctx context.Context, current, reference types.List) bool {
@@ -1349,9 +1382,22 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 	}
 
 	// AgentOptions
+	var agentOptions *v1.AgentOptions
 	if !m.SkipInstall.IsNull() && !m.SkipInstall.IsUnknown() {
 		skip := m.SkipInstall.ValueBool()
-		w.AgentOptions = &v1.AgentOptions{SkipInstall: &skip}
+		agentOptions = &v1.AgentOptions{SkipInstall: &skip}
+	}
+	if !m.EnvironmentPublicID.IsNull() && !m.EnvironmentPublicID.IsUnknown() {
+		environmentPublicID := strings.TrimSpace(m.EnvironmentPublicID.ValueString())
+		if environmentPublicID != "" {
+			if agentOptions == nil {
+				agentOptions = &v1.AgentOptions{}
+			}
+			agentOptions.EnvironmentPublicId = &environmentPublicID
+		}
+	}
+	if agentOptions != nil {
+		w.AgentOptions = agentOptions
 	}
 
 	// MemoryEnabled
@@ -2063,10 +2109,20 @@ func protoToModel(ctx context.Context, withOwner *v1.AutomationWithOwner) (platf
 	}
 
 	// AgentOptions
-	if ao := wf.GetAgentOptions(); ao != nil && ao.SkipInstall != nil {
-		m.SkipInstall = types.BoolValue(ao.GetSkipInstall())
+	if ao := wf.GetAgentOptions(); ao != nil {
+		if ao.SkipInstall != nil {
+			m.SkipInstall = types.BoolValue(ao.GetSkipInstall())
+		} else {
+			m.SkipInstall = types.BoolNull()
+		}
+		if ao.EnvironmentPublicId != nil && ao.GetEnvironmentPublicId() != "" {
+			m.EnvironmentPublicID = types.StringValue(ao.GetEnvironmentPublicId())
+		} else {
+			m.EnvironmentPublicID = types.StringNull()
+		}
 	} else {
 		m.SkipInstall = types.BoolNull()
+		m.EnvironmentPublicID = types.StringNull()
 	}
 
 	// MemoryEnabled

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -1087,14 +1087,24 @@ func preserveEquivalentEnvironmentPublicID(state *platformWorkflowModel, referen
 	if state == nil {
 		return
 	}
-	if state.EnvironmentPublicID.IsNull() || state.EnvironmentPublicID.IsUnknown() {
-		return
-	}
 	if reference.EnvironmentPublicID.IsNull() || reference.EnvironmentPublicID.IsUnknown() {
 		return
 	}
-
 	referenceValue := reference.EnvironmentPublicID.ValueString()
+
+	// An empty/whitespace-only configured value is omitted from the API
+	// request and comes back as null; keep the configured value so the state
+	// matches the plan instead of drifting forever.
+	if state.EnvironmentPublicID.IsNull() {
+		if strings.TrimSpace(referenceValue) == "" {
+			state.EnvironmentPublicID = reference.EnvironmentPublicID
+		}
+		return
+	}
+	if state.EnvironmentPublicID.IsUnknown() {
+		return
+	}
+
 	if referenceValue == "" {
 		return
 	}

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -2178,3 +2178,97 @@ func TestGitConfigReposRoundTripStable(t *testing.T) {
 		t.Fatalf("GitConfig.Repo after round trip = %q, want %q", got, want)
 	}
 }
+
+// TestEnvironmentPublicIDRoundTrip verifies that agent_options.environment_public_id
+// round-trips through modelToWorkflow -> proto -> protoToModel, and that an unset
+// value stays null rather than becoming an empty string.
+func TestEnvironmentPublicIDRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("set_value_round_trips", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt:              types.StringValue("do the thing"),
+			EnvironmentPublicID: types.StringValue("env-abc123"),
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}},
+			},
+		}
+
+		workflow, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error = %v", err)
+		}
+		if got := workflow.GetAgentOptions().GetEnvironmentPublicId(); got != "env-abc123" {
+			t.Fatalf("AgentOptions.EnvironmentPublicId = %q, want %q", got, "env-abc123")
+		}
+
+		out, err := protoToModel(ctx, &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{Workflow: workflow},
+		})
+		if err != nil {
+			t.Fatalf("protoToModel() error = %v", err)
+		}
+		if out.EnvironmentPublicID.IsNull() || out.EnvironmentPublicID.ValueString() != "env-abc123" {
+			t.Fatalf("EnvironmentPublicID = %v, want %q", out.EnvironmentPublicID, "env-abc123")
+		}
+	})
+
+	t.Run("unset_value_stays_null", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("do the thing"),
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}},
+			},
+		}
+
+		workflow, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error = %v", err)
+		}
+		if workflow.GetAgentOptions() != nil {
+			t.Fatalf("AgentOptions = %v, want nil when no agent options are set", workflow.GetAgentOptions())
+		}
+
+		out, err := protoToModel(ctx, &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{Workflow: workflow},
+		})
+		if err != nil {
+			t.Fatalf("protoToModel() error = %v", err)
+		}
+		if !out.EnvironmentPublicID.IsNull() {
+			t.Fatalf("EnvironmentPublicID = %v, want null", out.EnvironmentPublicID)
+		}
+	})
+}
+
+func TestPreserveEquivalentEnvironmentPublicID(t *testing.T) {
+	t.Run("preserves_reference_formatting_for_equivalent_value", func(t *testing.T) {
+		state := &platformWorkflowModel{
+			EnvironmentPublicID: types.StringValue("env-abc123"),
+		}
+		reference := platformWorkflowModel{
+			EnvironmentPublicID: types.StringValue("  env-abc123  "),
+		}
+
+		preserveEquivalentEnvironmentPublicID(state, reference)
+
+		if got := state.EnvironmentPublicID.ValueString(); got != "  env-abc123  " {
+			t.Fatalf("EnvironmentPublicID = %q, want %q", got, "  env-abc123  ")
+		}
+	})
+
+	t.Run("leaves_state_unchanged_for_non_equivalent_value", func(t *testing.T) {
+		state := &platformWorkflowModel{
+			EnvironmentPublicID: types.StringValue("env-abc123"),
+		}
+		reference := platformWorkflowModel{
+			EnvironmentPublicID: types.StringValue("env-different"),
+		}
+
+		preserveEquivalentEnvironmentPublicID(state, reference)
+
+		if got := state.EnvironmentPublicID.ValueString(); got != "env-abc123" {
+			t.Fatalf("EnvironmentPublicID = %q, want %q", got, "env-abc123")
+		}
+	})
+}

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -2257,6 +2257,37 @@ func TestPreserveEquivalentEnvironmentPublicID(t *testing.T) {
 		}
 	})
 
+
+	t.Run("empty_configured_value_does_not_drift_to_null", func(t *testing.T) {
+		state := &platformWorkflowModel{
+			EnvironmentPublicID: types.StringNull(),
+		}
+		reference := platformWorkflowModel{
+			EnvironmentPublicID: types.StringValue("   "),
+		}
+
+		preserveEquivalentEnvironmentPublicID(state, reference)
+
+		if state.EnvironmentPublicID.IsNull() || state.EnvironmentPublicID.ValueString() != "   " {
+			t.Fatalf("EnvironmentPublicID = %v, want %q", state.EnvironmentPublicID, "   ")
+		}
+	})
+
+	t.Run("null_state_with_real_reference_value_stays_null", func(t *testing.T) {
+		state := &platformWorkflowModel{
+			EnvironmentPublicID: types.StringNull(),
+		}
+		reference := platformWorkflowModel{
+			EnvironmentPublicID: types.StringValue("env-abc123"),
+		}
+
+		preserveEquivalentEnvironmentPublicID(state, reference)
+
+		if !state.EnvironmentPublicID.IsNull() {
+			t.Fatalf("EnvironmentPublicID = %v, want null", state.EnvironmentPublicID)
+		}
+	})
+
 	t.Run("leaves_state_unchanged_for_non_equivalent_value", func(t *testing.T) {
 		state := &platformWorkflowModel{
 			EnvironmentPublicID: types.StringValue("env-abc123"),

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -2257,7 +2257,6 @@ func TestPreserveEquivalentEnvironmentPublicID(t *testing.T) {
 		}
 	})
 
-
 	t.Run("empty_configured_value_does_not_drift_to_null", func(t *testing.T) {
 		state := &platformWorkflowModel{
 			EnvironmentPublicID: types.StringNull(),


### PR DESCRIPTION
Adds the `environment_public_id` attribute to the `cursor_platform_workflow` resource and data source, mapping to the automation's Cloud Agent environment (`AgentOptions.environment_public_id`). Lets practitioners pin which environment an automation runs in — previously only settable through the console.

- Optional string on the resource; computed on the data source
- Round-trip conversions in `modelToWorkflow`/`protoToModel` (null-preserving: no empty-string state)
- `preserveEquivalentEnvironmentPublicID` keeps practitioner-supplied formatting when the API returns the trimmed equivalent
- Tests: round-trip (set + unset) and preservation behavior; docs regenerated

Resolves CHAR-590

Made with [Cursor](https://cursor.com)