### PR TITLE
Add private worker routing support

### DIFF
--- a/docs/data-sources/platform_workflow.md
+++ b/docs/data-sources/platform_workflow.md
@@ -37,6 +37,7 @@ data "cursor_platform_workflow" "existing" {
 - `memory_enabled` (Boolean) Whether the AutomationMemory tool is enabled for persistent memory across runs.
 - `model` (String) Model name.
 - `name` (String) Display name for the automation.
+- `private_worker` (Attributes) Private-worker routing configuration for this automation. (see [below for nested schema](#nestedatt--private_worker))
 - `prompt` (String) The prompt text.
 - `scope` (String) Automation ownership scope: "user" or "team".
 - `skip_install` (Boolean) Whether to skip install commands.
@@ -115,6 +116,14 @@ Read-Only:
 - `post_as_thread` (Boolean) If true, post a parent message with the automation name and reply in the thread.
 - `respond_in_thread` (Boolean) If true, respond in the thread of the triggering Slack message (Slack triggers only).
 
+
+
+<a id="nestedatt--private_worker"></a>
+### Nested Schema for `private_worker`
+
+Read-Only:
+
+- `labels` (Map of String) Private-worker selector labels.
 
 
 <a id="nestedatt--trigger"></a>

--- a/docs/resources/platform_workflow.md
+++ b/docs/resources/platform_workflow.md
@@ -21,6 +21,13 @@ resource "cursor_platform_workflow" "example_review" {
   prompt = file("prompt.md")
   model  = "gpt-5.5"
 
+  private_worker = {
+    labels = {
+      repo = "example-org/example-repo"
+      pool = "example-reviewers"
+    }
+  }
+
   trigger = [
     {
       git_pull_request = {
@@ -66,6 +73,7 @@ resource "cursor_platform_workflow" "example_review" {
 - `git_repo` (String) Git repository for non-git triggers (cron, slack, linear). E.g. github.com/org/repo.
 - `memory_enabled` (Boolean) Enable the AutomationMemory tool, giving the agent persistent memory across runs.
 - `model` (String) Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model.
+- `private_worker` (Attributes) Route this automation to private workers. An empty object targets any private worker; labels narrow the eligible workers. (see [below for nested schema](#nestedatt--private_worker))
 - `scope` (String) Automation ownership scope: "user", "team", "team_visible", "team_editable_user", or "team_editable". "user" is private (owner and admins only), "team" is shared (team admins can edit, runs as team service account), "team_visible" is viewable by team (team can view, only owner can edit, runs as owner), "team_editable_user" is editable by the team but still runs as the creator user, and "team_editable" is editable by the team and runs as the team service account. Defaults to "user" when unset.
 - `skip_install` (Boolean) Skip user install commands and cloud testing.
 
@@ -295,6 +303,15 @@ Optional:
 - `generalized` (Boolean) If true, agent can list and send to any Slack channel or DM dynamically.
 - `post_as_thread` (Boolean) If true, post a parent message with the automation name and reply in the thread.
 - `respond_in_thread` (Boolean) If true, respond in the thread of the triggering Slack message (Slack triggers only).
+
+
+
+<a id="nestedatt--private_worker"></a>
+### Nested Schema for `private_worker`
+
+Optional:
+
+- `labels` (Map of String) Private-worker selector labels. Label keys and values are matched exactly.
 
 ## Import
 

--- a/examples/resources/cursor_platform_workflow/resource.tf
+++ b/examples/resources/cursor_platform_workflow/resource.tf
@@ -6,6 +6,13 @@ resource "cursor_platform_workflow" "example_review" {
   prompt = file("prompt.md")
   model  = "gpt-5.5"
 
+  private_worker = {
+    labels = {
+      repo = "example-org/example-repo"
+      pool = "example-reviewers"
+    }
+  }
+
   trigger = [
     {
       git_pull_request = {

--- a/internal/provider/data_source_platform_workflow.go
+++ b/internal/provider/data_source_platform_workflow.go
@@ -71,6 +71,17 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 				Computed:    true,
 				Description: "Public ID of the Cloud Agent environment this automation runs in.",
 			},
+			"private_worker": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Private-worker routing configuration for this automation.",
+				Attributes: map[string]schema.Attribute{
+					"labels": schema.MapAttribute{
+						Computed:    true,
+						ElementType: types.StringType,
+						Description: "Private-worker selector labels.",
+					},
+				},
+			},
 			"memory_enabled": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Whether the AutomationMemory tool is enabled for persistent memory across runs.",

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -5,15 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	connect "connectrpc.com/connect"
 	v1 "github.com/cursor/terraform-provider-cursor/internal/proto/v1"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -116,22 +119,27 @@ func parseCustomErrorDetailsTitleDetail(b []byte) (string, string) {
 // ---------------------------------------------------------------------------
 
 type platformWorkflowModel struct {
-	ID                  types.String   `tfsdk:"id"`
-	Name                types.String   `tfsdk:"name"`
-	Scope               types.String   `tfsdk:"scope"`
-	Enabled             types.Bool     `tfsdk:"enabled"`
-	Prompt              types.String   `tfsdk:"prompt"`
-	EffortLevel         types.String   `tfsdk:"effort_level"`
-	Model               types.String   `tfsdk:"model"`
-	GitRepo             types.String   `tfsdk:"git_repo"`
-	GitBranch           types.String   `tfsdk:"git_branch"`
-	SkipInstall         types.Bool     `tfsdk:"skip_install"`
-	EnvironmentPublicID types.String   `tfsdk:"environment_public_id"`
-	MemoryEnabled       types.Bool     `tfsdk:"memory_enabled"`
-	Triggers            []triggerModel `tfsdk:"trigger"`
-	Actions             []actionModel  `tfsdk:"action"`
-	CreatedAt           types.Int64    `tfsdk:"created_at"`
-	UpdatedAt           types.Int64    `tfsdk:"updated_at"`
+	ID                  types.String        `tfsdk:"id"`
+	Name                types.String        `tfsdk:"name"`
+	Scope               types.String        `tfsdk:"scope"`
+	Enabled             types.Bool          `tfsdk:"enabled"`
+	Prompt              types.String        `tfsdk:"prompt"`
+	EffortLevel         types.String        `tfsdk:"effort_level"`
+	Model               types.String        `tfsdk:"model"`
+	GitRepo             types.String        `tfsdk:"git_repo"`
+	GitBranch           types.String        `tfsdk:"git_branch"`
+	SkipInstall         types.Bool          `tfsdk:"skip_install"`
+	EnvironmentPublicID types.String        `tfsdk:"environment_public_id"`
+	PrivateWorker       *privateWorkerModel `tfsdk:"private_worker"`
+	MemoryEnabled       types.Bool          `tfsdk:"memory_enabled"`
+	Triggers            []triggerModel      `tfsdk:"trigger"`
+	Actions             []actionModel       `tfsdk:"action"`
+	CreatedAt           types.Int64         `tfsdk:"created_at"`
+	UpdatedAt           types.Int64         `tfsdk:"updated_at"`
+}
+
+type privateWorkerModel struct {
+	Labels types.Map `tfsdk:"labels"`
 }
 
 type triggerModel struct {
@@ -353,6 +361,22 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 			"environment_public_id": schema.StringAttribute{
 				Optional:    true,
 				Description: "Public ID of the Cloud Agent environment this automation should run in.",
+			},
+			"private_worker": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Route this automation to private workers. An empty object targets any private worker; labels narrow the eligible workers.",
+				Attributes: map[string]schema.Attribute{
+					"labels": schema.MapAttribute{
+						Optional:    true,
+						Computed:    true,
+						ElementType: types.StringType,
+						Default: mapdefault.StaticValue(types.MapValueMust(
+							types.StringType,
+							map[string]attr.Value{},
+						)),
+						Description: "Private-worker selector labels. Label keys and values are matched exactly.",
+					},
+				},
 			},
 			"memory_enabled": schema.BoolAttribute{
 				Optional:    true,
@@ -1406,6 +1430,33 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 			agentOptions.EnvironmentPublicId = &environmentPublicID
 		}
 	}
+	if m.PrivateWorker != nil {
+		if agentOptions == nil {
+			agentOptions = &v1.AgentOptions{}
+		}
+
+		privateWorker := &v1.AgentPrivateWorkerConfig{}
+		if !m.PrivateWorker.Labels.IsNull() && !m.PrivateWorker.Labels.IsUnknown() {
+			labels := make(map[string]string)
+			diags := m.PrivateWorker.Labels.ElementsAs(ctx, &labels, false)
+			if diags.HasError() {
+				return nil, fmt.Errorf("failed to read private_worker.labels")
+			}
+
+			keys := make([]string, 0, len(labels))
+			for key := range labels {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				privateWorker.Labels = append(privateWorker.Labels, &v1.AgentPrivateWorkerLabel{
+					Key:   key,
+					Value: labels[key],
+				})
+			}
+		}
+		agentOptions.PrivateWorker = privateWorker
+	}
 	if agentOptions != nil {
 		w.AgentOptions = agentOptions
 	}
@@ -2130,9 +2181,29 @@ func protoToModel(ctx context.Context, withOwner *v1.AutomationWithOwner) (platf
 		} else {
 			m.EnvironmentPublicID = types.StringNull()
 		}
+		if privateWorker := ao.GetPrivateWorker(); privateWorker != nil {
+			labels := make(map[string]string, len(privateWorker.GetLabels()))
+			for _, label := range privateWorker.GetLabels() {
+				if label == nil {
+					continue
+				}
+				if _, exists := labels[label.GetKey()]; exists {
+					return platformWorkflowModel{}, fmt.Errorf("private_worker contains duplicate label key %q", label.GetKey())
+				}
+				labels[label.GetKey()] = label.GetValue()
+			}
+			labelMap, diags := types.MapValueFrom(ctx, types.StringType, labels)
+			if diags.HasError() {
+				return platformWorkflowModel{}, fmt.Errorf("reading private_worker.labels")
+			}
+			m.PrivateWorker = &privateWorkerModel{Labels: labelMap}
+		} else {
+			m.PrivateWorker = nil
+		}
 	} else {
 		m.SkipInstall = types.BoolNull()
 		m.EnvironmentPublicID = types.StringNull()
+		m.PrivateWorker = nil
 	}
 
 	// MemoryEnabled

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	v1 "github.com/cursor/terraform-provider-cursor/internal/proto/v1"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,6 +22,16 @@ func mustStringList(t *testing.T, ctx context.Context, values []string) types.Li
 		t.Fatalf("failed to build string list: %v", diags)
 	}
 	return list
+}
+
+func mustStringMap(t *testing.T, ctx context.Context, values map[string]string) types.Map {
+	t.Helper()
+
+	value, diags := types.MapValueFrom(ctx, types.StringType, values)
+	if diags.HasError() {
+		t.Fatalf("failed to build string map: %v", diags)
+	}
+	return value
 }
 
 // TestUpdatedAtHasNoPlanModifiers verifies that the updated_at attribute does
@@ -2301,4 +2313,192 @@ func TestPreserveEquivalentEnvironmentPublicID(t *testing.T) {
 			t.Fatalf("EnvironmentPublicID = %q, want %q", got, "env-abc123")
 		}
 	})
+}
+
+func TestPrivateWorkerSchemaParity(t *testing.T) {
+	resourceResponse := &resource.SchemaResponse{}
+	(&platformWorkflowResource{}).Schema(context.Background(), resource.SchemaRequest{}, resourceResponse)
+
+	resourceAttribute, ok := resourceResponse.Schema.Attributes["private_worker"]
+	if !ok {
+		t.Fatal("resource schema is missing private_worker")
+	}
+	resourcePrivateWorker, ok := resourceAttribute.(schema.SingleNestedAttribute)
+	if !ok || !resourcePrivateWorker.Optional {
+		t.Fatalf("resource private_worker = %#v, want optional SingleNestedAttribute", resourceAttribute)
+	}
+	resourceLabels, ok := resourcePrivateWorker.Attributes["labels"].(schema.MapAttribute)
+	if !ok || !resourceLabels.Optional || !resourceLabels.Computed || resourceLabels.Default == nil || resourceLabels.ElementType != types.StringType {
+		t.Fatalf("resource private_worker.labels = %#v, want optional+computed map(string) with an empty default", resourcePrivateWorker.Attributes["labels"])
+	}
+
+	dataSourceResponse := &datasource.SchemaResponse{}
+	(&platformWorkflowDataSource{}).Schema(context.Background(), datasource.SchemaRequest{}, dataSourceResponse)
+
+	dataSourceAttribute, ok := dataSourceResponse.Schema.Attributes["private_worker"]
+	if !ok {
+		t.Fatal("data source schema is missing private_worker")
+	}
+	dataSourcePrivateWorker, ok := dataSourceAttribute.(datasourceschema.SingleNestedAttribute)
+	if !ok || !dataSourcePrivateWorker.Computed {
+		t.Fatalf("data source private_worker = %#v, want computed SingleNestedAttribute", dataSourceAttribute)
+	}
+	dataSourceLabels, ok := dataSourcePrivateWorker.Attributes["labels"].(datasourceschema.MapAttribute)
+	if !ok || !dataSourceLabels.Computed || dataSourceLabels.ElementType != types.StringType {
+		t.Fatalf("data source private_worker.labels = %#v, want computed map(string)", dataSourcePrivateWorker.Attributes["labels"])
+	}
+}
+
+func TestPrivateWorkerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	wantLabels := map[string]string{
+		"repo": "example-org/example-repo",
+		"pool": "example-production-pool",
+	}
+	skipInstall := false
+
+	model := &platformWorkflowModel{
+		Prompt:              types.StringValue("review requests"),
+		SkipInstall:         types.BoolValue(skipInstall),
+		EnvironmentPublicID: types.StringValue("environment-id"),
+		PrivateWorker: &privateWorkerModel{
+			Labels: mustStringMap(t, ctx, wantLabels),
+		},
+		Triggers: []triggerModel{{Webhook: &webhookTriggerModel{}}},
+	}
+
+	workflow, err := modelToWorkflow(ctx, model)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() error = %v", err)
+	}
+	if workflow.GetAgentOptions().GetPrivateWorker() == nil {
+		t.Fatal("AgentOptions.PrivateWorker is nil")
+	}
+	gotProtoLabels := workflow.GetAgentOptions().GetPrivateWorker().GetLabels()
+	if len(gotProtoLabels) != 2 || gotProtoLabels[0].GetKey() != "pool" || gotProtoLabels[1].GetKey() != "repo" {
+		t.Fatalf("private worker labels are not serialized deterministically: %#v", gotProtoLabels)
+	}
+	if workflow.GetAgentOptions().SkipInstall == nil || workflow.GetAgentOptions().GetSkipInstall() != skipInstall {
+		t.Fatal("adding private_worker clobbered skip_install")
+	}
+	if got := workflow.GetAgentOptions().GetEnvironmentPublicId(); got != "environment-id" {
+		t.Fatalf("adding private_worker clobbered environment_public_id: got %q", got)
+	}
+
+	state, err := protoToModel(ctx, &v1.AutomationWithOwner{
+		Workflow: &v1.Automation{Workflow: workflow},
+	})
+	if err != nil {
+		t.Fatalf("protoToModel() error = %v", err)
+	}
+	if state.PrivateWorker == nil {
+		t.Fatal("PrivateWorker is nil after round trip")
+	}
+	var gotLabels map[string]string
+	diags := state.PrivateWorker.Labels.ElementsAs(ctx, &gotLabels, false)
+	if diags.HasError() {
+		t.Fatalf("failed to read private worker labels: %v", diags)
+	}
+	if !reflect.DeepEqual(gotLabels, wantLabels) {
+		t.Fatalf("private worker labels = %#v, want %#v", gotLabels, wantLabels)
+	}
+
+	state.Prompt = types.StringValue("updated review prompt")
+	updatedWorkflow, err := modelToWorkflow(ctx, &state)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() after unrelated update error = %v", err)
+	}
+	updatedLabels := updatedWorkflow.GetAgentOptions().GetPrivateWorker().GetLabels()
+	if len(updatedLabels) != 2 || updatedLabels[0].GetKey() != "pool" || updatedLabels[1].GetKey() != "repo" {
+		t.Fatalf("unrelated update did not retain private worker labels: %#v", updatedLabels)
+	}
+}
+
+func TestPrivateWorkerPresenceSemantics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("absent_uses_default_worker_routing", func(t *testing.T) {
+		workflow, err := modelToWorkflow(ctx, &platformWorkflowModel{
+			Prompt:   types.StringValue("do the thing"),
+			Triggers: []triggerModel{{Webhook: &webhookTriggerModel{}}},
+		})
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error = %v", err)
+		}
+		if workflow.GetAgentOptions() != nil {
+			t.Fatalf("AgentOptions = %#v, want nil", workflow.GetAgentOptions())
+		}
+	})
+
+	t.Run("removal_preserves_other_agent_options", func(t *testing.T) {
+		workflow, err := modelToWorkflow(ctx, &platformWorkflowModel{
+			Prompt:      types.StringValue("do the thing"),
+			SkipInstall: types.BoolValue(true),
+			Triggers:    []triggerModel{{Webhook: &webhookTriggerModel{}}},
+		})
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error = %v", err)
+		}
+		if workflow.GetAgentOptions() == nil || !workflow.GetAgentOptions().GetSkipInstall() {
+			t.Fatal("removing private_worker clobbered skip_install")
+		}
+		if workflow.GetAgentOptions().GetPrivateWorker() != nil {
+			t.Fatalf("PrivateWorker = %#v, want nil", workflow.GetAgentOptions().GetPrivateWorker())
+		}
+	})
+
+	t.Run("present_empty_targets_any_private_worker", func(t *testing.T) {
+		workflow, err := modelToWorkflow(ctx, &platformWorkflowModel{
+			Prompt: types.StringValue("do the thing"),
+			PrivateWorker: &privateWorkerModel{
+				Labels: mustStringMap(t, ctx, map[string]string{}),
+			},
+			Triggers: []triggerModel{{Webhook: &webhookTriggerModel{}}},
+		})
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error = %v", err)
+		}
+		if workflow.GetAgentOptions().GetPrivateWorker() == nil {
+			t.Fatal("PrivateWorker is nil for a present empty object")
+		}
+		if got := workflow.GetAgentOptions().GetPrivateWorker().GetLabels(); len(got) != 0 {
+			t.Fatalf("PrivateWorker.Labels = %#v, want empty", got)
+		}
+
+		state, err := protoToModel(ctx, &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{Workflow: workflow},
+		})
+		if err != nil {
+			t.Fatalf("protoToModel() error = %v", err)
+		}
+		if state.PrivateWorker == nil || state.PrivateWorker.Labels.IsNull() {
+			t.Fatal("present empty PrivateWorker did not survive round trip")
+		}
+	})
+}
+
+func TestPrivateWorkerAPILabelOrderDoesNotDrift(t *testing.T) {
+	ctx := context.Background()
+	state, err := protoToModel(ctx, &v1.AutomationWithOwner{
+		Workflow: &v1.Automation{Workflow: &v1.Workflow{
+			AgentOptions: &v1.AgentOptions{
+				PrivateWorker: &v1.AgentPrivateWorkerConfig{Labels: []*v1.AgentPrivateWorkerLabel{
+					{Key: "repo", Value: "example-org/example-repo"},
+					{Key: "pool", Value: "example-production-pool"},
+				}},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("protoToModel() error = %v", err)
+	}
+
+	workflow, err := modelToWorkflow(ctx, &state)
+	if err != nil {
+		t.Fatalf("modelToWorkflow() error = %v", err)
+	}
+	labels := workflow.GetAgentOptions().GetPrivateWorker().GetLabels()
+	if len(labels) != 2 || labels[0].GetKey() != "pool" || labels[1].GetKey() != "repo" {
+		t.Fatalf("private worker labels were not canonicalized: %#v", labels)
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New optional field changes where automations execute when set; misconfigured labels could route runs to the wrong workers, though default behavior is unchanged when omitted.
> 
> **Overview**
> Adds optional **`private_worker`** on `cursor_platform_workflow` (resource and data source) so automations can be routed to private workers instead of default cloud execution.
> 
> Practitioners can set **`private_worker.labels`** (string map, exact key/value match) to narrow eligible workers; an empty **`private_worker {}`** means any private worker, and omitting the block leaves default routing unchanged. The provider maps this into **`AgentOptions.PrivateWorker`** on create/update/read, sorts label keys when serializing to the API to avoid plan drift, and rejects duplicate label keys from API responses.
> 
> Docs, the example `resource.tf`, and unit tests cover schema parity, round-trip, presence semantics, and coexistence with **`skip_install`** / **`environment_public_id`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533f6cb198ff3a3f16771fd43e174c80482dbab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->