### PR TITLE
Add Slack, PagerDuty, Sentry triggers, check-run actions, model_selection and team_id to cursor_platform_workflow

### DIFF
--- a/docs/data-sources/platform_workflow.md
+++ b/docs/data-sources/platform_workflow.md
@@ -41,7 +41,8 @@ data "cursor_platform_workflow" "existing" {
 - `git_branch` (String) Git branch for non-git triggers.
 - `git_repo` (String) Git repository for non-git triggers.
 - `memory_enabled` (Boolean) Whether the AutomationMemory tool is enabled for persistent memory across runs.
-- `model` (String) Model name.
+- `model` (String) Legacy model slug.
+- `model_selection` (Attributes) Structured model choice (catalog model ID plus parameters such as the Auto tier). Null when the automation only stores a legacy model slug. (see [below for nested schema](#nestedatt--model_selection))
 - `name` (String) Display name for the automation.
 - `private_worker` (Attributes) Private-worker routing configuration for this automation. (see [below for nested schema](#nestedatt--private_worker))
 - `prompt` (String) The prompt text.
@@ -136,6 +137,25 @@ Read-Only:
 - `generalized` (Boolean) If true, agent can list and send to any Slack channel or DM dynamically.
 - `post_as_thread` (Boolean) If true, post a parent message with the automation name and reply in the thread.
 - `respond_in_thread` (Boolean, Deprecated) Deprecated: ignored by the server, which always replies in the triggering Slack thread.
+
+
+
+<a id="nestedatt--model_selection"></a>
+### Nested Schema for `model_selection`
+
+Read-Only:
+
+- `max_mode` (Boolean) Whether the model runs in max mode.
+- `model_id` (String) Catalog model ID (e.g. auto-smart).
+- `parameters` (Attributes List) Parameter values selecting the model variant (e.g. optimize_for = cost). (see [below for nested schema](#nestedatt--model_selection--parameters))
+
+<a id="nestedatt--model_selection--parameters"></a>
+### Nested Schema for `model_selection.parameters`
+
+Read-Only:
+
+- `id` (String) Parameter ID.
+- `value` (String) Parameter value.
 
 
 

--- a/docs/data-sources/platform_workflow.md
+++ b/docs/data-sources/platform_workflow.md
@@ -25,10 +25,16 @@ data "cursor_platform_workflow" "existing" {
 
 - `id` (String) Automation ID.
 
+### Optional
+
+- `team_id` (Number) Numeric Cursor team ID. Set it to read a team-visible automation under a specific team; otherwise the team owning the automation is reported.
+
 ### Read-Only
 
 - `action` (Attributes List) Actions the automation can perform. (see [below for nested schema](#nestedatt--action))
 - `created_at` (Number) Unix timestamp (seconds) when the automation was created.
+- `description` (String) Free-text description of the automation.
+- `disabled_default_tools` (List of String) Default automation tools withheld from the agent (e.g. "open_git_pr").
 - `effort_level` (String) Effort level: standard or hard.
 - `enabled` (Boolean) Whether the automation is enabled.
 - `environment_public_id` (String) Public ID of the Cloud Agent environment this automation runs in.
@@ -39,7 +45,7 @@ data "cursor_platform_workflow" "existing" {
 - `name` (String) Display name for the automation.
 - `private_worker` (Attributes) Private-worker routing configuration for this automation. (see [below for nested schema](#nestedatt--private_worker))
 - `prompt` (String) The prompt text.
-- `scope` (String) Automation ownership scope: "user" or "team".
+- `scope` (String) Automation ownership scope: "user", "team", "team_visible", "team_editable_user", or "team_editable".
 - `skip_install` (Boolean) Whether to skip install commands.
 - `trigger` (Attributes List) Triggers that start the automation. (see [below for nested schema](#nestedatt--trigger))
 - `updated_at` (Number) Unix timestamp (seconds) when the automation was last updated.
@@ -49,17 +55,28 @@ data "cursor_platform_workflow" "existing" {
 
 Read-Only:
 
+- `approve_pr` (Attributes) Deprecated: allow the agent to approve the PR. Superseded by pr_comment.allow_approve. (see [below for nested schema](#nestedatt--action--approve_pr))
 - `git_pr` (Attributes) Create a pull request. (see [below for nested schema](#nestedatt--action--git_pr))
+- `manage_check_run` (Attributes) Create and resolve a GitHub check run on the PR for each automation run. (see [below for nested schema](#nestedatt--action--manage_check_run))
 - `mcp` (Attributes) Enable an MCP server for this automation. (see [below for nested schema](#nestedatt--action--mcp))
 - `microsoft_teams` (Attributes) Post messages to a Microsoft Teams channel. (see [below for nested schema](#nestedatt--action--microsoft_teams))
 - `pr_comment` (Attributes) Post a comment on the PR. (see [below for nested schema](#nestedatt--action--pr_comment))
 - `read_microsoft_teams` (Attributes) Give the agent read-only access to Microsoft Teams channels (ListMicrosoftTeamsChannels, ReadMicrosoftTeamsMessages tools). (see [below for nested schema](#nestedatt--action--read_microsoft_teams))
 - `read_slack` (Attributes) Give the agent read-only access to public Slack channels (ListSlackChannels, ReadSlackMessages tools). (see [below for nested schema](#nestedatt--action--read_slack))
 - `request_reviewers` (Attributes) Request reviewers on the PR. (see [below for nested schema](#nestedatt--action--request_reviewers))
+- `resolve_review_threads` (Attributes) Let the agent resolve its own prior PR review threads (ResolveReviewThreads tool). (see [below for nested schema](#nestedatt--action--resolve_review_threads))
 - `slack` (Attributes) Post messages to a Slack channel. (see [below for nested schema](#nestedatt--action--slack))
+
+<a id="nestedatt--action--approve_pr"></a>
+### Nested Schema for `action.approve_pr`
+
 
 <a id="nestedatt--action--git_pr"></a>
 ### Nested Schema for `action.git_pr`
+
+
+<a id="nestedatt--action--manage_check_run"></a>
+### Nested Schema for `action.manage_check_run`
 
 
 <a id="nestedatt--action--mcp"></a>
@@ -106,6 +123,10 @@ Read-Only:
 ### Nested Schema for `action.request_reviewers`
 
 
+<a id="nestedatt--action--resolve_review_threads"></a>
+### Nested Schema for `action.resolve_review_threads`
+
+
 <a id="nestedatt--action--slack"></a>
 ### Nested Schema for `action.slack`
 
@@ -114,7 +135,7 @@ Read-Only:
 - `channel` (String) Slack channel ID to post to.
 - `generalized` (Boolean) If true, agent can list and send to any Slack channel or DM dynamically.
 - `post_as_thread` (Boolean) If true, post a parent message with the automation name and reply in the thread.
-- `respond_in_thread` (Boolean) If true, respond in the thread of the triggering Slack message (Slack triggers only).
+- `respond_in_thread` (Boolean, Deprecated) Deprecated: ignored by the server, which always replies in the triggering Slack thread.
 
 
 
@@ -138,7 +159,13 @@ Read-Only:
 - `linear` (Attributes) Trigger on Linear events. (see [below for nested schema](#nestedatt--trigger--linear))
 - `microsoft_teams` (Attributes) Trigger on Microsoft Teams channel messages. (see [below for nested schema](#nestedatt--trigger--microsoft_teams))
 - `microsoft_teams_channel_created` (Attributes) Trigger when a new Microsoft Teams channel is created. (see [below for nested schema](#nestedatt--trigger--microsoft_teams_channel_created))
+- `pagerduty` (Attributes) Trigger on PagerDuty incident events. (see [below for nested schema](#nestedatt--trigger--pagerduty))
+- `sentry` (Attributes) Trigger on Sentry issue webhooks. (see [below for nested schema](#nestedatt--trigger--sentry))
 - `slack` (Attributes) Trigger on Slack messages. (see [below for nested schema](#nestedatt--trigger--slack))
+- `slack_any_reaction_added` (Attributes) Trigger when any emoji reaction is added in a Slack channel. (see [below for nested schema](#nestedatt--trigger--slack_any_reaction_added))
+- `slack_channel_created` (Attributes) Trigger when a public Slack channel is created. (see [below for nested schema](#nestedatt--trigger--slack_channel_created))
+- `slack_mention` (Attributes) Trigger when the Cursor Slack app is mentioned in a channel. (see [below for nested schema](#nestedatt--trigger--slack_mention))
+- `slack_reaction_added` (Attributes) Trigger when a specific emoji reaction is added in a Slack channel. (see [below for nested schema](#nestedatt--trigger--slack_reaction_added))
 - `user_allowlist` (List of String) Git usernames allowed to trigger this automation. Empty means all users.
 - `webhook` (Attributes) Trigger on generic webhook POST requests. (see [below for nested schema](#nestedatt--trigger--webhook))
 
@@ -235,8 +262,79 @@ Read-Only:
 Read-Only:
 
 - `channel_name_contains` (String) Channel name filter (case-insensitive).
-- `team_ids` (List of String) AAD group IDs to scope to. Empty fires for any team in the tenant.
+- `team_ids` (List of String) AAD group IDs of the teams watched.
 - `tenant_id` (String) AAD tenant GUID hosting the team.
+
+
+<a id="nestedatt--trigger--pagerduty"></a>
+### Nested Schema for `trigger.pagerduty`
+
+Read-Only:
+
+- `incident_acknowledged` (Attributes) Set when the trigger fires on acknowledged incidents. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_acknowledged))
+- `incident_any` (Attributes) Set when the trigger fires on any incident event. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_any))
+- `incident_escalated` (Attributes) Set when the trigger fires on escalated incidents. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_escalated))
+- `incident_resolved` (Attributes) Set when the trigger fires on resolved incidents. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_resolved))
+- `incident_triggered` (Attributes) Set when the trigger fires on triggered incidents. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_triggered))
+- `service_ids` (List of String) PagerDuty service IDs scoping the trigger.
+
+<a id="nestedatt--trigger--pagerduty--incident_acknowledged"></a>
+### Nested Schema for `trigger.pagerduty.incident_acknowledged`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_any"></a>
+### Nested Schema for `trigger.pagerduty.incident_any`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_escalated"></a>
+### Nested Schema for `trigger.pagerduty.incident_escalated`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_resolved"></a>
+### Nested Schema for `trigger.pagerduty.incident_resolved`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_triggered"></a>
+### Nested Schema for `trigger.pagerduty.incident_triggered`
+
+
+
+<a id="nestedatt--trigger--sentry"></a>
+### Nested Schema for `trigger.sentry`
+
+Read-Only:
+
+- `issue_any` (Attributes) Set when the trigger fires on any issue event. (see [below for nested schema](#nestedatt--trigger--sentry--issue_any))
+- `issue_archived` (Attributes) Set when the trigger fires on archived issues. (see [below for nested schema](#nestedatt--trigger--sentry--issue_archived))
+- `issue_assigned` (Attributes) Set when the trigger fires on assigned issues. (see [below for nested schema](#nestedatt--trigger--sentry--issue_assigned))
+- `issue_created` (Attributes) Set when the trigger fires on created issues. (see [below for nested schema](#nestedatt--trigger--sentry--issue_created))
+- `issue_resolved` (Attributes) Set when the trigger fires on resolved issues. (see [below for nested schema](#nestedatt--trigger--sentry--issue_resolved))
+- `issue_unresolved` (Attributes) Set when the trigger fires on issues marked unresolved. (see [below for nested schema](#nestedatt--trigger--sentry--issue_unresolved))
+- `project_ids` (List of String) Sentry project IDs scoping the trigger.
+
+<a id="nestedatt--trigger--sentry--issue_any"></a>
+### Nested Schema for `trigger.sentry.issue_any`
+
+
+<a id="nestedatt--trigger--sentry--issue_archived"></a>
+### Nested Schema for `trigger.sentry.issue_archived`
+
+
+<a id="nestedatt--trigger--sentry--issue_assigned"></a>
+### Nested Schema for `trigger.sentry.issue_assigned`
+
+
+<a id="nestedatt--trigger--sentry--issue_created"></a>
+### Nested Schema for `trigger.sentry.issue_created`
+
+
+<a id="nestedatt--trigger--sentry--issue_resolved"></a>
+### Nested Schema for `trigger.sentry.issue_resolved`
+
+
+<a id="nestedatt--trigger--sentry--issue_unresolved"></a>
+### Nested Schema for `trigger.sentry.issue_unresolved`
+
 
 
 <a id="nestedatt--trigger--slack"></a>
@@ -250,6 +348,44 @@ Read-Only:
 - `completion_reaction_mode` (String) Emoji reaction behavior on successful completion: "on", "off", or "custom".
 - `message_contains` (String) Message text filter (case-insensitive).
 - `message_contains_is_regex` (Boolean) Whether message_contains is a regex pattern.
+
+
+<a id="nestedatt--trigger--slack_any_reaction_added"></a>
+### Nested Schema for `trigger.slack_any_reaction_added`
+
+Read-Only:
+
+- `block_unauthenticated_slack_users` (Boolean) Whether only Slack users who linked Cursor can trigger.
+- `channel` (String) Slack channel ID.
+- `only_owner_reactions` (Boolean) Whether only the automation owner's reactions trigger it.
+
+
+<a id="nestedatt--trigger--slack_channel_created"></a>
+### Nested Schema for `trigger.slack_channel_created`
+
+Read-Only:
+
+- `channel_name_contains` (String) Channel name filter (case-insensitive).
+
+
+<a id="nestedatt--trigger--slack_mention"></a>
+### Nested Schema for `trigger.slack_mention`
+
+Read-Only:
+
+- `block_unauthenticated_slack_users` (Boolean) Whether only Slack users who linked Cursor can trigger.
+- `channel` (String) Slack channel ID.
+
+
+<a id="nestedatt--trigger--slack_reaction_added"></a>
+### Nested Schema for `trigger.slack_reaction_added`
+
+Read-Only:
+
+- `block_unauthenticated_slack_users` (Boolean) Whether only Slack users who linked Cursor can trigger.
+- `channel` (String) Slack channel ID.
+- `emoji_name` (String) Slack emoji short name without colons.
+- `only_owner_reactions` (Boolean) Whether only the automation owner's reactions trigger it.
 
 
 <a id="nestedatt--trigger--webhook"></a>

--- a/docs/resources/platform_workflow.md
+++ b/docs/resources/platform_workflow.md
@@ -3,20 +3,21 @@
 page_title: "cursor_platform_workflow Resource - cursor"
 subcategory: ""
 description: |-
-  Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).
+  Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, PagerDuty, Sentry, Microsoft Teams) and actions (PR comments, PRs, reviewers, check runs, MCP servers, Slack, Microsoft Teams).
 ---
 
 # cursor_platform_workflow (Resource)
 
-Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).
+Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, PagerDuty, Sentry, Microsoft Teams) and actions (PR comments, PRs, reviewers, check runs, MCP servers, Slack, Microsoft Teams).
 
 ## Example Usage
 
 ```terraform
 resource "cursor_platform_workflow" "example_review" {
-  name    = "Example review automation"
-  scope   = "team"
-  enabled = true
+  name        = "Example review automation"
+  description = "Reviews pull requests and posts inline comments."
+  scope       = "team"
+  enabled     = true
 
   prompt = file("prompt.md")
   model  = "gpt-5.5"
@@ -46,9 +47,73 @@ resource "cursor_platform_workflow" "example_review" {
       }
     },
     {
+      manage_check_run = {}
+    },
+    {
+      resolve_review_threads = {}
+    },
+    {
       mcp = {
         server = "example-mcp-server"
       }
+    }
+  ]
+}
+
+resource "cursor_platform_workflow" "example_slack_triage" {
+  name   = "Triage Slack reactions"
+  prompt = "Investigate the message that received the reaction and reply in thread."
+
+  git_repo               = "github.com/example-org/example-repo"
+  disabled_default_tools = ["open_git_pr"]
+
+  trigger = [
+    {
+      slack_reaction_added = {
+        channel    = "C0123456789"
+        emoji_name = "eyes"
+      }
+    },
+    {
+      slack_mention = {
+        channel = "C0123456789"
+      }
+    }
+  ]
+
+  action = [
+    {
+      slack = {
+        channel = "C0123456789"
+      }
+    }
+  ]
+}
+
+resource "cursor_platform_workflow" "example_incidents" {
+  name   = "Incident responder"
+  prompt = "Summarise the incident and open a PR with a proposed fix."
+
+  git_repo = "github.com/example-org/example-repo"
+
+  trigger = [
+    {
+      pagerduty = {
+        incident_triggered = {}
+        service_ids        = ["PABC123"]
+      }
+    },
+    {
+      sentry = {
+        issue_created = {}
+        project_ids   = ["123456"]
+      }
+    }
+  ]
+
+  action = [
+    {
+      git_pr = {}
     }
   ]
 }
@@ -66,6 +131,8 @@ resource "cursor_platform_workflow" "example_review" {
 ### Optional
 
 - `action` (Attributes List) Actions the automation can perform. Each action block specifies one action type. (see [below for nested schema](#nestedatt--action))
+- `description` (String) Optional free-text description shown in the Cursor dashboard.
+- `disabled_default_tools` (List of String) Default automation tools to withhold from the agent. Supported values: "open_git_pr". Leave unset to keep the platform defaults.
 - `effort_level` (String) Effort level for the prompt: "standard" or "hard". Defaults to standard if unset.
 - `enabled` (Boolean) Whether the automation is enabled.
 - `environment_public_id` (String) Public ID of the Cloud Agent environment this automation should run in.
@@ -76,6 +143,7 @@ resource "cursor_platform_workflow" "example_review" {
 - `private_worker` (Attributes) Route this automation to private workers. An empty object targets any private worker; labels narrow the eligible workers. (see [below for nested schema](#nestedatt--private_worker))
 - `scope` (String) Automation ownership scope: "user", "team", "team_visible", "team_editable_user", or "team_editable". "user" is private (owner and admins only), "team" is shared (team admins can edit, runs as team service account), "team_visible" is viewable by team (team can view, only owner can edit, runs as owner), "team_editable_user" is editable by the team but still runs as the creator user, and "team_editable" is editable by the team and runs as the team service account. Defaults to "user" when unset.
 - `skip_install` (Boolean) Skip user install commands and cloud testing.
+- `team_id` (Number) Numeric Cursor team ID to create and read the automation under. When unset, the team associated with the token is used. Requires a user token that is a member (or org admin) of the team; service-account tokens must leave this unset. Changing it between two set values forces a new automation because an automation cannot move between teams.
 
 ### Read-Only
 
@@ -95,7 +163,13 @@ Optional:
 - `linear` (Attributes) Trigger on Linear events. (see [below for nested schema](#nestedatt--trigger--linear))
 - `microsoft_teams` (Attributes) Trigger on Microsoft Teams channel messages. (see [below for nested schema](#nestedatt--trigger--microsoft_teams))
 - `microsoft_teams_channel_created` (Attributes) Trigger when a new Microsoft Teams channel is created in a configured team. (see [below for nested schema](#nestedatt--trigger--microsoft_teams_channel_created))
+- `pagerduty` (Attributes) Trigger on PagerDuty incident events. Exactly one of incident_triggered, incident_acknowledged, incident_resolved, incident_escalated, or incident_any must be set. (see [below for nested schema](#nestedatt--trigger--pagerduty))
+- `sentry` (Attributes) Trigger on Sentry issue webhooks. Exactly one of issue_created, issue_resolved, issue_assigned, issue_archived, issue_unresolved, or issue_any must be set. The Cursor Sentry integration must be connected for the owner before the automation can be saved. (see [below for nested schema](#nestedatt--trigger--sentry))
 - `slack` (Attributes) Trigger on Slack messages. (see [below for nested schema](#nestedatt--trigger--slack))
+- `slack_any_reaction_added` (Attributes) Trigger when any emoji reaction is added to a message in a Slack channel. (see [below for nested schema](#nestedatt--trigger--slack_any_reaction_added))
+- `slack_channel_created` (Attributes) Trigger when a public Slack channel is created. (see [below for nested schema](#nestedatt--trigger--slack_channel_created))
+- `slack_mention` (Attributes) Trigger when the Cursor Slack app is mentioned in a Slack channel. (see [below for nested schema](#nestedatt--trigger--slack_mention))
+- `slack_reaction_added` (Attributes) Trigger when a specific emoji reaction is added to a message in a Slack channel. (see [below for nested schema](#nestedatt--trigger--slack_reaction_added))
 - `user_allowlist` (List of String) Git usernames allowed to trigger this automation. Empty means all users.
 - `webhook` (Attributes) Trigger on generic webhook POST requests. (see [below for nested schema](#nestedatt--trigger--webhook))
 
@@ -200,12 +274,83 @@ Optional:
 
 Required:
 
+- `team_ids` (List of String) AAD group IDs of the teams to watch. At least one is required.
 - `tenant_id` (String) AAD tenant GUID hosting the team.
 
 Optional:
 
 - `channel_name_contains` (String) Only trigger if the new channel name contains this text (case-insensitive).
-- `team_ids` (List of String) Optional AAD group IDs to scope to. Empty fires for any team in the tenant.
+
+
+<a id="nestedatt--trigger--pagerduty"></a>
+### Nested Schema for `trigger.pagerduty`
+
+Optional:
+
+- `incident_acknowledged` (Attributes) Trigger when an incident is acknowledged. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_acknowledged))
+- `incident_any` (Attributes) Trigger on any incident event (triggered, acknowledged, resolved, escalated). (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_any))
+- `incident_escalated` (Attributes) Trigger when an incident is escalated. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_escalated))
+- `incident_resolved` (Attributes) Trigger when an incident is resolved. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_resolved))
+- `incident_triggered` (Attributes) Trigger when an incident is triggered. (see [below for nested schema](#nestedatt--trigger--pagerduty--incident_triggered))
+- `service_ids` (List of String) Optional PagerDuty service IDs to scope the trigger to. Empty fires for all services.
+
+<a id="nestedatt--trigger--pagerduty--incident_acknowledged"></a>
+### Nested Schema for `trigger.pagerduty.incident_acknowledged`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_any"></a>
+### Nested Schema for `trigger.pagerduty.incident_any`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_escalated"></a>
+### Nested Schema for `trigger.pagerduty.incident_escalated`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_resolved"></a>
+### Nested Schema for `trigger.pagerduty.incident_resolved`
+
+
+<a id="nestedatt--trigger--pagerduty--incident_triggered"></a>
+### Nested Schema for `trigger.pagerduty.incident_triggered`
+
+
+
+<a id="nestedatt--trigger--sentry"></a>
+### Nested Schema for `trigger.sentry`
+
+Optional:
+
+- `issue_any` (Attributes) Trigger on any Sentry issue event. (see [below for nested schema](#nestedatt--trigger--sentry--issue_any))
+- `issue_archived` (Attributes) Trigger when a Sentry issue is archived. (see [below for nested schema](#nestedatt--trigger--sentry--issue_archived))
+- `issue_assigned` (Attributes) Trigger when a Sentry issue is assigned. (see [below for nested schema](#nestedatt--trigger--sentry--issue_assigned))
+- `issue_created` (Attributes) Trigger when a Sentry issue is created. (see [below for nested schema](#nestedatt--trigger--sentry--issue_created))
+- `issue_resolved` (Attributes) Trigger when a Sentry issue is resolved. (see [below for nested schema](#nestedatt--trigger--sentry--issue_resolved))
+- `issue_unresolved` (Attributes) Trigger when a Sentry issue is marked unresolved. (see [below for nested schema](#nestedatt--trigger--sentry--issue_unresolved))
+- `project_ids` (List of String) Optional Sentry numeric project IDs (as strings) to scope the trigger to. Empty matches all projects in the organization.
+
+<a id="nestedatt--trigger--sentry--issue_any"></a>
+### Nested Schema for `trigger.sentry.issue_any`
+
+
+<a id="nestedatt--trigger--sentry--issue_archived"></a>
+### Nested Schema for `trigger.sentry.issue_archived`
+
+
+<a id="nestedatt--trigger--sentry--issue_assigned"></a>
+### Nested Schema for `trigger.sentry.issue_assigned`
+
+
+<a id="nestedatt--trigger--sentry--issue_created"></a>
+### Nested Schema for `trigger.sentry.issue_created`
+
+
+<a id="nestedatt--trigger--sentry--issue_resolved"></a>
+### Nested Schema for `trigger.sentry.issue_resolved`
+
+
+<a id="nestedatt--trigger--sentry--issue_unresolved"></a>
+### Nested Schema for `trigger.sentry.issue_unresolved`
+
 
 
 <a id="nestedatt--trigger--slack"></a>
@@ -224,6 +369,53 @@ Optional:
 - `message_contains_is_regex` (Boolean) If true, message_contains is treated as a regex pattern (case-insensitive).
 
 
+<a id="nestedatt--trigger--slack_any_reaction_added"></a>
+### Nested Schema for `trigger.slack_any_reaction_added`
+
+Required:
+
+- `channel` (String) Slack channel ID.
+
+Optional:
+
+- `block_unauthenticated_slack_users` (Boolean) If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).
+- `only_owner_reactions` (Boolean) If true, only the automation owner's own linked Slack user can trigger it. Stricter than block_unauthenticated_slack_users.
+
+
+<a id="nestedatt--trigger--slack_channel_created"></a>
+### Nested Schema for `trigger.slack_channel_created`
+
+Optional:
+
+- `channel_name_contains` (String) Only trigger if the new channel name contains this text (case-insensitive).
+
+
+<a id="nestedatt--trigger--slack_mention"></a>
+### Nested Schema for `trigger.slack_mention`
+
+Required:
+
+- `channel` (String) Slack channel ID.
+
+Optional:
+
+- `block_unauthenticated_slack_users` (Boolean) If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).
+
+
+<a id="nestedatt--trigger--slack_reaction_added"></a>
+### Nested Schema for `trigger.slack_reaction_added`
+
+Required:
+
+- `channel` (String) Slack channel ID.
+- `emoji_name` (String) Slack emoji short name without colons, lowercase (e.g. "thumbsup", "white_check_mark").
+
+Optional:
+
+- `block_unauthenticated_slack_users` (Boolean) If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).
+- `only_owner_reactions` (Boolean) If true, only the automation owner's own linked Slack user can trigger it. Stricter than block_unauthenticated_slack_users.
+
+
 <a id="nestedatt--trigger--webhook"></a>
 ### Nested Schema for `trigger.webhook`
 
@@ -234,17 +426,28 @@ Optional:
 
 Optional:
 
+- `approve_pr` (Attributes, Deprecated) Deprecated: allow the agent to approve the PR. Use pr_comment.allow_approve instead. (see [below for nested schema](#nestedatt--action--approve_pr))
 - `git_pr` (Attributes) Create a pull request. (see [below for nested schema](#nestedatt--action--git_pr))
+- `manage_check_run` (Attributes) Create and resolve a GitHub check run on the PR for each automation run. Only relevant for git_pull_request triggers; the check run lifecycle is always system-managed. (see [below for nested schema](#nestedatt--action--manage_check_run))
 - `mcp` (Attributes) Enable an MCP server for this automation. (see [below for nested schema](#nestedatt--action--mcp))
 - `microsoft_teams` (Attributes) Post messages to a Microsoft Teams channel. (see [below for nested schema](#nestedatt--action--microsoft_teams))
 - `pr_comment` (Attributes) Post a comment on the PR. (see [below for nested schema](#nestedatt--action--pr_comment))
 - `read_microsoft_teams` (Attributes) Give the agent read-only access to Microsoft Teams channels (ListMicrosoftTeamsChannels, ReadMicrosoftTeamsMessages tools). (see [below for nested schema](#nestedatt--action--read_microsoft_teams))
 - `read_slack` (Attributes) Give the agent read-only access to public Slack channels (ListSlackChannels, ReadSlackMessages tools). (see [below for nested schema](#nestedatt--action--read_slack))
 - `request_reviewers` (Attributes) Request reviewers on the PR. (see [below for nested schema](#nestedatt--action--request_reviewers))
+- `resolve_review_threads` (Attributes) Let the agent mark its own prior PR review threads as addressed and resolve them on GitHub (ResolveReviewThreads tool). (see [below for nested schema](#nestedatt--action--resolve_review_threads))
 - `slack` (Attributes) Post messages to a Slack channel. (see [below for nested schema](#nestedatt--action--slack))
+
+<a id="nestedatt--action--approve_pr"></a>
+### Nested Schema for `action.approve_pr`
+
 
 <a id="nestedatt--action--git_pr"></a>
 ### Nested Schema for `action.git_pr`
+
+
+<a id="nestedatt--action--manage_check_run"></a>
+### Nested Schema for `action.manage_check_run`
 
 
 <a id="nestedatt--action--mcp"></a>
@@ -294,6 +497,10 @@ Optional:
 ### Nested Schema for `action.request_reviewers`
 
 
+<a id="nestedatt--action--resolve_review_threads"></a>
+### Nested Schema for `action.resolve_review_threads`
+
+
 <a id="nestedatt--action--slack"></a>
 ### Nested Schema for `action.slack`
 
@@ -302,7 +509,7 @@ Optional:
 - `channel` (String) Slack channel ID to post to.
 - `generalized` (Boolean) If true, agent can list and send to any Slack channel or DM dynamically.
 - `post_as_thread` (Boolean) If true, post a parent message with the automation name and reply in the thread.
-- `respond_in_thread` (Boolean) If true, respond in the thread of the triggering Slack message (Slack triggers only).
+- `respond_in_thread` (Boolean, Deprecated) Deprecated: the server ignores this flag and always replies in the triggering Slack thread. Kept for compatibility with existing configurations.
 
 
 

--- a/docs/resources/platform_workflow.md
+++ b/docs/resources/platform_workflow.md
@@ -64,6 +64,16 @@ resource "cursor_platform_workflow" "example_slack_triage" {
   name   = "Triage Slack reactions"
   prompt = "Investigate the message that received the reaction and reply in thread."
 
+  # Structured model choice. Auto tiers all share the "auto-smart" model ID and
+  # differ by optimize_for: "cost" (Auto Cost), "balanced" (Auto Balance) or
+  # "intelligence". Leave `model` unset: the server derives it from the selection.
+  model_selection = {
+    model_id = "auto-smart"
+    parameters = [
+      { id = "optimize_for", value = "cost" }
+    ]
+  }
+
   git_repo               = "github.com/example-org/example-repo"
   disabled_default_tools = ["open_git_pr"]
 
@@ -93,6 +103,14 @@ resource "cursor_platform_workflow" "example_slack_triage" {
 resource "cursor_platform_workflow" "example_incidents" {
   name   = "Incident responder"
   prompt = "Summarise the incident and open a PR with a proposed fix."
+
+  # Auto Balance.
+  model_selection = {
+    model_id = "auto-smart"
+    parameters = [
+      { id = "optimize_for", value = "balanced" }
+    ]
+  }
 
   git_repo = "github.com/example-org/example-repo"
 
@@ -139,7 +157,8 @@ resource "cursor_platform_workflow" "example_incidents" {
 - `git_branch` (String) Git branch for non-git triggers. Defaults to main.
 - `git_repo` (String) Git repository for non-git triggers (cron, slack, linear). E.g. github.com/org/repo.
 - `memory_enabled` (Boolean) Enable the AutomationMemory tool, giving the agent persistent memory across runs.
-- `model` (String) Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model.
+- `model` (String) Legacy model slug (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model. Cannot be combined with model_selection: when model_selection is set the server derives this value from it.
+- `model_selection` (Attributes) Structured model choice: a catalog model ID plus parameters the legacy model slug cannot carry. Use it to pick an Auto tier, e.g. model_id = "auto-smart" with parameters = [{ id = "optimize_for", value = "cost" }] (Auto Cost) or value = "balanced" (Auto Balance) or "intelligence". Takes priority over model at run time; leave model unset when using it. (see [below for nested schema](#nestedatt--model_selection))
 - `private_worker` (Attributes) Route this automation to private workers. An empty object targets any private worker; labels narrow the eligible workers. (see [below for nested schema](#nestedatt--private_worker))
 - `scope` (String) Automation ownership scope: "user", "team", "team_visible", "team_editable_user", or "team_editable". "user" is private (owner and admins only), "team" is shared (team admins can edit, runs as team service account), "team_visible" is viewable by team (team can view, only owner can edit, runs as owner), "team_editable_user" is editable by the team but still runs as the creator user, and "team_editable" is editable by the team and runs as the team service account. Defaults to "user" when unset.
 - `skip_install` (Boolean) Skip user install commands and cloud testing.
@@ -510,6 +529,28 @@ Optional:
 - `generalized` (Boolean) If true, agent can list and send to any Slack channel or DM dynamically.
 - `post_as_thread` (Boolean) If true, post a parent message with the automation name and reply in the thread.
 - `respond_in_thread` (Boolean, Deprecated) Deprecated: the server ignores this flag and always replies in the triggering Slack thread. Kept for compatibility with existing configurations.
+
+
+
+<a id="nestedatt--model_selection"></a>
+### Nested Schema for `model_selection`
+
+Required:
+
+- `model_id` (String) Catalog model ID (e.g. "auto-smart"). Use the canonical ID: the server rejects unknown IDs and rewrites aliases, which would show up as a diff.
+
+Optional:
+
+- `max_mode` (Boolean) Run the model in max mode. Defaults to true and is reported back as true; the server currently rejects false.
+- `parameters` (Attributes List) Parameter values selecting a model variant, e.g. { id = "optimize_for", value = "cost" }. Parameter IDs must be unique. When omitted the server picks the model's default variant and reports its parameters here. (see [below for nested schema](#nestedatt--model_selection--parameters))
+
+<a id="nestedatt--model_selection--parameters"></a>
+### Nested Schema for `model_selection.parameters`
+
+Required:
+
+- `id` (String) Parameter ID (e.g. optimize_for).
+- `value` (String) Parameter value. Enum parameters take one of their enum values (e.g. "cost", "balanced", "intelligence" for optimize_for); booleans take "true"/"false".
 
 
 

--- a/examples/resources/cursor_platform_workflow/resource.tf
+++ b/examples/resources/cursor_platform_workflow/resource.tf
@@ -49,6 +49,16 @@ resource "cursor_platform_workflow" "example_slack_triage" {
   name   = "Triage Slack reactions"
   prompt = "Investigate the message that received the reaction and reply in thread."
 
+  # Structured model choice. Auto tiers all share the "auto-smart" model ID and
+  # differ by optimize_for: "cost" (Auto Cost), "balanced" (Auto Balance) or
+  # "intelligence". Leave `model` unset: the server derives it from the selection.
+  model_selection = {
+    model_id = "auto-smart"
+    parameters = [
+      { id = "optimize_for", value = "cost" }
+    ]
+  }
+
   git_repo               = "github.com/example-org/example-repo"
   disabled_default_tools = ["open_git_pr"]
 
@@ -78,6 +88,14 @@ resource "cursor_platform_workflow" "example_slack_triage" {
 resource "cursor_platform_workflow" "example_incidents" {
   name   = "Incident responder"
   prompt = "Summarise the incident and open a PR with a proposed fix."
+
+  # Auto Balance.
+  model_selection = {
+    model_id = "auto-smart"
+    parameters = [
+      { id = "optimize_for", value = "balanced" }
+    ]
+  }
 
   git_repo = "github.com/example-org/example-repo"
 

--- a/examples/resources/cursor_platform_workflow/resource.tf
+++ b/examples/resources/cursor_platform_workflow/resource.tf
@@ -1,7 +1,8 @@
 resource "cursor_platform_workflow" "example_review" {
-  name    = "Example review automation"
-  scope   = "team"
-  enabled = true
+  name        = "Example review automation"
+  description = "Reviews pull requests and posts inline comments."
+  scope       = "team"
+  enabled     = true
 
   prompt = file("prompt.md")
   model  = "gpt-5.5"
@@ -31,9 +32,73 @@ resource "cursor_platform_workflow" "example_review" {
       }
     },
     {
+      manage_check_run = {}
+    },
+    {
+      resolve_review_threads = {}
+    },
+    {
       mcp = {
         server = "example-mcp-server"
       }
+    }
+  ]
+}
+
+resource "cursor_platform_workflow" "example_slack_triage" {
+  name   = "Triage Slack reactions"
+  prompt = "Investigate the message that received the reaction and reply in thread."
+
+  git_repo               = "github.com/example-org/example-repo"
+  disabled_default_tools = ["open_git_pr"]
+
+  trigger = [
+    {
+      slack_reaction_added = {
+        channel    = "C0123456789"
+        emoji_name = "eyes"
+      }
+    },
+    {
+      slack_mention = {
+        channel = "C0123456789"
+      }
+    }
+  ]
+
+  action = [
+    {
+      slack = {
+        channel = "C0123456789"
+      }
+    }
+  ]
+}
+
+resource "cursor_platform_workflow" "example_incidents" {
+  name   = "Incident responder"
+  prompt = "Summarise the incident and open a PR with a proposed fix."
+
+  git_repo = "github.com/example-org/example-repo"
+
+  trigger = [
+    {
+      pagerduty = {
+        incident_triggered = {}
+        service_ids        = ["PABC123"]
+      }
+    },
+    {
+      sentry = {
+        issue_created = {}
+        project_ids   = ["123456"]
+      }
+    }
+  ]
+
+  action = [
+    {
+      git_pr = {}
     }
   ]
 }

--- a/internal/proto/v1/automations.pb.go
+++ b/internal/proto/v1/automations.pb.go
@@ -1447,8 +1447,13 @@ type Workflow struct {
 	// that user. Absent on main routines (the owner's) and on session routines
 	// from before it was recorded, which are refused rather than run as the owner.
 	GrokBotCreatorAuthId *string `protobuf:"bytes,21,opt,name=grok_bot_creator_auth_id,json=grokBotCreatorAuthId,proto3,oneof" json:"grok_bot_creator_auth_id,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Structured form of `model`: model id plus parameters (e.g. Auto's
+	// optimize_for), which the legacy slug in `model` cannot carry. Writers set
+	// both; readers prefer this and fall back to `model` when it is absent or
+	// names a different model than `model` does.
+	ModelSelection *AutomationModelSelection `protobuf:"bytes,22,opt,name=model_selection,json=modelSelection,proto3,oneof" json:"model_selection,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Workflow) Reset() {
@@ -1579,6 +1584,13 @@ func (x *Workflow) GetGrokBotCreatorAuthId() string {
 	return ""
 }
 
+func (x *Workflow) GetModelSelection() *AutomationModelSelection {
+	if x != nil {
+		return x.ModelSelection
+	}
+	return nil
+}
+
 type Prompt struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Prompt string                 `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
@@ -1592,8 +1604,10 @@ type Prompt struct {
 	RunMode *PromptRunMode `protobuf:"varint,5,opt,name=run_mode,json=runMode,proto3,enum=aiserver.v1.PromptRunMode,oneof" json:"run_mode,omitempty"`
 	// Skip Slack hourglass / "is reviewing" status while this prompt runs.
 	SuppressSlackReaction *bool `protobuf:"varint,6,opt,name=suppress_slack_reaction,json=suppressSlackReaction,proto3,oneof" json:"suppress_slack_reaction,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Structured form of `model`, same contract as Workflow.model_selection.
+	ModelSelection *AutomationModelSelection `protobuf:"bytes,7,opt,name=model_selection,json=modelSelection,proto3,oneof" json:"model_selection,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Prompt) Reset() {
@@ -1668,6 +1682,77 @@ func (x *Prompt) GetSuppressSlackReaction() bool {
 	return false
 }
 
+func (x *Prompt) GetModelSelection() *AutomationModelSelection {
+	if x != nil {
+		return x.ModelSelection
+	}
+	return nil
+}
+
+// A durable model choice: the catalog model id plus the parameter values the
+// legacy slug cannot carry. Same shape as CloudAgentModelSelection, declared
+// here so the public Terraform provider's pruned copy of this file stays
+// self-contained.
+type AutomationModelSelection struct {
+	state         protoimpl.MessageState                     `protogen:"open.v1"`
+	ModelId       string                                     `protobuf:"bytes,1,opt,name=model_id,json=modelId,proto3" json:"model_id,omitempty"`
+	Parameters    []*AutomationModelSelection_ParameterValue `protobuf:"bytes,2,rep,name=parameters,proto3" json:"parameters,omitempty"`
+	MaxMode       *bool                                      `protobuf:"varint,3,opt,name=max_mode,json=maxMode,proto3,oneof" json:"max_mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AutomationModelSelection) Reset() {
+	*x = AutomationModelSelection{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AutomationModelSelection) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AutomationModelSelection) ProtoMessage() {}
+
+func (x *AutomationModelSelection) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AutomationModelSelection.ProtoReflect.Descriptor instead.
+func (*AutomationModelSelection) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *AutomationModelSelection) GetModelId() string {
+	if x != nil {
+		return x.ModelId
+	}
+	return ""
+}
+
+func (x *AutomationModelSelection) GetParameters() []*AutomationModelSelection_ParameterValue {
+	if x != nil {
+		return x.Parameters
+	}
+	return nil
+}
+
+func (x *AutomationModelSelection) GetMaxMode() bool {
+	if x != nil && x.MaxMode != nil {
+		return *x.MaxMode
+	}
+	return false
+}
+
 // Used in non-git triggers to define which repo to use.
 type GitConfig struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -1680,7 +1765,7 @@ type GitConfig struct {
 
 func (x *GitConfig) Reset() {
 	*x = GitConfig{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[9]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1692,7 +1777,7 @@ func (x *GitConfig) String() string {
 func (*GitConfig) ProtoMessage() {}
 
 func (x *GitConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[9]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1705,7 +1790,7 @@ func (x *GitConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitConfig.ProtoReflect.Descriptor instead.
 func (*GitConfig) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{9}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GitConfig) GetRepo() string {
@@ -1738,7 +1823,7 @@ type CronTrigger struct {
 
 func (x *CronTrigger) Reset() {
 	*x = CronTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[10]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1750,7 +1835,7 @@ func (x *CronTrigger) String() string {
 func (*CronTrigger) ProtoMessage() {}
 
 func (x *CronTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[10]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1763,7 +1848,7 @@ func (x *CronTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CronTrigger.ProtoReflect.Descriptor instead.
 func (*CronTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{10}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CronTrigger) GetCron() string {
@@ -1799,7 +1884,7 @@ type GitTrigger struct {
 
 func (x *GitTrigger) Reset() {
 	*x = GitTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[11]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1811,7 +1896,7 @@ func (x *GitTrigger) String() string {
 func (*GitTrigger) ProtoMessage() {}
 
 func (x *GitTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[11]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1824,7 +1909,7 @@ func (x *GitTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitTrigger.ProtoReflect.Descriptor instead.
 func (*GitTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{11}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *GitTrigger) GetEvent() isGitTrigger_Event {
@@ -2056,7 +2141,7 @@ type GitPullRequestEvent struct {
 
 func (x *GitPullRequestEvent) Reset() {
 	*x = GitPullRequestEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[12]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2068,7 +2153,7 @@ func (x *GitPullRequestEvent) String() string {
 func (*GitPullRequestEvent) ProtoMessage() {}
 
 func (x *GitPullRequestEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[12]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2081,7 +2166,7 @@ func (x *GitPullRequestEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPullRequestEvent.ProtoReflect.Descriptor instead.
 func (*GitPullRequestEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{12}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *GitPullRequestEvent) GetRepo() string {
@@ -2163,7 +2248,7 @@ type GitPullRequestReviewRequestedEvent struct {
 
 func (x *GitPullRequestReviewRequestedEvent) Reset() {
 	*x = GitPullRequestReviewRequestedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2175,7 +2260,7 @@ func (x *GitPullRequestReviewRequestedEvent) String() string {
 func (*GitPullRequestReviewRequestedEvent) ProtoMessage() {}
 
 func (x *GitPullRequestReviewRequestedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2188,7 +2273,7 @@ func (x *GitPullRequestReviewRequestedEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use GitPullRequestReviewRequestedEvent.ProtoReflect.Descriptor instead.
 func (*GitPullRequestReviewRequestedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{13}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *GitPullRequestReviewRequestedEvent) GetRepos() []string {
@@ -2207,7 +2292,7 @@ type GitIssueAssignedEvent struct {
 
 func (x *GitIssueAssignedEvent) Reset() {
 	*x = GitIssueAssignedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2219,7 +2304,7 @@ func (x *GitIssueAssignedEvent) String() string {
 func (*GitIssueAssignedEvent) ProtoMessage() {}
 
 func (x *GitIssueAssignedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2232,7 +2317,7 @@ func (x *GitIssueAssignedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitIssueAssignedEvent.ProtoReflect.Descriptor instead.
 func (*GitIssueAssignedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{14}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GitIssueAssignedEvent) GetRepos() []string {
@@ -2253,7 +2338,7 @@ type GitPushEvent struct {
 
 func (x *GitPushEvent) Reset() {
 	*x = GitPushEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2265,7 +2350,7 @@ func (x *GitPushEvent) String() string {
 func (*GitPushEvent) ProtoMessage() {}
 
 func (x *GitPushEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2278,7 +2363,7 @@ func (x *GitPushEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPushEvent.ProtoReflect.Descriptor instead.
 func (*GitPushEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{15}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GitPushEvent) GetRepo() string {
@@ -2321,7 +2406,7 @@ type GitCICompletedEvent struct {
 
 func (x *GitCICompletedEvent) Reset() {
 	*x = GitCICompletedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2333,7 +2418,7 @@ func (x *GitCICompletedEvent) String() string {
 func (*GitCICompletedEvent) ProtoMessage() {}
 
 func (x *GitCICompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2346,7 +2431,7 @@ func (x *GitCICompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitCICompletedEvent.ProtoReflect.Descriptor instead.
 func (*GitCICompletedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{16}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GitCICompletedEvent) GetRepos() []string {
@@ -2396,7 +2481,7 @@ type GitIssueLabeledEvent struct {
 
 func (x *GitIssueLabeledEvent) Reset() {
 	*x = GitIssueLabeledEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2408,7 +2493,7 @@ func (x *GitIssueLabeledEvent) String() string {
 func (*GitIssueLabeledEvent) ProtoMessage() {}
 
 func (x *GitIssueLabeledEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2421,7 +2506,7 @@ func (x *GitIssueLabeledEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitIssueLabeledEvent.ProtoReflect.Descriptor instead.
 func (*GitIssueLabeledEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{17}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GitIssueLabeledEvent) GetRepos() []string {
@@ -2465,7 +2550,7 @@ type GitIssueCommentEvent struct {
 
 func (x *GitIssueCommentEvent) Reset() {
 	*x = GitIssueCommentEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2477,7 +2562,7 @@ func (x *GitIssueCommentEvent) String() string {
 func (*GitIssueCommentEvent) ProtoMessage() {}
 
 func (x *GitIssueCommentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2490,7 +2575,7 @@ func (x *GitIssueCommentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitIssueCommentEvent.ProtoReflect.Descriptor instead.
 func (*GitIssueCommentEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{18}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GitIssueCommentEvent) GetRepos() []string {
@@ -2542,7 +2627,7 @@ type GitPullRequestReviewCommentEvent struct {
 
 func (x *GitPullRequestReviewCommentEvent) Reset() {
 	*x = GitPullRequestReviewCommentEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2554,7 +2639,7 @@ func (x *GitPullRequestReviewCommentEvent) String() string {
 func (*GitPullRequestReviewCommentEvent) ProtoMessage() {}
 
 func (x *GitPullRequestReviewCommentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2567,7 +2652,7 @@ func (x *GitPullRequestReviewCommentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPullRequestReviewCommentEvent.ProtoReflect.Descriptor instead.
 func (*GitPullRequestReviewCommentEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{19}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GitPullRequestReviewCommentEvent) GetRepos() []string {
@@ -2615,7 +2700,7 @@ type GitPullRequestReviewEvent struct {
 
 func (x *GitPullRequestReviewEvent) Reset() {
 	*x = GitPullRequestReviewEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2627,7 +2712,7 @@ func (x *GitPullRequestReviewEvent) String() string {
 func (*GitPullRequestReviewEvent) ProtoMessage() {}
 
 func (x *GitPullRequestReviewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2640,7 +2725,7 @@ func (x *GitPullRequestReviewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPullRequestReviewEvent.ProtoReflect.Descriptor instead.
 func (*GitPullRequestReviewEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{20}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GitPullRequestReviewEvent) GetRepos() []string {
@@ -2685,7 +2770,7 @@ type GitReviewThreadEvent struct {
 
 func (x *GitReviewThreadEvent) Reset() {
 	*x = GitReviewThreadEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2697,7 +2782,7 @@ func (x *GitReviewThreadEvent) String() string {
 func (*GitReviewThreadEvent) ProtoMessage() {}
 
 func (x *GitReviewThreadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2710,7 +2795,7 @@ func (x *GitReviewThreadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitReviewThreadEvent.ProtoReflect.Descriptor instead.
 func (*GitReviewThreadEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{21}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GitReviewThreadEvent) GetRepos() []string {
@@ -2753,7 +2838,7 @@ type GitWorkflowRunEvent struct {
 
 func (x *GitWorkflowRunEvent) Reset() {
 	*x = GitWorkflowRunEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2765,7 +2850,7 @@ func (x *GitWorkflowRunEvent) String() string {
 func (*GitWorkflowRunEvent) ProtoMessage() {}
 
 func (x *GitWorkflowRunEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2778,7 +2863,7 @@ func (x *GitWorkflowRunEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitWorkflowRunEvent.ProtoReflect.Descriptor instead.
 func (*GitWorkflowRunEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{22}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GitWorkflowRunEvent) GetRepos() []string {
@@ -2830,7 +2915,7 @@ type GitLabelEvent struct {
 
 func (x *GitLabelEvent) Reset() {
 	*x = GitLabelEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2842,7 +2927,7 @@ func (x *GitLabelEvent) String() string {
 func (*GitLabelEvent) ProtoMessage() {}
 
 func (x *GitLabelEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2855,7 +2940,7 @@ func (x *GitLabelEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitLabelEvent.ProtoReflect.Descriptor instead.
 func (*GitLabelEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{23}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GitLabelEvent) GetRepos() []string {
@@ -2929,7 +3014,7 @@ type SlackTrigger struct {
 
 func (x *SlackTrigger) Reset() {
 	*x = SlackTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2941,7 +3026,7 @@ func (x *SlackTrigger) String() string {
 func (*SlackTrigger) ProtoMessage() {}
 
 func (x *SlackTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2954,7 +3039,7 @@ func (x *SlackTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackTrigger.ProtoReflect.Descriptor instead.
 func (*SlackTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{24}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SlackTrigger) GetChannel() string {
@@ -3024,7 +3109,7 @@ type SlackChannelCreatedTrigger struct {
 
 func (x *SlackChannelCreatedTrigger) Reset() {
 	*x = SlackChannelCreatedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3036,7 +3121,7 @@ func (x *SlackChannelCreatedTrigger) String() string {
 func (*SlackChannelCreatedTrigger) ProtoMessage() {}
 
 func (x *SlackChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3049,7 +3134,7 @@ func (x *SlackChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackChannelCreatedTrigger.ProtoReflect.Descriptor instead.
 func (*SlackChannelCreatedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{25}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SlackChannelCreatedTrigger) GetChannelNameContains() string {
@@ -3082,7 +3167,7 @@ type SlackReactionAddedTrigger struct {
 
 func (x *SlackReactionAddedTrigger) Reset() {
 	*x = SlackReactionAddedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3094,7 +3179,7 @@ func (x *SlackReactionAddedTrigger) String() string {
 func (*SlackReactionAddedTrigger) ProtoMessage() {}
 
 func (x *SlackReactionAddedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3107,7 +3192,7 @@ func (x *SlackReactionAddedTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackReactionAddedTrigger.ProtoReflect.Descriptor instead.
 func (*SlackReactionAddedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{26}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *SlackReactionAddedTrigger) GetChannel() string {
@@ -3156,7 +3241,7 @@ type SlackMentionTrigger struct {
 
 func (x *SlackMentionTrigger) Reset() {
 	*x = SlackMentionTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3168,7 +3253,7 @@ func (x *SlackMentionTrigger) String() string {
 func (*SlackMentionTrigger) ProtoMessage() {}
 
 func (x *SlackMentionTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3181,7 +3266,7 @@ func (x *SlackMentionTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackMentionTrigger.ProtoReflect.Descriptor instead.
 func (*SlackMentionTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{27}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *SlackMentionTrigger) GetChannel() string {
@@ -3218,7 +3303,7 @@ type SlackAnyReactionAddedTrigger struct {
 
 func (x *SlackAnyReactionAddedTrigger) Reset() {
 	*x = SlackAnyReactionAddedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3230,7 +3315,7 @@ func (x *SlackAnyReactionAddedTrigger) String() string {
 func (*SlackAnyReactionAddedTrigger) ProtoMessage() {}
 
 func (x *SlackAnyReactionAddedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3243,7 +3328,7 @@ func (x *SlackAnyReactionAddedTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackAnyReactionAddedTrigger.ProtoReflect.Descriptor instead.
 func (*SlackAnyReactionAddedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{28}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SlackAnyReactionAddedTrigger) GetChannel() string {
@@ -3295,7 +3380,7 @@ type LinearTrigger struct {
 
 func (x *LinearTrigger) Reset() {
 	*x = LinearTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3307,7 +3392,7 @@ func (x *LinearTrigger) String() string {
 func (*LinearTrigger) ProtoMessage() {}
 
 func (x *LinearTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3320,7 +3405,7 @@ func (x *LinearTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearTrigger.ProtoReflect.Descriptor instead.
 func (*LinearTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{29}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *LinearTrigger) GetEvent() isLinearTrigger_Event {
@@ -3401,7 +3486,7 @@ type LinearIssueCreatedEvent struct {
 
 func (x *LinearIssueCreatedEvent) Reset() {
 	*x = LinearIssueCreatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3413,7 +3498,7 @@ func (x *LinearIssueCreatedEvent) String() string {
 func (*LinearIssueCreatedEvent) ProtoMessage() {}
 
 func (x *LinearIssueCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3426,7 +3511,7 @@ func (x *LinearIssueCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearIssueCreatedEvent.ProtoReflect.Descriptor instead.
 func (*LinearIssueCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{30}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{31}
 }
 
 type LinearStatusChangedEvent struct {
@@ -3439,7 +3524,7 @@ type LinearStatusChangedEvent struct {
 
 func (x *LinearStatusChangedEvent) Reset() {
 	*x = LinearStatusChangedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3451,7 +3536,7 @@ func (x *LinearStatusChangedEvent) String() string {
 func (*LinearStatusChangedEvent) ProtoMessage() {}
 
 func (x *LinearStatusChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3464,7 +3549,7 @@ func (x *LinearStatusChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearStatusChangedEvent.ProtoReflect.Descriptor instead.
 func (*LinearStatusChangedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{31}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LinearStatusChangedEvent) GetStatusIds() []string {
@@ -3484,7 +3569,7 @@ type LinearEndOfCycleEvent struct {
 
 func (x *LinearEndOfCycleEvent) Reset() {
 	*x = LinearEndOfCycleEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3496,7 +3581,7 @@ func (x *LinearEndOfCycleEvent) String() string {
 func (*LinearEndOfCycleEvent) ProtoMessage() {}
 
 func (x *LinearEndOfCycleEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3509,7 +3594,7 @@ func (x *LinearEndOfCycleEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearEndOfCycleEvent.ProtoReflect.Descriptor instead.
 func (*LinearEndOfCycleEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{32}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *LinearEndOfCycleEvent) GetCycleIds() []string {
@@ -3528,7 +3613,7 @@ type WebhookTrigger struct {
 
 func (x *WebhookTrigger) Reset() {
 	*x = WebhookTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3540,7 +3625,7 @@ func (x *WebhookTrigger) String() string {
 func (*WebhookTrigger) ProtoMessage() {}
 
 func (x *WebhookTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3553,7 +3638,7 @@ func (x *WebhookTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebhookTrigger.ProtoReflect.Descriptor instead.
 func (*WebhookTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{33}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{34}
 }
 
 // PagerDutyTrigger fires when PagerDuty incident events occur.
@@ -3576,7 +3661,7 @@ type PagerDutyTrigger struct {
 
 func (x *PagerDutyTrigger) Reset() {
 	*x = PagerDutyTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3588,7 +3673,7 @@ func (x *PagerDutyTrigger) String() string {
 func (*PagerDutyTrigger) ProtoMessage() {}
 
 func (x *PagerDutyTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3601,7 +3686,7 @@ func (x *PagerDutyTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyTrigger.ProtoReflect.Descriptor instead.
 func (*PagerDutyTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{34}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *PagerDutyTrigger) GetEvent() isPagerDutyTrigger_Event {
@@ -3705,7 +3790,7 @@ type PagerDutyIncidentTriggeredEvent struct {
 
 func (x *PagerDutyIncidentTriggeredEvent) Reset() {
 	*x = PagerDutyIncidentTriggeredEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3717,7 +3802,7 @@ func (x *PagerDutyIncidentTriggeredEvent) String() string {
 func (*PagerDutyIncidentTriggeredEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentTriggeredEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3730,7 +3815,7 @@ func (x *PagerDutyIncidentTriggeredEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentTriggeredEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentTriggeredEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{35}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{36}
 }
 
 type PagerDutyIncidentAcknowledgedEvent struct {
@@ -3741,7 +3826,7 @@ type PagerDutyIncidentAcknowledgedEvent struct {
 
 func (x *PagerDutyIncidentAcknowledgedEvent) Reset() {
 	*x = PagerDutyIncidentAcknowledgedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3753,7 +3838,7 @@ func (x *PagerDutyIncidentAcknowledgedEvent) String() string {
 func (*PagerDutyIncidentAcknowledgedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentAcknowledgedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3766,7 +3851,7 @@ func (x *PagerDutyIncidentAcknowledgedEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use PagerDutyIncidentAcknowledgedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentAcknowledgedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{36}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{37}
 }
 
 type PagerDutyIncidentResolvedEvent struct {
@@ -3777,7 +3862,7 @@ type PagerDutyIncidentResolvedEvent struct {
 
 func (x *PagerDutyIncidentResolvedEvent) Reset() {
 	*x = PagerDutyIncidentResolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3789,7 +3874,7 @@ func (x *PagerDutyIncidentResolvedEvent) String() string {
 func (*PagerDutyIncidentResolvedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentResolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3802,7 +3887,7 @@ func (x *PagerDutyIncidentResolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentResolvedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentResolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{37}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{38}
 }
 
 type PagerDutyIncidentEscalatedEvent struct {
@@ -3813,7 +3898,7 @@ type PagerDutyIncidentEscalatedEvent struct {
 
 func (x *PagerDutyIncidentEscalatedEvent) Reset() {
 	*x = PagerDutyIncidentEscalatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3825,7 +3910,7 @@ func (x *PagerDutyIncidentEscalatedEvent) String() string {
 func (*PagerDutyIncidentEscalatedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentEscalatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3838,7 +3923,7 @@ func (x *PagerDutyIncidentEscalatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentEscalatedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentEscalatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{38}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{39}
 }
 
 // Matches any incident event type (triggered, acknowledged, resolved, escalated).
@@ -3850,7 +3935,7 @@ type PagerDutyIncidentAnyEvent struct {
 
 func (x *PagerDutyIncidentAnyEvent) Reset() {
 	*x = PagerDutyIncidentAnyEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3862,7 +3947,7 @@ func (x *PagerDutyIncidentAnyEvent) String() string {
 func (*PagerDutyIncidentAnyEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentAnyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3875,7 +3960,7 @@ func (x *PagerDutyIncidentAnyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentAnyEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentAnyEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{39}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{40}
 }
 
 // SentryTrigger fires when Sentry issue webhooks are delivered to the Integration Platform
@@ -3901,7 +3986,7 @@ type SentryTrigger struct {
 
 func (x *SentryTrigger) Reset() {
 	*x = SentryTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3913,7 +3998,7 @@ func (x *SentryTrigger) String() string {
 func (*SentryTrigger) ProtoMessage() {}
 
 func (x *SentryTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3926,7 +4011,7 @@ func (x *SentryTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryTrigger.ProtoReflect.Descriptor instead.
 func (*SentryTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{40}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *SentryTrigger) GetEvent() isSentryTrigger_Event {
@@ -4045,7 +4130,7 @@ type SentryIssueCreatedEvent struct {
 
 func (x *SentryIssueCreatedEvent) Reset() {
 	*x = SentryIssueCreatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4057,7 +4142,7 @@ func (x *SentryIssueCreatedEvent) String() string {
 func (*SentryIssueCreatedEvent) ProtoMessage() {}
 
 func (x *SentryIssueCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4070,7 +4155,7 @@ func (x *SentryIssueCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueCreatedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{41}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{42}
 }
 
 type SentryIssueResolvedEvent struct {
@@ -4081,7 +4166,7 @@ type SentryIssueResolvedEvent struct {
 
 func (x *SentryIssueResolvedEvent) Reset() {
 	*x = SentryIssueResolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4093,7 +4178,7 @@ func (x *SentryIssueResolvedEvent) String() string {
 func (*SentryIssueResolvedEvent) ProtoMessage() {}
 
 func (x *SentryIssueResolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4106,7 +4191,7 @@ func (x *SentryIssueResolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueResolvedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueResolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{42}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{43}
 }
 
 type SentryIssueAssignedEvent struct {
@@ -4117,7 +4202,7 @@ type SentryIssueAssignedEvent struct {
 
 func (x *SentryIssueAssignedEvent) Reset() {
 	*x = SentryIssueAssignedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4129,7 +4214,7 @@ func (x *SentryIssueAssignedEvent) String() string {
 func (*SentryIssueAssignedEvent) ProtoMessage() {}
 
 func (x *SentryIssueAssignedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4142,7 +4227,7 @@ func (x *SentryIssueAssignedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueAssignedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueAssignedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{43}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{44}
 }
 
 type SentryIssueArchivedEvent struct {
@@ -4153,7 +4238,7 @@ type SentryIssueArchivedEvent struct {
 
 func (x *SentryIssueArchivedEvent) Reset() {
 	*x = SentryIssueArchivedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4165,7 +4250,7 @@ func (x *SentryIssueArchivedEvent) String() string {
 func (*SentryIssueArchivedEvent) ProtoMessage() {}
 
 func (x *SentryIssueArchivedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4178,7 +4263,7 @@ func (x *SentryIssueArchivedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueArchivedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueArchivedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{44}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{45}
 }
 
 type SentryIssueUnresolvedEvent struct {
@@ -4189,7 +4274,7 @@ type SentryIssueUnresolvedEvent struct {
 
 func (x *SentryIssueUnresolvedEvent) Reset() {
 	*x = SentryIssueUnresolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4201,7 +4286,7 @@ func (x *SentryIssueUnresolvedEvent) String() string {
 func (*SentryIssueUnresolvedEvent) ProtoMessage() {}
 
 func (x *SentryIssueUnresolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4214,7 +4299,7 @@ func (x *SentryIssueUnresolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueUnresolvedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueUnresolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{45}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{46}
 }
 
 type SentryIssueAnyEvent struct {
@@ -4225,7 +4310,7 @@ type SentryIssueAnyEvent struct {
 
 func (x *SentryIssueAnyEvent) Reset() {
 	*x = SentryIssueAnyEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4237,7 +4322,7 @@ func (x *SentryIssueAnyEvent) String() string {
 func (*SentryIssueAnyEvent) ProtoMessage() {}
 
 func (x *SentryIssueAnyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4250,7 +4335,7 @@ func (x *SentryIssueAnyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueAnyEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueAnyEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{46}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{47}
 }
 
 // MicrosoftTeamsTrigger fires when messages are posted in a configured
@@ -4289,7 +4374,7 @@ type MicrosoftTeamsTrigger struct {
 
 func (x *MicrosoftTeamsTrigger) Reset() {
 	*x = MicrosoftTeamsTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4301,7 +4386,7 @@ func (x *MicrosoftTeamsTrigger) String() string {
 func (*MicrosoftTeamsTrigger) ProtoMessage() {}
 
 func (x *MicrosoftTeamsTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4314,7 +4399,7 @@ func (x *MicrosoftTeamsTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosoftTeamsTrigger.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{47}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *MicrosoftTeamsTrigger) GetTenantId() string {
@@ -4383,7 +4468,7 @@ type MicrosoftTeamsChannelCreatedTrigger struct {
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) Reset() {
 	*x = MicrosoftTeamsChannelCreatedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4395,7 +4480,7 @@ func (x *MicrosoftTeamsChannelCreatedTrigger) String() string {
 func (*MicrosoftTeamsChannelCreatedTrigger) ProtoMessage() {}
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4408,7 +4493,7 @@ func (x *MicrosoftTeamsChannelCreatedTrigger) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use MicrosoftTeamsChannelCreatedTrigger.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsChannelCreatedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{48}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) GetTenantId() string {
@@ -4441,7 +4526,7 @@ type GitPrAction struct {
 
 func (x *GitPrAction) Reset() {
 	*x = GitPrAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4453,7 +4538,7 @@ func (x *GitPrAction) String() string {
 func (*GitPrAction) ProtoMessage() {}
 
 func (x *GitPrAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4466,7 +4551,7 @@ func (x *GitPrAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPrAction.ProtoReflect.Descriptor instead.
 func (*GitPrAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{49}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{50}
 }
 
 // Action: posts a comment/review on a PR. Defaults to the pull request from a
@@ -4489,7 +4574,7 @@ type PrCommentAction struct {
 
 func (x *PrCommentAction) Reset() {
 	*x = PrCommentAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4501,7 +4586,7 @@ func (x *PrCommentAction) String() string {
 func (*PrCommentAction) ProtoMessage() {}
 
 func (x *PrCommentAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4514,7 +4599,7 @@ func (x *PrCommentAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrCommentAction.ProtoReflect.Descriptor instead.
 func (*PrCommentAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{50}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{51}
 }
 
 // Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
@@ -4562,7 +4647,7 @@ type ManageCheckRunAction struct {
 
 func (x *ManageCheckRunAction) Reset() {
 	*x = ManageCheckRunAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4574,7 +4659,7 @@ func (x *ManageCheckRunAction) String() string {
 func (*ManageCheckRunAction) ProtoMessage() {}
 
 func (x *ManageCheckRunAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4587,7 +4672,7 @@ func (x *ManageCheckRunAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManageCheckRunAction.ProtoReflect.Descriptor instead.
 func (*ManageCheckRunAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{51}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{52}
 }
 
 // Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
@@ -4610,7 +4695,7 @@ type RequestReviewersAction struct {
 
 func (x *RequestReviewersAction) Reset() {
 	*x = RequestReviewersAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4622,7 +4707,7 @@ func (x *RequestReviewersAction) String() string {
 func (*RequestReviewersAction) ProtoMessage() {}
 
 func (x *RequestReviewersAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4635,7 +4720,7 @@ func (x *RequestReviewersAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestReviewersAction.ProtoReflect.Descriptor instead.
 func (*RequestReviewersAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{52}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{53}
 }
 
 // Deprecated: approve capability is now a field on PrCommentAction.allow_approve.
@@ -4650,7 +4735,7 @@ type ApprovePrAction struct {
 
 func (x *ApprovePrAction) Reset() {
 	*x = ApprovePrAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4662,7 +4747,7 @@ func (x *ApprovePrAction) String() string {
 func (*ApprovePrAction) ProtoMessage() {}
 
 func (x *ApprovePrAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4675,7 +4760,7 @@ func (x *ApprovePrAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApprovePrAction.ProtoReflect.Descriptor instead.
 func (*ApprovePrAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{53}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{54}
 }
 
 // Action: gives the agent read-only access to public Slack channels the user belongs to.
@@ -4688,7 +4773,7 @@ type ReadSlackAction struct {
 
 func (x *ReadSlackAction) Reset() {
 	*x = ReadSlackAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4700,7 +4785,7 @@ func (x *ReadSlackAction) String() string {
 func (*ReadSlackAction) ProtoMessage() {}
 
 func (x *ReadSlackAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4713,7 +4798,7 @@ func (x *ReadSlackAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSlackAction.ProtoReflect.Descriptor instead.
 func (*ReadSlackAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{54}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{55}
 }
 
 // Action: lets the automation mark its own prior PR review threads as addressed
@@ -4729,7 +4814,7 @@ type ResolveReviewThreadsAction struct {
 
 func (x *ResolveReviewThreadsAction) Reset() {
 	*x = ResolveReviewThreadsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4741,7 +4826,7 @@ func (x *ResolveReviewThreadsAction) String() string {
 func (*ResolveReviewThreadsAction) ProtoMessage() {}
 
 func (x *ResolveReviewThreadsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4754,7 +4839,7 @@ func (x *ResolveReviewThreadsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveReviewThreadsAction.ProtoReflect.Descriptor instead.
 func (*ResolveReviewThreadsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{55}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{56}
 }
 
 type SlackAction struct {
@@ -4776,7 +4861,7 @@ type SlackAction struct {
 
 func (x *SlackAction) Reset() {
 	*x = SlackAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4788,7 +4873,7 @@ func (x *SlackAction) String() string {
 func (*SlackAction) ProtoMessage() {}
 
 func (x *SlackAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4801,7 +4886,7 @@ func (x *SlackAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackAction.ProtoReflect.Descriptor instead.
 func (*SlackAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{56}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *SlackAction) GetChannel() string {
@@ -4873,7 +4958,7 @@ type MicrosoftTeamsAction struct {
 
 func (x *MicrosoftTeamsAction) Reset() {
 	*x = MicrosoftTeamsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4885,7 +4970,7 @@ func (x *MicrosoftTeamsAction) String() string {
 func (*MicrosoftTeamsAction) ProtoMessage() {}
 
 func (x *MicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4898,7 +4983,7 @@ func (x *MicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosoftTeamsAction.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{57}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *MicrosoftTeamsAction) GetTenantId() string {
@@ -4961,7 +5046,7 @@ type ReadMicrosoftTeamsAction struct {
 
 func (x *ReadMicrosoftTeamsAction) Reset() {
 	*x = ReadMicrosoftTeamsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4973,7 +5058,7 @@ func (x *ReadMicrosoftTeamsAction) String() string {
 func (*ReadMicrosoftTeamsAction) ProtoMessage() {}
 
 func (x *ReadMicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4986,7 +5071,7 @@ func (x *ReadMicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadMicrosoftTeamsAction.ProtoReflect.Descriptor instead.
 func (*ReadMicrosoftTeamsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{58}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{59}
 }
 
 type CreateAutomationRequest struct {
@@ -5014,7 +5099,7 @@ type CreateAutomationRequest struct {
 
 func (x *CreateAutomationRequest) Reset() {
 	*x = CreateAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5026,7 +5111,7 @@ func (x *CreateAutomationRequest) String() string {
 func (*CreateAutomationRequest) ProtoMessage() {}
 
 func (x *CreateAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5039,7 +5124,7 @@ func (x *CreateAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAutomationRequest.ProtoReflect.Descriptor instead.
 func (*CreateAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{59}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *CreateAutomationRequest) GetName() string {
@@ -5135,7 +5220,7 @@ type CreateAutomationResponse struct {
 
 func (x *CreateAutomationResponse) Reset() {
 	*x = CreateAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5147,7 +5232,7 @@ func (x *CreateAutomationResponse) String() string {
 func (*CreateAutomationResponse) ProtoMessage() {}
 
 func (x *CreateAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5160,7 +5245,7 @@ func (x *CreateAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAutomationResponse.ProtoReflect.Descriptor instead.
 func (*CreateAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{60}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *CreateAutomationResponse) GetWorkflow() *AutomationWithOwner {
@@ -5183,7 +5268,7 @@ type GetAutomationRequest struct {
 
 func (x *GetAutomationRequest) Reset() {
 	*x = GetAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5195,7 +5280,7 @@ func (x *GetAutomationRequest) String() string {
 func (*GetAutomationRequest) ProtoMessage() {}
 
 func (x *GetAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5208,7 +5293,7 @@ func (x *GetAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAutomationRequest.ProtoReflect.Descriptor instead.
 func (*GetAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{61}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetAutomationRequest) GetAutomationId() string {
@@ -5239,7 +5324,7 @@ type RestrictedAutomationSummary struct {
 
 func (x *RestrictedAutomationSummary) Reset() {
 	*x = RestrictedAutomationSummary{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5251,7 +5336,7 @@ func (x *RestrictedAutomationSummary) String() string {
 func (*RestrictedAutomationSummary) ProtoMessage() {}
 
 func (x *RestrictedAutomationSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5264,7 +5349,7 @@ func (x *RestrictedAutomationSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestrictedAutomationSummary.ProtoReflect.Descriptor instead.
 func (*RestrictedAutomationSummary) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{62}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *RestrictedAutomationSummary) GetAutomationId() string {
@@ -5308,7 +5393,7 @@ type GetAutomationResponse struct {
 
 func (x *GetAutomationResponse) Reset() {
 	*x = GetAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5320,7 +5405,7 @@ func (x *GetAutomationResponse) String() string {
 func (*GetAutomationResponse) ProtoMessage() {}
 
 func (x *GetAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5333,7 +5418,7 @@ func (x *GetAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAutomationResponse.ProtoReflect.Descriptor instead.
 func (*GetAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{63}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *GetAutomationResponse) GetResult() isGetAutomationResponse_Result {
@@ -5395,7 +5480,7 @@ type UpdateAutomationRequest struct {
 
 func (x *UpdateAutomationRequest) Reset() {
 	*x = UpdateAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5407,7 +5492,7 @@ func (x *UpdateAutomationRequest) String() string {
 func (*UpdateAutomationRequest) ProtoMessage() {}
 
 func (x *UpdateAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5420,7 +5505,7 @@ func (x *UpdateAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAutomationRequest.ProtoReflect.Descriptor instead.
 func (*UpdateAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{64}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpdateAutomationRequest) GetName() string {
@@ -5488,7 +5573,7 @@ type UpdateAutomationResponse struct {
 
 func (x *UpdateAutomationResponse) Reset() {
 	*x = UpdateAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5500,7 +5585,7 @@ func (x *UpdateAutomationResponse) String() string {
 func (*UpdateAutomationResponse) ProtoMessage() {}
 
 func (x *UpdateAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5513,7 +5598,7 @@ func (x *UpdateAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAutomationResponse.ProtoReflect.Descriptor instead.
 func (*UpdateAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{65}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *UpdateAutomationResponse) GetWorkflow() *AutomationWithOwner {
@@ -5533,7 +5618,7 @@ type DeleteAutomationRequest struct {
 
 func (x *DeleteAutomationRequest) Reset() {
 	*x = DeleteAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5545,7 +5630,7 @@ func (x *DeleteAutomationRequest) String() string {
 func (*DeleteAutomationRequest) ProtoMessage() {}
 
 func (x *DeleteAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5558,7 +5643,7 @@ func (x *DeleteAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAutomationRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{66}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DeleteAutomationRequest) GetAutomationId() string {
@@ -5576,7 +5661,7 @@ type DeleteAutomationResponse struct {
 
 func (x *DeleteAutomationResponse) Reset() {
 	*x = DeleteAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[67]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5588,7 +5673,7 @@ func (x *DeleteAutomationResponse) String() string {
 func (*DeleteAutomationResponse) ProtoMessage() {}
 
 func (x *DeleteAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[67]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5601,7 +5686,7 @@ func (x *DeleteAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAutomationResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{67}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{68}
 }
 
 type Automation struct {
@@ -5634,7 +5719,7 @@ type Automation struct {
 
 func (x *Automation) Reset() {
 	*x = Automation{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[68]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5646,7 +5731,7 @@ func (x *Automation) String() string {
 func (*Automation) ProtoMessage() {}
 
 func (x *Automation) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[68]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5659,7 +5744,7 @@ func (x *Automation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Automation.ProtoReflect.Descriptor instead.
 func (*Automation) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{68}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *Automation) GetName() string {
@@ -5792,7 +5877,7 @@ type AutomationMcpAuthState struct {
 
 func (x *AutomationMcpAuthState) Reset() {
 	*x = AutomationMcpAuthState{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[69]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5804,7 +5889,7 @@ func (x *AutomationMcpAuthState) String() string {
 func (*AutomationMcpAuthState) ProtoMessage() {}
 
 func (x *AutomationMcpAuthState) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[69]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5817,7 +5902,7 @@ func (x *AutomationMcpAuthState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AutomationMcpAuthState.ProtoReflect.Descriptor instead.
 func (*AutomationMcpAuthState) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{69}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *AutomationMcpAuthState) GetServerId() int64 {
@@ -5859,7 +5944,7 @@ type AutomationWithOwner struct {
 
 func (x *AutomationWithOwner) Reset() {
 	*x = AutomationWithOwner{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[70]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5871,7 +5956,7 @@ func (x *AutomationWithOwner) String() string {
 func (*AutomationWithOwner) ProtoMessage() {}
 
 func (x *AutomationWithOwner) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[70]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5884,7 +5969,7 @@ func (x *AutomationWithOwner) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AutomationWithOwner.ProtoReflect.Descriptor instead.
 func (*AutomationWithOwner) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{70}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *AutomationWithOwner) GetWorkflow() *Automation {
@@ -5920,6 +6005,59 @@ func (x *AutomationWithOwner) GetTeamId() int32 {
 		return *x.TeamId
 	}
 	return 0
+}
+
+type AutomationModelSelection_ParameterValue struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Enum parameters carry one of the enum values; booleans carry "true"/"false".
+	Value         string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AutomationModelSelection_ParameterValue) Reset() {
+	*x = AutomationModelSelection_ParameterValue{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[72]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AutomationModelSelection_ParameterValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AutomationModelSelection_ParameterValue) ProtoMessage() {}
+
+func (x *AutomationModelSelection_ParameterValue) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[72]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AutomationModelSelection_ParameterValue.ProtoReflect.Descriptor instead.
+func (*AutomationModelSelection_ParameterValue) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{9, 0}
+}
+
+func (x *AutomationModelSelection_ParameterValue) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *AutomationModelSelection_ParameterValue) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
 }
 
 var File_aiserver_v1_automations_proto protoreflect.FileDescriptor
@@ -5979,7 +6117,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x15environment_public_id\x18\x03 \x01(\tH\x02R\x13environmentPublicId\x88\x01\x01B\x0f\n" +
 	"\r_skip_installB\x11\n" +
 	"\x0f_private_workerB\x18\n" +
-	"\x16_environment_public_id\"\xf5\b\n" +
+	"\x16_environment_public_id\"\xde\t\n" +
 	"\bWorkflow\x120\n" +
 	"\btriggers\x18\n" +
 	" \x03(\v2\x14.aiserver.v1.TriggerR\btriggers\x12-\n" +
@@ -5996,7 +6134,8 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x0emanaged_config\x18\x12 \x01(\v2\x17.google.protobuf.StructH\x06R\rmanagedConfig\x88\x01\x01\x12X\n" +
 	"\x16disabled_default_tools\x18\x13 \x03(\x0e2\".aiserver.v1.AutomationDefaultToolR\x14disabledDefaultTools\x122\n" +
 	"\x13grok_bot_session_id\x18\x14 \x01(\tH\aR\x10grokBotSessionId\x88\x01\x01\x12;\n" +
-	"\x18grok_bot_creator_auth_id\x18\x15 \x01(\tH\bR\x14grokBotCreatorAuthId\x88\x01\x01B\b\n" +
+	"\x18grok_bot_creator_auth_id\x18\x15 \x01(\tH\bR\x14grokBotCreatorAuthId\x88\x01\x01\x12S\n" +
+	"\x0fmodel_selection\x18\x16 \x01(\v2%.aiserver.v1.AutomationModelSelectionH\tR\x0emodelSelection\x88\x01\x01B\b\n" +
 	"\x06_modelB\r\n" +
 	"\v_git_configB\x10\n" +
 	"\x0e_agent_optionsB\x11\n" +
@@ -6005,20 +6144,33 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"'_slack_completion_reaction_custom_emojiB\x11\n" +
 	"\x0f_managed_configB\x16\n" +
 	"\x14_grok_bot_session_idB\x1b\n" +
-	"\x19_grok_bot_creator_auth_idJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
-	"\"\xda\x02\n" +
+	"\x19_grok_bot_creator_auth_idB\x12\n" +
+	"\x10_model_selectionJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
+	"\"\xc3\x03\n" +
 	"\x06Prompt\x12\x16\n" +
 	"\x06prompt\x18\x01 \x01(\tR\x06prompt\x12A\n" +
 	"\feffort_level\x18\x02 \x01(\x0e2\x1e.aiserver.v1.PromptEffortLevelR\veffortLevel\x12\x19\n" +
 	"\x05model\x18\x03 \x01(\tH\x00R\x05model\x88\x01\x01\x12 \n" +
 	"\tis_filter\x18\x04 \x01(\bH\x01R\bisFilter\x88\x01\x01\x12:\n" +
 	"\brun_mode\x18\x05 \x01(\x0e2\x1a.aiserver.v1.PromptRunModeH\x02R\arunMode\x88\x01\x01\x12;\n" +
-	"\x17suppress_slack_reaction\x18\x06 \x01(\bH\x03R\x15suppressSlackReaction\x88\x01\x01B\b\n" +
+	"\x17suppress_slack_reaction\x18\x06 \x01(\bH\x03R\x15suppressSlackReaction\x88\x01\x01\x12S\n" +
+	"\x0fmodel_selection\x18\a \x01(\v2%.aiserver.v1.AutomationModelSelectionH\x04R\x0emodelSelection\x88\x01\x01B\b\n" +
 	"\x06_modelB\f\n" +
 	"\n" +
 	"_is_filterB\v\n" +
 	"\t_run_modeB\x1a\n" +
-	"\x18_suppress_slack_reaction\"Y\n" +
+	"\x18_suppress_slack_reactionB\x12\n" +
+	"\x10_model_selection\"\xf0\x01\n" +
+	"\x18AutomationModelSelection\x12\x19\n" +
+	"\bmodel_id\x18\x01 \x01(\tR\amodelId\x12T\n" +
+	"\n" +
+	"parameters\x18\x02 \x03(\v24.aiserver.v1.AutomationModelSelection.ParameterValueR\n" +
+	"parameters\x12\x1e\n" +
+	"\bmax_mode\x18\x03 \x01(\bH\x00R\amaxMode\x88\x01\x01\x1a6\n" +
+	"\x0eParameterValue\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05valueB\v\n" +
+	"\t_max_mode\"Y\n" +
 	"\tGitConfig\x12\x12\n" +
 	"\x04repo\x18\x03 \x01(\tR\x04repo\x12\x16\n" +
 	"\x06branch\x18\x04 \x01(\tR\x06branch\x12\x14\n" +
@@ -6425,188 +6577,193 @@ func file_aiserver_v1_automations_proto_rawDescGZIP() []byte {
 }
 
 var file_aiserver_v1_automations_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_aiserver_v1_automations_proto_msgTypes = make([]protoimpl.MessageInfo, 71)
+var file_aiserver_v1_automations_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
 var file_aiserver_v1_automations_proto_goTypes = []any{
-	(AutomationDefaultTool)(0),                  // 0: aiserver.v1.AutomationDefaultTool
-	(SlackCompletionReactionMode)(0),            // 1: aiserver.v1.SlackCompletionReactionMode
-	(AutomationScope)(0),                        // 2: aiserver.v1.AutomationScope
-	(AutomationCreationSource)(0),               // 3: aiserver.v1.AutomationCreationSource
-	(AutomationManagedBy)(0),                    // 4: aiserver.v1.AutomationManagedBy
-	(PromptEffortLevel)(0),                      // 5: aiserver.v1.PromptEffortLevel
-	(PromptRunMode)(0),                          // 6: aiserver.v1.PromptRunMode
-	(GitPullRequestAction)(0),                   // 7: aiserver.v1.GitPullRequestAction
-	(GitCICompletionCondition)(0),               // 8: aiserver.v1.GitCICompletionCondition
-	(GitWorkflowRunConclusion)(0),               // 9: aiserver.v1.GitWorkflowRunConclusion
-	(McpAuthState)(0),                           // 10: aiserver.v1.McpAuthState
-	(*Trigger)(nil),                             // 11: aiserver.v1.Trigger
-	(*Action)(nil),                              // 12: aiserver.v1.Action
-	(*McpAction)(nil),                           // 13: aiserver.v1.McpAction
-	(*McpServerConfig)(nil),                     // 14: aiserver.v1.McpServerConfig
-	(*AgentPrivateWorkerLabel)(nil),             // 15: aiserver.v1.AgentPrivateWorkerLabel
-	(*AgentPrivateWorkerConfig)(nil),            // 16: aiserver.v1.AgentPrivateWorkerConfig
-	(*AgentOptions)(nil),                        // 17: aiserver.v1.AgentOptions
-	(*Workflow)(nil),                            // 18: aiserver.v1.Workflow
-	(*Prompt)(nil),                              // 19: aiserver.v1.Prompt
-	(*GitConfig)(nil),                           // 20: aiserver.v1.GitConfig
-	(*CronTrigger)(nil),                         // 21: aiserver.v1.CronTrigger
-	(*GitTrigger)(nil),                          // 22: aiserver.v1.GitTrigger
-	(*GitPullRequestEvent)(nil),                 // 23: aiserver.v1.GitPullRequestEvent
-	(*GitPullRequestReviewRequestedEvent)(nil),  // 24: aiserver.v1.GitPullRequestReviewRequestedEvent
-	(*GitIssueAssignedEvent)(nil),               // 25: aiserver.v1.GitIssueAssignedEvent
-	(*GitPushEvent)(nil),                        // 26: aiserver.v1.GitPushEvent
-	(*GitCICompletedEvent)(nil),                 // 27: aiserver.v1.GitCICompletedEvent
-	(*GitIssueLabeledEvent)(nil),                // 28: aiserver.v1.GitIssueLabeledEvent
-	(*GitIssueCommentEvent)(nil),                // 29: aiserver.v1.GitIssueCommentEvent
-	(*GitPullRequestReviewCommentEvent)(nil),    // 30: aiserver.v1.GitPullRequestReviewCommentEvent
-	(*GitPullRequestReviewEvent)(nil),           // 31: aiserver.v1.GitPullRequestReviewEvent
-	(*GitReviewThreadEvent)(nil),                // 32: aiserver.v1.GitReviewThreadEvent
-	(*GitWorkflowRunEvent)(nil),                 // 33: aiserver.v1.GitWorkflowRunEvent
-	(*GitLabelEvent)(nil),                       // 34: aiserver.v1.GitLabelEvent
-	(*SlackTrigger)(nil),                        // 35: aiserver.v1.SlackTrigger
-	(*SlackChannelCreatedTrigger)(nil),          // 36: aiserver.v1.SlackChannelCreatedTrigger
-	(*SlackReactionAddedTrigger)(nil),           // 37: aiserver.v1.SlackReactionAddedTrigger
-	(*SlackMentionTrigger)(nil),                 // 38: aiserver.v1.SlackMentionTrigger
-	(*SlackAnyReactionAddedTrigger)(nil),        // 39: aiserver.v1.SlackAnyReactionAddedTrigger
-	(*LinearTrigger)(nil),                       // 40: aiserver.v1.LinearTrigger
-	(*LinearIssueCreatedEvent)(nil),             // 41: aiserver.v1.LinearIssueCreatedEvent
-	(*LinearStatusChangedEvent)(nil),            // 42: aiserver.v1.LinearStatusChangedEvent
-	(*LinearEndOfCycleEvent)(nil),               // 43: aiserver.v1.LinearEndOfCycleEvent
-	(*WebhookTrigger)(nil),                      // 44: aiserver.v1.WebhookTrigger
-	(*PagerDutyTrigger)(nil),                    // 45: aiserver.v1.PagerDutyTrigger
-	(*PagerDutyIncidentTriggeredEvent)(nil),     // 46: aiserver.v1.PagerDutyIncidentTriggeredEvent
-	(*PagerDutyIncidentAcknowledgedEvent)(nil),  // 47: aiserver.v1.PagerDutyIncidentAcknowledgedEvent
-	(*PagerDutyIncidentResolvedEvent)(nil),      // 48: aiserver.v1.PagerDutyIncidentResolvedEvent
-	(*PagerDutyIncidentEscalatedEvent)(nil),     // 49: aiserver.v1.PagerDutyIncidentEscalatedEvent
-	(*PagerDutyIncidentAnyEvent)(nil),           // 50: aiserver.v1.PagerDutyIncidentAnyEvent
-	(*SentryTrigger)(nil),                       // 51: aiserver.v1.SentryTrigger
-	(*SentryIssueCreatedEvent)(nil),             // 52: aiserver.v1.SentryIssueCreatedEvent
-	(*SentryIssueResolvedEvent)(nil),            // 53: aiserver.v1.SentryIssueResolvedEvent
-	(*SentryIssueAssignedEvent)(nil),            // 54: aiserver.v1.SentryIssueAssignedEvent
-	(*SentryIssueArchivedEvent)(nil),            // 55: aiserver.v1.SentryIssueArchivedEvent
-	(*SentryIssueUnresolvedEvent)(nil),          // 56: aiserver.v1.SentryIssueUnresolvedEvent
-	(*SentryIssueAnyEvent)(nil),                 // 57: aiserver.v1.SentryIssueAnyEvent
-	(*MicrosoftTeamsTrigger)(nil),               // 58: aiserver.v1.MicrosoftTeamsTrigger
-	(*MicrosoftTeamsChannelCreatedTrigger)(nil), // 59: aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
-	(*GitPrAction)(nil),                         // 60: aiserver.v1.GitPrAction
-	(*PrCommentAction)(nil),                     // 61: aiserver.v1.PrCommentAction
-	(*ManageCheckRunAction)(nil),                // 62: aiserver.v1.ManageCheckRunAction
-	(*RequestReviewersAction)(nil),              // 63: aiserver.v1.RequestReviewersAction
-	(*ApprovePrAction)(nil),                     // 64: aiserver.v1.ApprovePrAction
-	(*ReadSlackAction)(nil),                     // 65: aiserver.v1.ReadSlackAction
-	(*ResolveReviewThreadsAction)(nil),          // 66: aiserver.v1.ResolveReviewThreadsAction
-	(*SlackAction)(nil),                         // 67: aiserver.v1.SlackAction
-	(*MicrosoftTeamsAction)(nil),                // 68: aiserver.v1.MicrosoftTeamsAction
-	(*ReadMicrosoftTeamsAction)(nil),            // 69: aiserver.v1.ReadMicrosoftTeamsAction
-	(*CreateAutomationRequest)(nil),             // 70: aiserver.v1.CreateAutomationRequest
-	(*CreateAutomationResponse)(nil),            // 71: aiserver.v1.CreateAutomationResponse
-	(*GetAutomationRequest)(nil),                // 72: aiserver.v1.GetAutomationRequest
-	(*RestrictedAutomationSummary)(nil),         // 73: aiserver.v1.RestrictedAutomationSummary
-	(*GetAutomationResponse)(nil),               // 74: aiserver.v1.GetAutomationResponse
-	(*UpdateAutomationRequest)(nil),             // 75: aiserver.v1.UpdateAutomationRequest
-	(*UpdateAutomationResponse)(nil),            // 76: aiserver.v1.UpdateAutomationResponse
-	(*DeleteAutomationRequest)(nil),             // 77: aiserver.v1.DeleteAutomationRequest
-	(*DeleteAutomationResponse)(nil),            // 78: aiserver.v1.DeleteAutomationResponse
-	(*Automation)(nil),                          // 79: aiserver.v1.Automation
-	(*AutomationMcpAuthState)(nil),              // 80: aiserver.v1.AutomationMcpAuthState
-	(*AutomationWithOwner)(nil),                 // 81: aiserver.v1.AutomationWithOwner
-	(*structpb.Struct)(nil),                     // 82: google.protobuf.Struct
+	(AutomationDefaultTool)(0),                      // 0: aiserver.v1.AutomationDefaultTool
+	(SlackCompletionReactionMode)(0),                // 1: aiserver.v1.SlackCompletionReactionMode
+	(AutomationScope)(0),                            // 2: aiserver.v1.AutomationScope
+	(AutomationCreationSource)(0),                   // 3: aiserver.v1.AutomationCreationSource
+	(AutomationManagedBy)(0),                        // 4: aiserver.v1.AutomationManagedBy
+	(PromptEffortLevel)(0),                          // 5: aiserver.v1.PromptEffortLevel
+	(PromptRunMode)(0),                              // 6: aiserver.v1.PromptRunMode
+	(GitPullRequestAction)(0),                       // 7: aiserver.v1.GitPullRequestAction
+	(GitCICompletionCondition)(0),                   // 8: aiserver.v1.GitCICompletionCondition
+	(GitWorkflowRunConclusion)(0),                   // 9: aiserver.v1.GitWorkflowRunConclusion
+	(McpAuthState)(0),                               // 10: aiserver.v1.McpAuthState
+	(*Trigger)(nil),                                 // 11: aiserver.v1.Trigger
+	(*Action)(nil),                                  // 12: aiserver.v1.Action
+	(*McpAction)(nil),                               // 13: aiserver.v1.McpAction
+	(*McpServerConfig)(nil),                         // 14: aiserver.v1.McpServerConfig
+	(*AgentPrivateWorkerLabel)(nil),                 // 15: aiserver.v1.AgentPrivateWorkerLabel
+	(*AgentPrivateWorkerConfig)(nil),                // 16: aiserver.v1.AgentPrivateWorkerConfig
+	(*AgentOptions)(nil),                            // 17: aiserver.v1.AgentOptions
+	(*Workflow)(nil),                                // 18: aiserver.v1.Workflow
+	(*Prompt)(nil),                                  // 19: aiserver.v1.Prompt
+	(*AutomationModelSelection)(nil),                // 20: aiserver.v1.AutomationModelSelection
+	(*GitConfig)(nil),                               // 21: aiserver.v1.GitConfig
+	(*CronTrigger)(nil),                             // 22: aiserver.v1.CronTrigger
+	(*GitTrigger)(nil),                              // 23: aiserver.v1.GitTrigger
+	(*GitPullRequestEvent)(nil),                     // 24: aiserver.v1.GitPullRequestEvent
+	(*GitPullRequestReviewRequestedEvent)(nil),      // 25: aiserver.v1.GitPullRequestReviewRequestedEvent
+	(*GitIssueAssignedEvent)(nil),                   // 26: aiserver.v1.GitIssueAssignedEvent
+	(*GitPushEvent)(nil),                            // 27: aiserver.v1.GitPushEvent
+	(*GitCICompletedEvent)(nil),                     // 28: aiserver.v1.GitCICompletedEvent
+	(*GitIssueLabeledEvent)(nil),                    // 29: aiserver.v1.GitIssueLabeledEvent
+	(*GitIssueCommentEvent)(nil),                    // 30: aiserver.v1.GitIssueCommentEvent
+	(*GitPullRequestReviewCommentEvent)(nil),        // 31: aiserver.v1.GitPullRequestReviewCommentEvent
+	(*GitPullRequestReviewEvent)(nil),               // 32: aiserver.v1.GitPullRequestReviewEvent
+	(*GitReviewThreadEvent)(nil),                    // 33: aiserver.v1.GitReviewThreadEvent
+	(*GitWorkflowRunEvent)(nil),                     // 34: aiserver.v1.GitWorkflowRunEvent
+	(*GitLabelEvent)(nil),                           // 35: aiserver.v1.GitLabelEvent
+	(*SlackTrigger)(nil),                            // 36: aiserver.v1.SlackTrigger
+	(*SlackChannelCreatedTrigger)(nil),              // 37: aiserver.v1.SlackChannelCreatedTrigger
+	(*SlackReactionAddedTrigger)(nil),               // 38: aiserver.v1.SlackReactionAddedTrigger
+	(*SlackMentionTrigger)(nil),                     // 39: aiserver.v1.SlackMentionTrigger
+	(*SlackAnyReactionAddedTrigger)(nil),            // 40: aiserver.v1.SlackAnyReactionAddedTrigger
+	(*LinearTrigger)(nil),                           // 41: aiserver.v1.LinearTrigger
+	(*LinearIssueCreatedEvent)(nil),                 // 42: aiserver.v1.LinearIssueCreatedEvent
+	(*LinearStatusChangedEvent)(nil),                // 43: aiserver.v1.LinearStatusChangedEvent
+	(*LinearEndOfCycleEvent)(nil),                   // 44: aiserver.v1.LinearEndOfCycleEvent
+	(*WebhookTrigger)(nil),                          // 45: aiserver.v1.WebhookTrigger
+	(*PagerDutyTrigger)(nil),                        // 46: aiserver.v1.PagerDutyTrigger
+	(*PagerDutyIncidentTriggeredEvent)(nil),         // 47: aiserver.v1.PagerDutyIncidentTriggeredEvent
+	(*PagerDutyIncidentAcknowledgedEvent)(nil),      // 48: aiserver.v1.PagerDutyIncidentAcknowledgedEvent
+	(*PagerDutyIncidentResolvedEvent)(nil),          // 49: aiserver.v1.PagerDutyIncidentResolvedEvent
+	(*PagerDutyIncidentEscalatedEvent)(nil),         // 50: aiserver.v1.PagerDutyIncidentEscalatedEvent
+	(*PagerDutyIncidentAnyEvent)(nil),               // 51: aiserver.v1.PagerDutyIncidentAnyEvent
+	(*SentryTrigger)(nil),                           // 52: aiserver.v1.SentryTrigger
+	(*SentryIssueCreatedEvent)(nil),                 // 53: aiserver.v1.SentryIssueCreatedEvent
+	(*SentryIssueResolvedEvent)(nil),                // 54: aiserver.v1.SentryIssueResolvedEvent
+	(*SentryIssueAssignedEvent)(nil),                // 55: aiserver.v1.SentryIssueAssignedEvent
+	(*SentryIssueArchivedEvent)(nil),                // 56: aiserver.v1.SentryIssueArchivedEvent
+	(*SentryIssueUnresolvedEvent)(nil),              // 57: aiserver.v1.SentryIssueUnresolvedEvent
+	(*SentryIssueAnyEvent)(nil),                     // 58: aiserver.v1.SentryIssueAnyEvent
+	(*MicrosoftTeamsTrigger)(nil),                   // 59: aiserver.v1.MicrosoftTeamsTrigger
+	(*MicrosoftTeamsChannelCreatedTrigger)(nil),     // 60: aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
+	(*GitPrAction)(nil),                             // 61: aiserver.v1.GitPrAction
+	(*PrCommentAction)(nil),                         // 62: aiserver.v1.PrCommentAction
+	(*ManageCheckRunAction)(nil),                    // 63: aiserver.v1.ManageCheckRunAction
+	(*RequestReviewersAction)(nil),                  // 64: aiserver.v1.RequestReviewersAction
+	(*ApprovePrAction)(nil),                         // 65: aiserver.v1.ApprovePrAction
+	(*ReadSlackAction)(nil),                         // 66: aiserver.v1.ReadSlackAction
+	(*ResolveReviewThreadsAction)(nil),              // 67: aiserver.v1.ResolveReviewThreadsAction
+	(*SlackAction)(nil),                             // 68: aiserver.v1.SlackAction
+	(*MicrosoftTeamsAction)(nil),                    // 69: aiserver.v1.MicrosoftTeamsAction
+	(*ReadMicrosoftTeamsAction)(nil),                // 70: aiserver.v1.ReadMicrosoftTeamsAction
+	(*CreateAutomationRequest)(nil),                 // 71: aiserver.v1.CreateAutomationRequest
+	(*CreateAutomationResponse)(nil),                // 72: aiserver.v1.CreateAutomationResponse
+	(*GetAutomationRequest)(nil),                    // 73: aiserver.v1.GetAutomationRequest
+	(*RestrictedAutomationSummary)(nil),             // 74: aiserver.v1.RestrictedAutomationSummary
+	(*GetAutomationResponse)(nil),                   // 75: aiserver.v1.GetAutomationResponse
+	(*UpdateAutomationRequest)(nil),                 // 76: aiserver.v1.UpdateAutomationRequest
+	(*UpdateAutomationResponse)(nil),                // 77: aiserver.v1.UpdateAutomationResponse
+	(*DeleteAutomationRequest)(nil),                 // 78: aiserver.v1.DeleteAutomationRequest
+	(*DeleteAutomationResponse)(nil),                // 79: aiserver.v1.DeleteAutomationResponse
+	(*Automation)(nil),                              // 80: aiserver.v1.Automation
+	(*AutomationMcpAuthState)(nil),                  // 81: aiserver.v1.AutomationMcpAuthState
+	(*AutomationWithOwner)(nil),                     // 82: aiserver.v1.AutomationWithOwner
+	(*AutomationModelSelection_ParameterValue)(nil), // 83: aiserver.v1.AutomationModelSelection.ParameterValue
+	(*structpb.Struct)(nil),                         // 84: google.protobuf.Struct
 }
 var file_aiserver_v1_automations_proto_depIdxs = []int32{
-	21, // 0: aiserver.v1.Trigger.cron:type_name -> aiserver.v1.CronTrigger
-	22, // 1: aiserver.v1.Trigger.git:type_name -> aiserver.v1.GitTrigger
-	35, // 2: aiserver.v1.Trigger.slack_trigger:type_name -> aiserver.v1.SlackTrigger
-	40, // 3: aiserver.v1.Trigger.linear:type_name -> aiserver.v1.LinearTrigger
-	44, // 4: aiserver.v1.Trigger.webhook:type_name -> aiserver.v1.WebhookTrigger
-	36, // 5: aiserver.v1.Trigger.slack_channel_created:type_name -> aiserver.v1.SlackChannelCreatedTrigger
-	45, // 6: aiserver.v1.Trigger.pagerduty:type_name -> aiserver.v1.PagerDutyTrigger
-	51, // 7: aiserver.v1.Trigger.sentry:type_name -> aiserver.v1.SentryTrigger
-	58, // 8: aiserver.v1.Trigger.microsoft_teams_trigger:type_name -> aiserver.v1.MicrosoftTeamsTrigger
-	59, // 9: aiserver.v1.Trigger.microsoft_teams_channel_created:type_name -> aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
-	37, // 10: aiserver.v1.Trigger.slack_reaction_added:type_name -> aiserver.v1.SlackReactionAddedTrigger
-	38, // 11: aiserver.v1.Trigger.slack_mention:type_name -> aiserver.v1.SlackMentionTrigger
-	39, // 12: aiserver.v1.Trigger.slack_any_reaction_added:type_name -> aiserver.v1.SlackAnyReactionAddedTrigger
-	60, // 13: aiserver.v1.Action.git_pr:type_name -> aiserver.v1.GitPrAction
-	61, // 14: aiserver.v1.Action.pr_comment:type_name -> aiserver.v1.PrCommentAction
-	67, // 15: aiserver.v1.Action.slack:type_name -> aiserver.v1.SlackAction
+	22, // 0: aiserver.v1.Trigger.cron:type_name -> aiserver.v1.CronTrigger
+	23, // 1: aiserver.v1.Trigger.git:type_name -> aiserver.v1.GitTrigger
+	36, // 2: aiserver.v1.Trigger.slack_trigger:type_name -> aiserver.v1.SlackTrigger
+	41, // 3: aiserver.v1.Trigger.linear:type_name -> aiserver.v1.LinearTrigger
+	45, // 4: aiserver.v1.Trigger.webhook:type_name -> aiserver.v1.WebhookTrigger
+	37, // 5: aiserver.v1.Trigger.slack_channel_created:type_name -> aiserver.v1.SlackChannelCreatedTrigger
+	46, // 6: aiserver.v1.Trigger.pagerduty:type_name -> aiserver.v1.PagerDutyTrigger
+	52, // 7: aiserver.v1.Trigger.sentry:type_name -> aiserver.v1.SentryTrigger
+	59, // 8: aiserver.v1.Trigger.microsoft_teams_trigger:type_name -> aiserver.v1.MicrosoftTeamsTrigger
+	60, // 9: aiserver.v1.Trigger.microsoft_teams_channel_created:type_name -> aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
+	38, // 10: aiserver.v1.Trigger.slack_reaction_added:type_name -> aiserver.v1.SlackReactionAddedTrigger
+	39, // 11: aiserver.v1.Trigger.slack_mention:type_name -> aiserver.v1.SlackMentionTrigger
+	40, // 12: aiserver.v1.Trigger.slack_any_reaction_added:type_name -> aiserver.v1.SlackAnyReactionAddedTrigger
+	61, // 13: aiserver.v1.Action.git_pr:type_name -> aiserver.v1.GitPrAction
+	62, // 14: aiserver.v1.Action.pr_comment:type_name -> aiserver.v1.PrCommentAction
+	68, // 15: aiserver.v1.Action.slack:type_name -> aiserver.v1.SlackAction
 	13, // 16: aiserver.v1.Action.mcp:type_name -> aiserver.v1.McpAction
-	62, // 17: aiserver.v1.Action.manage_check_run:type_name -> aiserver.v1.ManageCheckRunAction
-	63, // 18: aiserver.v1.Action.request_reviewers:type_name -> aiserver.v1.RequestReviewersAction
-	65, // 19: aiserver.v1.Action.read_slack:type_name -> aiserver.v1.ReadSlackAction
-	64, // 20: aiserver.v1.Action.approve_pr:type_name -> aiserver.v1.ApprovePrAction
-	66, // 21: aiserver.v1.Action.resolve_review_threads:type_name -> aiserver.v1.ResolveReviewThreadsAction
-	68, // 22: aiserver.v1.Action.microsoft_teams:type_name -> aiserver.v1.MicrosoftTeamsAction
-	69, // 23: aiserver.v1.Action.read_microsoft_teams:type_name -> aiserver.v1.ReadMicrosoftTeamsAction
+	63, // 17: aiserver.v1.Action.manage_check_run:type_name -> aiserver.v1.ManageCheckRunAction
+	64, // 18: aiserver.v1.Action.request_reviewers:type_name -> aiserver.v1.RequestReviewersAction
+	66, // 19: aiserver.v1.Action.read_slack:type_name -> aiserver.v1.ReadSlackAction
+	65, // 20: aiserver.v1.Action.approve_pr:type_name -> aiserver.v1.ApprovePrAction
+	67, // 21: aiserver.v1.Action.resolve_review_threads:type_name -> aiserver.v1.ResolveReviewThreadsAction
+	69, // 22: aiserver.v1.Action.microsoft_teams:type_name -> aiserver.v1.MicrosoftTeamsAction
+	70, // 23: aiserver.v1.Action.read_microsoft_teams:type_name -> aiserver.v1.ReadMicrosoftTeamsAction
 	14, // 24: aiserver.v1.McpAction.server:type_name -> aiserver.v1.McpServerConfig
 	15, // 25: aiserver.v1.AgentPrivateWorkerConfig.labels:type_name -> aiserver.v1.AgentPrivateWorkerLabel
 	16, // 26: aiserver.v1.AgentOptions.private_worker:type_name -> aiserver.v1.AgentPrivateWorkerConfig
 	11, // 27: aiserver.v1.Workflow.triggers:type_name -> aiserver.v1.Trigger
 	12, // 28: aiserver.v1.Workflow.actions:type_name -> aiserver.v1.Action
 	19, // 29: aiserver.v1.Workflow.prompts:type_name -> aiserver.v1.Prompt
-	20, // 30: aiserver.v1.Workflow.git_config:type_name -> aiserver.v1.GitConfig
+	21, // 30: aiserver.v1.Workflow.git_config:type_name -> aiserver.v1.GitConfig
 	17, // 31: aiserver.v1.Workflow.agent_options:type_name -> aiserver.v1.AgentOptions
 	1,  // 32: aiserver.v1.Workflow.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
-	82, // 33: aiserver.v1.Workflow.managed_config:type_name -> google.protobuf.Struct
+	84, // 33: aiserver.v1.Workflow.managed_config:type_name -> google.protobuf.Struct
 	0,  // 34: aiserver.v1.Workflow.disabled_default_tools:type_name -> aiserver.v1.AutomationDefaultTool
-	5,  // 35: aiserver.v1.Prompt.effort_level:type_name -> aiserver.v1.PromptEffortLevel
-	6,  // 36: aiserver.v1.Prompt.run_mode:type_name -> aiserver.v1.PromptRunMode
-	23, // 37: aiserver.v1.GitTrigger.pull_request:type_name -> aiserver.v1.GitPullRequestEvent
-	26, // 38: aiserver.v1.GitTrigger.push:type_name -> aiserver.v1.GitPushEvent
-	27, // 39: aiserver.v1.GitTrigger.ci_completed:type_name -> aiserver.v1.GitCICompletedEvent
-	28, // 40: aiserver.v1.GitTrigger.issue_labeled:type_name -> aiserver.v1.GitIssueLabeledEvent
-	34, // 41: aiserver.v1.GitTrigger.label:type_name -> aiserver.v1.GitLabelEvent
-	29, // 42: aiserver.v1.GitTrigger.issue_comment:type_name -> aiserver.v1.GitIssueCommentEvent
-	30, // 43: aiserver.v1.GitTrigger.pull_request_review_comment:type_name -> aiserver.v1.GitPullRequestReviewCommentEvent
-	31, // 44: aiserver.v1.GitTrigger.pull_request_review:type_name -> aiserver.v1.GitPullRequestReviewEvent
-	32, // 45: aiserver.v1.GitTrigger.review_thread:type_name -> aiserver.v1.GitReviewThreadEvent
-	33, // 46: aiserver.v1.GitTrigger.workflow_run:type_name -> aiserver.v1.GitWorkflowRunEvent
-	24, // 47: aiserver.v1.GitTrigger.pull_request_review_requested:type_name -> aiserver.v1.GitPullRequestReviewRequestedEvent
-	25, // 48: aiserver.v1.GitTrigger.issue_assigned:type_name -> aiserver.v1.GitIssueAssignedEvent
-	7,  // 49: aiserver.v1.GitPullRequestEvent.pr_action:type_name -> aiserver.v1.GitPullRequestAction
-	8,  // 50: aiserver.v1.GitCICompletedEvent.condition:type_name -> aiserver.v1.GitCICompletionCondition
-	9,  // 51: aiserver.v1.GitWorkflowRunEvent.conclusion:type_name -> aiserver.v1.GitWorkflowRunConclusion
-	1,  // 52: aiserver.v1.SlackTrigger.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
-	41, // 53: aiserver.v1.LinearTrigger.issue_created:type_name -> aiserver.v1.LinearIssueCreatedEvent
-	42, // 54: aiserver.v1.LinearTrigger.status_changed:type_name -> aiserver.v1.LinearStatusChangedEvent
-	43, // 55: aiserver.v1.LinearTrigger.end_of_cycle:type_name -> aiserver.v1.LinearEndOfCycleEvent
-	46, // 56: aiserver.v1.PagerDutyTrigger.incident_triggered:type_name -> aiserver.v1.PagerDutyIncidentTriggeredEvent
-	47, // 57: aiserver.v1.PagerDutyTrigger.incident_acknowledged:type_name -> aiserver.v1.PagerDutyIncidentAcknowledgedEvent
-	48, // 58: aiserver.v1.PagerDutyTrigger.incident_resolved:type_name -> aiserver.v1.PagerDutyIncidentResolvedEvent
-	49, // 59: aiserver.v1.PagerDutyTrigger.incident_escalated:type_name -> aiserver.v1.PagerDutyIncidentEscalatedEvent
-	50, // 60: aiserver.v1.PagerDutyTrigger.incident_any:type_name -> aiserver.v1.PagerDutyIncidentAnyEvent
-	52, // 61: aiserver.v1.SentryTrigger.issue_created:type_name -> aiserver.v1.SentryIssueCreatedEvent
-	53, // 62: aiserver.v1.SentryTrigger.issue_resolved:type_name -> aiserver.v1.SentryIssueResolvedEvent
-	54, // 63: aiserver.v1.SentryTrigger.issue_assigned:type_name -> aiserver.v1.SentryIssueAssignedEvent
-	55, // 64: aiserver.v1.SentryTrigger.issue_archived:type_name -> aiserver.v1.SentryIssueArchivedEvent
-	56, // 65: aiserver.v1.SentryTrigger.issue_unresolved:type_name -> aiserver.v1.SentryIssueUnresolvedEvent
-	57, // 66: aiserver.v1.SentryTrigger.issue_any:type_name -> aiserver.v1.SentryIssueAnyEvent
-	18, // 67: aiserver.v1.CreateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
-	2,  // 68: aiserver.v1.CreateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
-	3,  // 69: aiserver.v1.CreateAutomationRequest.creation_source:type_name -> aiserver.v1.AutomationCreationSource
-	81, // 70: aiserver.v1.CreateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	81, // 71: aiserver.v1.GetAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	73, // 72: aiserver.v1.GetAutomationResponse.restricted_summary:type_name -> aiserver.v1.RestrictedAutomationSummary
-	18, // 73: aiserver.v1.UpdateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
-	2,  // 74: aiserver.v1.UpdateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
-	81, // 75: aiserver.v1.UpdateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	18, // 76: aiserver.v1.Automation.workflow:type_name -> aiserver.v1.Workflow
-	2,  // 77: aiserver.v1.Automation.scope:type_name -> aiserver.v1.AutomationScope
-	4,  // 78: aiserver.v1.Automation.managed_by:type_name -> aiserver.v1.AutomationManagedBy
-	10, // 79: aiserver.v1.AutomationMcpAuthState.auth_state:type_name -> aiserver.v1.McpAuthState
-	79, // 80: aiserver.v1.AutomationWithOwner.workflow:type_name -> aiserver.v1.Automation
-	80, // 81: aiserver.v1.AutomationWithOwner.mcp_auth_states:type_name -> aiserver.v1.AutomationMcpAuthState
-	70, // 82: aiserver.v1.AutomationsService.CreateAutomation:input_type -> aiserver.v1.CreateAutomationRequest
-	72, // 83: aiserver.v1.AutomationsService.GetAutomation:input_type -> aiserver.v1.GetAutomationRequest
-	75, // 84: aiserver.v1.AutomationsService.UpdateAutomation:input_type -> aiserver.v1.UpdateAutomationRequest
-	77, // 85: aiserver.v1.AutomationsService.DeleteAutomation:input_type -> aiserver.v1.DeleteAutomationRequest
-	71, // 86: aiserver.v1.AutomationsService.CreateAutomation:output_type -> aiserver.v1.CreateAutomationResponse
-	74, // 87: aiserver.v1.AutomationsService.GetAutomation:output_type -> aiserver.v1.GetAutomationResponse
-	76, // 88: aiserver.v1.AutomationsService.UpdateAutomation:output_type -> aiserver.v1.UpdateAutomationResponse
-	78, // 89: aiserver.v1.AutomationsService.DeleteAutomation:output_type -> aiserver.v1.DeleteAutomationResponse
-	86, // [86:90] is the sub-list for method output_type
-	82, // [82:86] is the sub-list for method input_type
-	82, // [82:82] is the sub-list for extension type_name
-	82, // [82:82] is the sub-list for extension extendee
-	0,  // [0:82] is the sub-list for field type_name
+	20, // 35: aiserver.v1.Workflow.model_selection:type_name -> aiserver.v1.AutomationModelSelection
+	5,  // 36: aiserver.v1.Prompt.effort_level:type_name -> aiserver.v1.PromptEffortLevel
+	6,  // 37: aiserver.v1.Prompt.run_mode:type_name -> aiserver.v1.PromptRunMode
+	20, // 38: aiserver.v1.Prompt.model_selection:type_name -> aiserver.v1.AutomationModelSelection
+	83, // 39: aiserver.v1.AutomationModelSelection.parameters:type_name -> aiserver.v1.AutomationModelSelection.ParameterValue
+	24, // 40: aiserver.v1.GitTrigger.pull_request:type_name -> aiserver.v1.GitPullRequestEvent
+	27, // 41: aiserver.v1.GitTrigger.push:type_name -> aiserver.v1.GitPushEvent
+	28, // 42: aiserver.v1.GitTrigger.ci_completed:type_name -> aiserver.v1.GitCICompletedEvent
+	29, // 43: aiserver.v1.GitTrigger.issue_labeled:type_name -> aiserver.v1.GitIssueLabeledEvent
+	35, // 44: aiserver.v1.GitTrigger.label:type_name -> aiserver.v1.GitLabelEvent
+	30, // 45: aiserver.v1.GitTrigger.issue_comment:type_name -> aiserver.v1.GitIssueCommentEvent
+	31, // 46: aiserver.v1.GitTrigger.pull_request_review_comment:type_name -> aiserver.v1.GitPullRequestReviewCommentEvent
+	32, // 47: aiserver.v1.GitTrigger.pull_request_review:type_name -> aiserver.v1.GitPullRequestReviewEvent
+	33, // 48: aiserver.v1.GitTrigger.review_thread:type_name -> aiserver.v1.GitReviewThreadEvent
+	34, // 49: aiserver.v1.GitTrigger.workflow_run:type_name -> aiserver.v1.GitWorkflowRunEvent
+	25, // 50: aiserver.v1.GitTrigger.pull_request_review_requested:type_name -> aiserver.v1.GitPullRequestReviewRequestedEvent
+	26, // 51: aiserver.v1.GitTrigger.issue_assigned:type_name -> aiserver.v1.GitIssueAssignedEvent
+	7,  // 52: aiserver.v1.GitPullRequestEvent.pr_action:type_name -> aiserver.v1.GitPullRequestAction
+	8,  // 53: aiserver.v1.GitCICompletedEvent.condition:type_name -> aiserver.v1.GitCICompletionCondition
+	9,  // 54: aiserver.v1.GitWorkflowRunEvent.conclusion:type_name -> aiserver.v1.GitWorkflowRunConclusion
+	1,  // 55: aiserver.v1.SlackTrigger.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
+	42, // 56: aiserver.v1.LinearTrigger.issue_created:type_name -> aiserver.v1.LinearIssueCreatedEvent
+	43, // 57: aiserver.v1.LinearTrigger.status_changed:type_name -> aiserver.v1.LinearStatusChangedEvent
+	44, // 58: aiserver.v1.LinearTrigger.end_of_cycle:type_name -> aiserver.v1.LinearEndOfCycleEvent
+	47, // 59: aiserver.v1.PagerDutyTrigger.incident_triggered:type_name -> aiserver.v1.PagerDutyIncidentTriggeredEvent
+	48, // 60: aiserver.v1.PagerDutyTrigger.incident_acknowledged:type_name -> aiserver.v1.PagerDutyIncidentAcknowledgedEvent
+	49, // 61: aiserver.v1.PagerDutyTrigger.incident_resolved:type_name -> aiserver.v1.PagerDutyIncidentResolvedEvent
+	50, // 62: aiserver.v1.PagerDutyTrigger.incident_escalated:type_name -> aiserver.v1.PagerDutyIncidentEscalatedEvent
+	51, // 63: aiserver.v1.PagerDutyTrigger.incident_any:type_name -> aiserver.v1.PagerDutyIncidentAnyEvent
+	53, // 64: aiserver.v1.SentryTrigger.issue_created:type_name -> aiserver.v1.SentryIssueCreatedEvent
+	54, // 65: aiserver.v1.SentryTrigger.issue_resolved:type_name -> aiserver.v1.SentryIssueResolvedEvent
+	55, // 66: aiserver.v1.SentryTrigger.issue_assigned:type_name -> aiserver.v1.SentryIssueAssignedEvent
+	56, // 67: aiserver.v1.SentryTrigger.issue_archived:type_name -> aiserver.v1.SentryIssueArchivedEvent
+	57, // 68: aiserver.v1.SentryTrigger.issue_unresolved:type_name -> aiserver.v1.SentryIssueUnresolvedEvent
+	58, // 69: aiserver.v1.SentryTrigger.issue_any:type_name -> aiserver.v1.SentryIssueAnyEvent
+	18, // 70: aiserver.v1.CreateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
+	2,  // 71: aiserver.v1.CreateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
+	3,  // 72: aiserver.v1.CreateAutomationRequest.creation_source:type_name -> aiserver.v1.AutomationCreationSource
+	82, // 73: aiserver.v1.CreateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	82, // 74: aiserver.v1.GetAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	74, // 75: aiserver.v1.GetAutomationResponse.restricted_summary:type_name -> aiserver.v1.RestrictedAutomationSummary
+	18, // 76: aiserver.v1.UpdateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
+	2,  // 77: aiserver.v1.UpdateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
+	82, // 78: aiserver.v1.UpdateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	18, // 79: aiserver.v1.Automation.workflow:type_name -> aiserver.v1.Workflow
+	2,  // 80: aiserver.v1.Automation.scope:type_name -> aiserver.v1.AutomationScope
+	4,  // 81: aiserver.v1.Automation.managed_by:type_name -> aiserver.v1.AutomationManagedBy
+	10, // 82: aiserver.v1.AutomationMcpAuthState.auth_state:type_name -> aiserver.v1.McpAuthState
+	80, // 83: aiserver.v1.AutomationWithOwner.workflow:type_name -> aiserver.v1.Automation
+	81, // 84: aiserver.v1.AutomationWithOwner.mcp_auth_states:type_name -> aiserver.v1.AutomationMcpAuthState
+	71, // 85: aiserver.v1.AutomationsService.CreateAutomation:input_type -> aiserver.v1.CreateAutomationRequest
+	73, // 86: aiserver.v1.AutomationsService.GetAutomation:input_type -> aiserver.v1.GetAutomationRequest
+	76, // 87: aiserver.v1.AutomationsService.UpdateAutomation:input_type -> aiserver.v1.UpdateAutomationRequest
+	78, // 88: aiserver.v1.AutomationsService.DeleteAutomation:input_type -> aiserver.v1.DeleteAutomationRequest
+	72, // 89: aiserver.v1.AutomationsService.CreateAutomation:output_type -> aiserver.v1.CreateAutomationResponse
+	75, // 90: aiserver.v1.AutomationsService.GetAutomation:output_type -> aiserver.v1.GetAutomationResponse
+	77, // 91: aiserver.v1.AutomationsService.UpdateAutomation:output_type -> aiserver.v1.UpdateAutomationResponse
+	79, // 92: aiserver.v1.AutomationsService.DeleteAutomation:output_type -> aiserver.v1.DeleteAutomationResponse
+	89, // [89:93] is the sub-list for method output_type
+	85, // [85:89] is the sub-list for method input_type
+	85, // [85:85] is the sub-list for extension type_name
+	85, // [85:85] is the sub-list for extension extendee
+	0,  // [0:85] is the sub-list for field type_name
 }
 
 func init() { file_aiserver_v1_automations_proto_init() }
@@ -6646,7 +6803,8 @@ func file_aiserver_v1_automations_proto_init() {
 	file_aiserver_v1_automations_proto_msgTypes[6].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[7].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[8].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[11].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[9].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[12].OneofWrappers = []any{
 		(*GitTrigger_PullRequest)(nil),
 		(*GitTrigger_Push)(nil),
 		(*GitTrigger_CiCompleted)(nil),
@@ -6660,20 +6818,20 @@ func file_aiserver_v1_automations_proto_init() {
 		(*GitTrigger_PullRequestReviewRequested)(nil),
 		(*GitTrigger_IssueAssigned)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[24].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[29].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[25].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[30].OneofWrappers = []any{
 		(*LinearTrigger_IssueCreated)(nil),
 		(*LinearTrigger_StatusChanged)(nil),
 		(*LinearTrigger_EndOfCycle)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[34].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[35].OneofWrappers = []any{
 		(*PagerDutyTrigger_IncidentTriggered)(nil),
 		(*PagerDutyTrigger_IncidentAcknowledged)(nil),
 		(*PagerDutyTrigger_IncidentResolved)(nil),
 		(*PagerDutyTrigger_IncidentEscalated)(nil),
 		(*PagerDutyTrigger_IncidentAny)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[40].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[41].OneofWrappers = []any{
 		(*SentryTrigger_IssueCreated)(nil),
 		(*SentryTrigger_IssueResolved)(nil),
 		(*SentryTrigger_IssueAssigned)(nil),
@@ -6681,23 +6839,23 @@ func file_aiserver_v1_automations_proto_init() {
 		(*SentryTrigger_IssueUnresolved)(nil),
 		(*SentryTrigger_IssueAny)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[59].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[61].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[63].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[60].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[62].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[64].OneofWrappers = []any{
 		(*GetAutomationResponse_Workflow)(nil),
 		(*GetAutomationResponse_RestrictedSummary)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[64].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[68].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[65].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[69].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[70].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[71].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_aiserver_v1_automations_proto_rawDesc), len(file_aiserver_v1_automations_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   71,
+			NumMessages:   73,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/proto/v1/automations.pb.go
+++ b/internal/proto/v1/automations.pb.go
@@ -1437,6 +1437,16 @@ type Workflow struct {
 	// Default automation tools that should not be available to this workflow.
 	// An empty list preserves the platform defaults.
 	DisabledDefaultTools []AutomationDefaultTool `protobuf:"varint,19,rep,packed,name=disabled_default_tools,json=disabledDefaultTools,proto3,enum=aiserver.v1.AutomationDefaultTool" json:"disabled_default_tools,omitempty"`
+	// Sand-only, server-managed (the wire never sets or changes it): the Grok Bot
+	// session the routine was created in, so its cron fires wake that
+	// conversation. Absent on routines created before sessions existed and on
+	// routines created from the main conversation; both run on main.
+	GrokBotSessionId *string `protobuf:"bytes,20,opt,name=grok_bot_session_id,json=grokBotSessionId,proto3,oneof" json:"grok_bot_session_id,omitempty"`
+	// Sand-only, server-managed: the Cursor auth id of the user whose turn
+	// created the routine, recorded with grok_bot_session_id so the fire runs as
+	// that user. Absent on main routines (the owner's) and on session routines
+	// from before it was recorded, which are refused rather than run as the owner.
+	GrokBotCreatorAuthId *string `protobuf:"bytes,21,opt,name=grok_bot_creator_auth_id,json=grokBotCreatorAuthId,proto3,oneof" json:"grok_bot_creator_auth_id,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -1553,6 +1563,20 @@ func (x *Workflow) GetDisabledDefaultTools() []AutomationDefaultTool {
 		return x.DisabledDefaultTools
 	}
 	return nil
+}
+
+func (x *Workflow) GetGrokBotSessionId() string {
+	if x != nil && x.GrokBotSessionId != nil {
+		return *x.GrokBotSessionId
+	}
+	return ""
+}
+
+func (x *Workflow) GetGrokBotCreatorAuthId() string {
+	if x != nil && x.GrokBotCreatorAuthId != nil {
+		return *x.GrokBotCreatorAuthId
+	}
+	return ""
 }
 
 type Prompt struct {
@@ -5601,8 +5625,11 @@ type Automation struct {
 	ManagedType          *string             `protobuf:"bytes,15,opt,name=managed_type,json=managedType,proto3,oneof" json:"managed_type,omitempty"`
 	Hidden               *bool               `protobuf:"varint,16,opt,name=hidden,proto3,oneof" json:"hidden,omitempty"`
 	TemplateId           *string             `protobuf:"bytes,17,opt,name=template_id,json=templateId,proto3,oneof" json:"template_id,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Sand only: when this automation last fired, from its newest non-skipped
+	// run row (epoch ms). Absent when it has never run.
+	SandLastRunAtMs *int64 `protobuf:"varint,18,opt,name=sand_last_run_at_ms,json=sandLastRunAtMs,proto3,oneof" json:"sand_last_run_at_ms,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *Automation) Reset() {
@@ -5745,6 +5772,13 @@ func (x *Automation) GetTemplateId() string {
 		return *x.TemplateId
 	}
 	return ""
+}
+
+func (x *Automation) GetSandLastRunAtMs() int64 {
+	if x != nil && x.SandLastRunAtMs != nil {
+		return *x.SandLastRunAtMs
+	}
+	return 0
 }
 
 type AutomationMcpAuthState struct {
@@ -5945,7 +5979,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x15environment_public_id\x18\x03 \x01(\tH\x02R\x13environmentPublicId\x88\x01\x01B\x0f\n" +
 	"\r_skip_installB\x11\n" +
 	"\x0f_private_workerB\x18\n" +
-	"\x16_environment_public_id\"\xcf\a\n" +
+	"\x16_environment_public_id\"\xf5\b\n" +
 	"\bWorkflow\x120\n" +
 	"\btriggers\x18\n" +
 	" \x03(\v2\x14.aiserver.v1.TriggerR\btriggers\x12-\n" +
@@ -5960,14 +5994,18 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x1eslack_completion_reaction_mode\x18\x10 \x01(\x0e2(.aiserver.v1.SlackCompletionReactionModeH\x04R\x1bslackCompletionReactionMode\x88\x01\x01\x12W\n" +
 	"&slack_completion_reaction_custom_emoji\x18\x11 \x01(\tH\x05R\"slackCompletionReactionCustomEmoji\x88\x01\x01\x12C\n" +
 	"\x0emanaged_config\x18\x12 \x01(\v2\x17.google.protobuf.StructH\x06R\rmanagedConfig\x88\x01\x01\x12X\n" +
-	"\x16disabled_default_tools\x18\x13 \x03(\x0e2\".aiserver.v1.AutomationDefaultToolR\x14disabledDefaultToolsB\b\n" +
+	"\x16disabled_default_tools\x18\x13 \x03(\x0e2\".aiserver.v1.AutomationDefaultToolR\x14disabledDefaultTools\x122\n" +
+	"\x13grok_bot_session_id\x18\x14 \x01(\tH\aR\x10grokBotSessionId\x88\x01\x01\x12;\n" +
+	"\x18grok_bot_creator_auth_id\x18\x15 \x01(\tH\bR\x14grokBotCreatorAuthId\x88\x01\x01B\b\n" +
 	"\x06_modelB\r\n" +
 	"\v_git_configB\x10\n" +
 	"\x0e_agent_optionsB\x11\n" +
 	"\x0f_memory_enabledB!\n" +
 	"\x1f_slack_completion_reaction_modeB)\n" +
 	"'_slack_completion_reaction_custom_emojiB\x11\n" +
-	"\x0f_managed_configJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
+	"\x0f_managed_configB\x16\n" +
+	"\x14_grok_bot_session_idB\x1b\n" +
+	"\x19_grok_bot_creator_auth_idJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\t\x10\n" +
 	"\"\xda\x02\n" +
 	"\x06Prompt\x12\x16\n" +
 	"\x06prompt\x18\x01 \x01(\tR\x06prompt\x12A\n" +
@@ -6255,7 +6293,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\bworkflow\x18\x01 \x01(\v2 .aiserver.v1.AutomationWithOwnerR\bworkflow\"D\n" +
 	"\x17DeleteAutomationRequest\x12#\n" +
 	"\rautomation_id\x18\x02 \x01(\tR\fautomationIdJ\x04\b\x01\x10\x02\"\x1a\n" +
-	"\x18DeleteAutomationResponse\"\xc3\x06\n" +
+	"\x18DeleteAutomationResponse\"\x8e\a\n" +
 	"\n" +
 	"Automation\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -6279,7 +6317,8 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\fmanaged_type\x18\x0f \x01(\tH\x05R\vmanagedType\x88\x01\x01\x12\x1b\n" +
 	"\x06hidden\x18\x10 \x01(\bH\x06R\x06hidden\x88\x01\x01\x12$\n" +
 	"\vtemplate_id\x18\x11 \x01(\tH\aR\n" +
-	"templateId\x88\x01\x01B\x0e\n" +
+	"templateId\x88\x01\x01\x121\n" +
+	"\x13sand_last_run_at_ms\x18\x12 \x01(\x03H\bR\x0fsandLastRunAtMs\x88\x01\x01B\x0e\n" +
 	"\f_descriptionB\x15\n" +
 	"\x13_service_account_idB\r\n" +
 	"\v_deploy_keyB\x19\n" +
@@ -6287,7 +6326,8 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x18_deploy_last_apply_errorB\x0f\n" +
 	"\r_managed_typeB\t\n" +
 	"\a_hiddenB\x0e\n" +
-	"\f_template_idJ\x04\b\x01\x10\x02\"\xa3\x01\n" +
+	"\f_template_idB\x16\n" +
+	"\x14_sand_last_run_at_msJ\x04\b\x01\x10\x02\"\xa3\x01\n" +
 	"\x16AutomationMcpAuthState\x12 \n" +
 	"\tserver_id\x18\x01 \x01(\x03H\x00R\bserverId\x88\x01\x01\x12\x1f\n" +
 	"\vserver_name\x18\x02 \x01(\tR\n" +

--- a/internal/proto/v1/automations.pb.go
+++ b/internal/proto/v1/automations.pb.go
@@ -22,6 +22,52 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type AutomationDefaultTool int32
+
+const (
+	AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_UNSPECIFIED AutomationDefaultTool = 0
+	AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR AutomationDefaultTool = 1
+)
+
+// Enum value maps for AutomationDefaultTool.
+var (
+	AutomationDefaultTool_name = map[int32]string{
+		0: "AUTOMATION_DEFAULT_TOOL_UNSPECIFIED",
+		1: "AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR",
+	}
+	AutomationDefaultTool_value = map[string]int32{
+		"AUTOMATION_DEFAULT_TOOL_UNSPECIFIED": 0,
+		"AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR": 1,
+	}
+)
+
+func (x AutomationDefaultTool) Enum() *AutomationDefaultTool {
+	p := new(AutomationDefaultTool)
+	*p = x
+	return p
+}
+
+func (x AutomationDefaultTool) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AutomationDefaultTool) Descriptor() protoreflect.EnumDescriptor {
+	return file_aiserver_v1_automations_proto_enumTypes[0].Descriptor()
+}
+
+func (AutomationDefaultTool) Type() protoreflect.EnumType {
+	return &file_aiserver_v1_automations_proto_enumTypes[0]
+}
+
+func (x AutomationDefaultTool) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AutomationDefaultTool.Descriptor instead.
+func (AutomationDefaultTool) EnumDescriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{0}
+}
+
 type SlackCompletionReactionMode int32
 
 const (
@@ -58,11 +104,11 @@ func (x SlackCompletionReactionMode) String() string {
 }
 
 func (SlackCompletionReactionMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[0].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[1].Descriptor()
 }
 
 func (SlackCompletionReactionMode) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[0]
+	return &file_aiserver_v1_automations_proto_enumTypes[1]
 }
 
 func (x SlackCompletionReactionMode) Number() protoreflect.EnumNumber {
@@ -71,7 +117,7 @@ func (x SlackCompletionReactionMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SlackCompletionReactionMode.Descriptor instead.
 func (SlackCompletionReactionMode) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{0}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{1}
 }
 
 type AutomationScope int32
@@ -124,11 +170,11 @@ func (x AutomationScope) String() string {
 }
 
 func (AutomationScope) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[1].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[2].Descriptor()
 }
 
 func (AutomationScope) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[1]
+	return &file_aiserver_v1_automations_proto_enumTypes[2]
 }
 
 func (x AutomationScope) Number() protoreflect.EnumNumber {
@@ -137,7 +183,7 @@ func (x AutomationScope) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AutomationScope.Descriptor instead.
 func (AutomationScope) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{1}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{2}
 }
 
 type AutomationCreationSource int32
@@ -179,11 +225,11 @@ func (x AutomationCreationSource) String() string {
 }
 
 func (AutomationCreationSource) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[2].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[3].Descriptor()
 }
 
 func (AutomationCreationSource) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[2]
+	return &file_aiserver_v1_automations_proto_enumTypes[3]
 }
 
 func (x AutomationCreationSource) Number() protoreflect.EnumNumber {
@@ -192,7 +238,7 @@ func (x AutomationCreationSource) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AutomationCreationSource.Descriptor instead.
 func (AutomationCreationSource) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{2}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{3}
 }
 
 type AutomationManagedBy int32
@@ -232,11 +278,11 @@ func (x AutomationManagedBy) String() string {
 }
 
 func (AutomationManagedBy) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[3].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[4].Descriptor()
 }
 
 func (AutomationManagedBy) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[3]
+	return &file_aiserver_v1_automations_proto_enumTypes[4]
 }
 
 func (x AutomationManagedBy) Number() protoreflect.EnumNumber {
@@ -245,7 +291,7 @@ func (x AutomationManagedBy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AutomationManagedBy.Descriptor instead.
 func (AutomationManagedBy) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{3}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{4}
 }
 
 type PromptEffortLevel int32
@@ -281,11 +327,11 @@ func (x PromptEffortLevel) String() string {
 }
 
 func (PromptEffortLevel) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[4].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[5].Descriptor()
 }
 
 func (PromptEffortLevel) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[4]
+	return &file_aiserver_v1_automations_proto_enumTypes[5]
 }
 
 func (x PromptEffortLevel) Number() protoreflect.EnumNumber {
@@ -294,7 +340,7 @@ func (x PromptEffortLevel) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PromptEffortLevel.Descriptor instead.
 func (PromptEffortLevel) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{4}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{5}
 }
 
 type PromptRunMode int32
@@ -330,11 +376,11 @@ func (x PromptRunMode) String() string {
 }
 
 func (PromptRunMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[5].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[6].Descriptor()
 }
 
 func (PromptRunMode) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[5]
+	return &file_aiserver_v1_automations_proto_enumTypes[6]
 }
 
 func (x PromptRunMode) Number() protoreflect.EnumNumber {
@@ -343,7 +389,7 @@ func (x PromptRunMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PromptRunMode.Descriptor instead.
 func (PromptRunMode) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{5}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{6}
 }
 
 // Which GitHub PR action triggers this automation.
@@ -358,6 +404,7 @@ const (
 	GitPullRequestAction_GIT_PULL_REQUEST_ACTION_DRAFT_OPENED GitPullRequestAction = 5 // Draft PR opened (non-draft PRs excluded)
 	GitPullRequestAction_GIT_PULL_REQUEST_ACTION_LABELED      GitPullRequestAction = 6 // Deprecated: use GitLabelEvent instead.
 	GitPullRequestAction_GIT_PULL_REQUEST_ACTION_UNLABELED    GitPullRequestAction = 7 // Deprecated: use GitLabelEvent instead.
+	GitPullRequestAction_GIT_PULL_REQUEST_ACTION_CLOSED       GitPullRequestAction = 8 // PR closed without merging
 )
 
 // Enum value maps for GitPullRequestAction.
@@ -371,6 +418,7 @@ var (
 		5: "GIT_PULL_REQUEST_ACTION_DRAFT_OPENED",
 		6: "GIT_PULL_REQUEST_ACTION_LABELED",
 		7: "GIT_PULL_REQUEST_ACTION_UNLABELED",
+		8: "GIT_PULL_REQUEST_ACTION_CLOSED",
 	}
 	GitPullRequestAction_value = map[string]int32{
 		"GIT_PULL_REQUEST_ACTION_UNSPECIFIED":  0,
@@ -381,6 +429,7 @@ var (
 		"GIT_PULL_REQUEST_ACTION_DRAFT_OPENED": 5,
 		"GIT_PULL_REQUEST_ACTION_LABELED":      6,
 		"GIT_PULL_REQUEST_ACTION_UNLABELED":    7,
+		"GIT_PULL_REQUEST_ACTION_CLOSED":       8,
 	}
 )
 
@@ -395,11 +444,11 @@ func (x GitPullRequestAction) String() string {
 }
 
 func (GitPullRequestAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[6].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[7].Descriptor()
 }
 
 func (GitPullRequestAction) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[6]
+	return &file_aiserver_v1_automations_proto_enumTypes[7]
 }
 
 func (x GitPullRequestAction) Number() protoreflect.EnumNumber {
@@ -408,7 +457,7 @@ func (x GitPullRequestAction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GitPullRequestAction.Descriptor instead.
 func (GitPullRequestAction) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{6}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{7}
 }
 
 // Condition for when CI completed trigger should fire.
@@ -448,11 +497,11 @@ func (x GitCICompletionCondition) String() string {
 }
 
 func (GitCICompletionCondition) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[7].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[8].Descriptor()
 }
 
 func (GitCICompletionCondition) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[7]
+	return &file_aiserver_v1_automations_proto_enumTypes[8]
 }
 
 func (x GitCICompletionCondition) Number() protoreflect.EnumNumber {
@@ -461,7 +510,7 @@ func (x GitCICompletionCondition) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GitCICompletionCondition.Descriptor instead.
 func (GitCICompletionCondition) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{7}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{8}
 }
 
 // Conclusion filter for GitWorkflowRunEvent.
@@ -504,11 +553,11 @@ func (x GitWorkflowRunConclusion) String() string {
 }
 
 func (GitWorkflowRunConclusion) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[8].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[9].Descriptor()
 }
 
 func (GitWorkflowRunConclusion) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[8]
+	return &file_aiserver_v1_automations_proto_enumTypes[9]
 }
 
 func (x GitWorkflowRunConclusion) Number() protoreflect.EnumNumber {
@@ -517,7 +566,7 @@ func (x GitWorkflowRunConclusion) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GitWorkflowRunConclusion.Descriptor instead.
 func (GitWorkflowRunConclusion) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{8}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{9}
 }
 
 // Response wrapper that includes Automation plus user context.
@@ -560,11 +609,11 @@ func (x McpAuthState) String() string {
 }
 
 func (McpAuthState) Descriptor() protoreflect.EnumDescriptor {
-	return file_aiserver_v1_automations_proto_enumTypes[9].Descriptor()
+	return file_aiserver_v1_automations_proto_enumTypes[10].Descriptor()
 }
 
 func (McpAuthState) Type() protoreflect.EnumType {
-	return &file_aiserver_v1_automations_proto_enumTypes[9]
+	return &file_aiserver_v1_automations_proto_enumTypes[10]
 }
 
 func (x McpAuthState) Number() protoreflect.EnumNumber {
@@ -573,7 +622,7 @@ func (x McpAuthState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use McpAuthState.Descriptor instead.
 func (McpAuthState) EnumDescriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{9}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{10}
 }
 
 // The two main concepts of automations are "Triggers" and "Actions (tools/MCPs)".
@@ -592,6 +641,8 @@ type Trigger struct {
 	//	*Trigger_MicrosoftTeamsTrigger
 	//	*Trigger_MicrosoftTeamsChannelCreated
 	//	*Trigger_SlackReactionAdded
+	//	*Trigger_SlackMention
+	//	*Trigger_SlackAnyReactionAdded
 	Trigger isTrigger_Trigger `protobuf_oneof:"trigger"`
 	// Optional natural-language filter evaluated by a lightweight model before the
 	// main automation run. When empty, no filter step runs.
@@ -736,6 +787,24 @@ func (x *Trigger) GetSlackReactionAdded() *SlackReactionAddedTrigger {
 	return nil
 }
 
+func (x *Trigger) GetSlackMention() *SlackMentionTrigger {
+	if x != nil {
+		if x, ok := x.Trigger.(*Trigger_SlackMention); ok {
+			return x.SlackMention
+		}
+	}
+	return nil
+}
+
+func (x *Trigger) GetSlackAnyReactionAdded() *SlackAnyReactionAddedTrigger {
+	if x != nil {
+		if x, ok := x.Trigger.(*Trigger_SlackAnyReactionAdded); ok {
+			return x.SlackAnyReactionAdded
+		}
+	}
+	return nil
+}
+
 func (x *Trigger) GetAgenticFilterPrompt() string {
 	if x != nil && x.AgenticFilterPrompt != nil {
 		return *x.AgenticFilterPrompt
@@ -791,6 +860,14 @@ type Trigger_SlackReactionAdded struct {
 	SlackReactionAdded *SlackReactionAddedTrigger `protobuf:"bytes,18,opt,name=slack_reaction_added,json=slackReactionAdded,proto3,oneof"` // Triggered when a specific emoji reaction is added in a Slack channel
 }
 
+type Trigger_SlackMention struct {
+	SlackMention *SlackMentionTrigger `protobuf:"bytes,19,opt,name=slack_mention,json=slackMention,proto3,oneof"`
+}
+
+type Trigger_SlackAnyReactionAdded struct {
+	SlackAnyReactionAdded *SlackAnyReactionAddedTrigger `protobuf:"bytes,20,opt,name=slack_any_reaction_added,json=slackAnyReactionAdded,proto3,oneof"`
+}
+
 func (*Trigger_Cron) isTrigger_Trigger() {}
 
 func (*Trigger_Git) isTrigger_Trigger() {}
@@ -812,6 +889,10 @@ func (*Trigger_MicrosoftTeamsTrigger) isTrigger_Trigger() {}
 func (*Trigger_MicrosoftTeamsChannelCreated) isTrigger_Trigger() {}
 
 func (*Trigger_SlackReactionAdded) isTrigger_Trigger() {}
+
+func (*Trigger_SlackMention) isTrigger_Trigger() {}
+
+func (*Trigger_SlackAnyReactionAdded) isTrigger_Trigger() {}
 
 // Each built-in action type (git_pr, pr_comment, slack, manage_check_run,
 // request_reviewers) may appear at most once per workflow.
@@ -1353,8 +1434,11 @@ type Workflow struct {
 	// VULNERABILITY_SCANNER). Carries check toggles and other type-specific settings
 	// so the backend can build the final prompt server-side when needed.
 	ManagedConfig *structpb.Struct `protobuf:"bytes,18,opt,name=managed_config,json=managedConfig,proto3,oneof" json:"managed_config,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Default automation tools that should not be available to this workflow.
+	// An empty list preserves the platform defaults.
+	DisabledDefaultTools []AutomationDefaultTool `protobuf:"varint,19,rep,packed,name=disabled_default_tools,json=disabledDefaultTools,proto3,enum=aiserver.v1.AutomationDefaultTool" json:"disabled_default_tools,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Workflow) Reset() {
@@ -1460,6 +1544,13 @@ func (x *Workflow) GetSlackCompletionReactionCustomEmoji() string {
 func (x *Workflow) GetManagedConfig() *structpb.Struct {
 	if x != nil {
 		return x.ManagedConfig
+	}
+	return nil
+}
+
+func (x *Workflow) GetDisabledDefaultTools() []AutomationDefaultTool {
+	if x != nil {
+		return x.DisabledDefaultTools
 	}
 	return nil
 }
@@ -1672,6 +1763,8 @@ type GitTrigger struct {
 	//	*GitTrigger_PullRequestReview
 	//	*GitTrigger_ReviewThread
 	//	*GitTrigger_WorkflowRun
+	//	*GitTrigger_PullRequestReviewRequested
+	//	*GitTrigger_IssueAssigned
 	Event isGitTrigger_Event `protobuf_oneof:"event"`
 	// Optional allowlist of git usernames that can trigger this automation.
 	// If empty, all users can trigger it.
@@ -1807,6 +1900,24 @@ func (x *GitTrigger) GetWorkflowRun() *GitWorkflowRunEvent {
 	return nil
 }
 
+func (x *GitTrigger) GetPullRequestReviewRequested() *GitPullRequestReviewRequestedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_PullRequestReviewRequested); ok {
+			return x.PullRequestReviewRequested
+		}
+	}
+	return nil
+}
+
+func (x *GitTrigger) GetIssueAssigned() *GitIssueAssignedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*GitTrigger_IssueAssigned); ok {
+			return x.IssueAssigned
+		}
+	}
+	return nil
+}
+
 func (x *GitTrigger) GetUserAllowlist() []string {
 	if x != nil {
 		return x.UserAllowlist
@@ -1858,6 +1969,14 @@ type GitTrigger_WorkflowRun struct {
 	WorkflowRun *GitWorkflowRunEvent `protobuf:"bytes,11,opt,name=workflow_run,json=workflowRun,proto3,oneof"`
 }
 
+type GitTrigger_PullRequestReviewRequested struct {
+	PullRequestReviewRequested *GitPullRequestReviewRequestedEvent `protobuf:"bytes,12,opt,name=pull_request_review_requested,json=pullRequestReviewRequested,proto3,oneof"`
+}
+
+type GitTrigger_IssueAssigned struct {
+	IssueAssigned *GitIssueAssignedEvent `protobuf:"bytes,13,opt,name=issue_assigned,json=issueAssigned,proto3,oneof"`
+}
+
 func (*GitTrigger_PullRequest) isGitTrigger_Event() {}
 
 func (*GitTrigger_Push) isGitTrigger_Event() {}
@@ -1877,6 +1996,10 @@ func (*GitTrigger_PullRequestReview) isGitTrigger_Event() {}
 func (*GitTrigger_ReviewThread) isGitTrigger_Event() {}
 
 func (*GitTrigger_WorkflowRun) isGitTrigger_Event() {}
+
+func (*GitTrigger_PullRequestReviewRequested) isGitTrigger_Event() {}
+
+func (*GitTrigger_IssueAssigned) isGitTrigger_Event() {}
 
 type GitPullRequestEvent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2007,6 +2130,94 @@ func (x *GitPullRequestEvent) GetOrgs() []string {
 	return nil
 }
 
+type GitPullRequestReviewRequestedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Repos         []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GitPullRequestReviewRequestedEvent) Reset() {
+	*x = GitPullRequestReviewRequestedEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitPullRequestReviewRequestedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitPullRequestReviewRequestedEvent) ProtoMessage() {}
+
+func (x *GitPullRequestReviewRequestedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitPullRequestReviewRequestedEvent.ProtoReflect.Descriptor instead.
+func (*GitPullRequestReviewRequestedEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GitPullRequestReviewRequestedEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
+type GitIssueAssignedEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Repos         []string               `protobuf:"bytes,1,rep,name=repos,proto3" json:"repos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GitIssueAssignedEvent) Reset() {
+	*x = GitIssueAssignedEvent{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitIssueAssignedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitIssueAssignedEvent) ProtoMessage() {}
+
+func (x *GitIssueAssignedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitIssueAssignedEvent.ProtoReflect.Descriptor instead.
+func (*GitIssueAssignedEvent) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *GitIssueAssignedEvent) GetRepos() []string {
+	if x != nil {
+		return x.Repos
+	}
+	return nil
+}
+
 type GitPushEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Repo          string                 `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
@@ -2018,7 +2229,7 @@ type GitPushEvent struct {
 
 func (x *GitPushEvent) Reset() {
 	*x = GitPushEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2030,7 +2241,7 @@ func (x *GitPushEvent) String() string {
 func (*GitPushEvent) ProtoMessage() {}
 
 func (x *GitPushEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[13]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2043,7 +2254,7 @@ func (x *GitPushEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPushEvent.ProtoReflect.Descriptor instead.
 func (*GitPushEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{13}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GitPushEvent) GetRepo() string {
@@ -2077,14 +2288,16 @@ type GitCICompletedEvent struct {
 	// If set, trigger on CI completion for this branch directly (e.g. "main")
 	// instead of on PRs. User allowlist and ignore_base_failures are ignored
 	// in branch mode.
-	Branch        string `protobuf:"bytes,4,opt,name=branch,proto3" json:"branch,omitempty"`
+	Branch string `protobuf:"bytes,4,opt,name=branch,proto3" json:"branch,omitempty"`
+	// If set, trigger only for this PR. Mutually exclusive with branch.
+	PrNumber      int32 `protobuf:"varint,5,opt,name=pr_number,json=prNumber,proto3" json:"pr_number,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GitCICompletedEvent) Reset() {
 	*x = GitCICompletedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2096,7 +2309,7 @@ func (x *GitCICompletedEvent) String() string {
 func (*GitCICompletedEvent) ProtoMessage() {}
 
 func (x *GitCICompletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[14]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2109,7 +2322,7 @@ func (x *GitCICompletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitCICompletedEvent.ProtoReflect.Descriptor instead.
 func (*GitCICompletedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{14}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GitCICompletedEvent) GetRepos() []string {
@@ -2140,6 +2353,13 @@ func (x *GitCICompletedEvent) GetBranch() string {
 	return ""
 }
 
+func (x *GitCICompletedEvent) GetPrNumber() int32 {
+	if x != nil {
+		return x.PrNumber
+	}
+	return 0
+}
+
 // Deprecated: use GitLabelEvent instead.
 type GitIssueLabeledEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2152,7 +2372,7 @@ type GitIssueLabeledEvent struct {
 
 func (x *GitIssueLabeledEvent) Reset() {
 	*x = GitIssueLabeledEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2164,7 +2384,7 @@ func (x *GitIssueLabeledEvent) String() string {
 func (*GitIssueLabeledEvent) ProtoMessage() {}
 
 func (x *GitIssueLabeledEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[15]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2177,7 +2397,7 @@ func (x *GitIssueLabeledEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitIssueLabeledEvent.ProtoReflect.Descriptor instead.
 func (*GitIssueLabeledEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{15}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GitIssueLabeledEvent) GetRepos() []string {
@@ -2221,7 +2441,7 @@ type GitIssueCommentEvent struct {
 
 func (x *GitIssueCommentEvent) Reset() {
 	*x = GitIssueCommentEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2233,7 +2453,7 @@ func (x *GitIssueCommentEvent) String() string {
 func (*GitIssueCommentEvent) ProtoMessage() {}
 
 func (x *GitIssueCommentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[16]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2246,7 +2466,7 @@ func (x *GitIssueCommentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitIssueCommentEvent.ProtoReflect.Descriptor instead.
 func (*GitIssueCommentEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{16}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GitIssueCommentEvent) GetRepos() []string {
@@ -2298,7 +2518,7 @@ type GitPullRequestReviewCommentEvent struct {
 
 func (x *GitPullRequestReviewCommentEvent) Reset() {
 	*x = GitPullRequestReviewCommentEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2310,7 +2530,7 @@ func (x *GitPullRequestReviewCommentEvent) String() string {
 func (*GitPullRequestReviewCommentEvent) ProtoMessage() {}
 
 func (x *GitPullRequestReviewCommentEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[17]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2323,7 +2543,7 @@ func (x *GitPullRequestReviewCommentEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPullRequestReviewCommentEvent.ProtoReflect.Descriptor instead.
 func (*GitPullRequestReviewCommentEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{17}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GitPullRequestReviewCommentEvent) GetRepos() []string {
@@ -2371,7 +2591,7 @@ type GitPullRequestReviewEvent struct {
 
 func (x *GitPullRequestReviewEvent) Reset() {
 	*x = GitPullRequestReviewEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2383,7 +2603,7 @@ func (x *GitPullRequestReviewEvent) String() string {
 func (*GitPullRequestReviewEvent) ProtoMessage() {}
 
 func (x *GitPullRequestReviewEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[18]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2396,7 +2616,7 @@ func (x *GitPullRequestReviewEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPullRequestReviewEvent.ProtoReflect.Descriptor instead.
 func (*GitPullRequestReviewEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{18}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GitPullRequestReviewEvent) GetRepos() []string {
@@ -2441,7 +2661,7 @@ type GitReviewThreadEvent struct {
 
 func (x *GitReviewThreadEvent) Reset() {
 	*x = GitReviewThreadEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2453,7 +2673,7 @@ func (x *GitReviewThreadEvent) String() string {
 func (*GitReviewThreadEvent) ProtoMessage() {}
 
 func (x *GitReviewThreadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[19]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2466,7 +2686,7 @@ func (x *GitReviewThreadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitReviewThreadEvent.ProtoReflect.Descriptor instead.
 func (*GitReviewThreadEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{19}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GitReviewThreadEvent) GetRepos() []string {
@@ -2509,7 +2729,7 @@ type GitWorkflowRunEvent struct {
 
 func (x *GitWorkflowRunEvent) Reset() {
 	*x = GitWorkflowRunEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2521,7 +2741,7 @@ func (x *GitWorkflowRunEvent) String() string {
 func (*GitWorkflowRunEvent) ProtoMessage() {}
 
 func (x *GitWorkflowRunEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[20]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2534,7 +2754,7 @@ func (x *GitWorkflowRunEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitWorkflowRunEvent.ProtoReflect.Descriptor instead.
 func (*GitWorkflowRunEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{20}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GitWorkflowRunEvent) GetRepos() []string {
@@ -2586,7 +2806,7 @@ type GitLabelEvent struct {
 
 func (x *GitLabelEvent) Reset() {
 	*x = GitLabelEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2598,7 +2818,7 @@ func (x *GitLabelEvent) String() string {
 func (*GitLabelEvent) ProtoMessage() {}
 
 func (x *GitLabelEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[21]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2611,7 +2831,7 @@ func (x *GitLabelEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitLabelEvent.ProtoReflect.Descriptor instead.
 func (*GitLabelEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{21}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GitLabelEvent) GetRepos() []string {
@@ -2685,7 +2905,7 @@ type SlackTrigger struct {
 
 func (x *SlackTrigger) Reset() {
 	*x = SlackTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2697,7 +2917,7 @@ func (x *SlackTrigger) String() string {
 func (*SlackTrigger) ProtoMessage() {}
 
 func (x *SlackTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[22]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2710,7 +2930,7 @@ func (x *SlackTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackTrigger.ProtoReflect.Descriptor instead.
 func (*SlackTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{22}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SlackTrigger) GetChannel() string {
@@ -2780,7 +3000,7 @@ type SlackChannelCreatedTrigger struct {
 
 func (x *SlackChannelCreatedTrigger) Reset() {
 	*x = SlackChannelCreatedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2792,7 +3012,7 @@ func (x *SlackChannelCreatedTrigger) String() string {
 func (*SlackChannelCreatedTrigger) ProtoMessage() {}
 
 func (x *SlackChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[23]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2805,7 +3025,7 @@ func (x *SlackChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackChannelCreatedTrigger.ProtoReflect.Descriptor instead.
 func (*SlackChannelCreatedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{23}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SlackChannelCreatedTrigger) GetChannelNameContains() string {
@@ -2828,13 +3048,17 @@ type SlackReactionAddedTrigger struct {
 	// If true, only Slack users who linked Cursor can trigger (bots/unknown blocked).
 	// Omitted/false = anyone in the channel can trigger (default).
 	BlockUnauthenticatedSlackUsers bool `protobuf:"varint,6,opt,name=block_unauthenticated_slack_users,json=blockUnauthenticatedSlackUsers,proto3" json:"block_unauthenticated_slack_users,omitempty"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	// If true, only the automation owner's own linked Slack user can trigger it
+	// ("when I react"). Stricter than block_unauthenticated_slack_users, which
+	// admits any member of an owning team, and it does not redact message_text.
+	OnlyOwnerReactions bool `protobuf:"varint,9,opt,name=only_owner_reactions,json=onlyOwnerReactions,proto3" json:"only_owner_reactions,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *SlackReactionAddedTrigger) Reset() {
 	*x = SlackReactionAddedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2846,7 +3070,7 @@ func (x *SlackReactionAddedTrigger) String() string {
 func (*SlackReactionAddedTrigger) ProtoMessage() {}
 
 func (x *SlackReactionAddedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[24]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2859,7 +3083,7 @@ func (x *SlackReactionAddedTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackReactionAddedTrigger.ProtoReflect.Descriptor instead.
 func (*SlackReactionAddedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{24}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SlackReactionAddedTrigger) GetChannel() string {
@@ -2890,6 +3114,142 @@ func (x *SlackReactionAddedTrigger) GetBlockUnauthenticatedSlackUsers() bool {
 	return false
 }
 
+func (x *SlackReactionAddedTrigger) GetOnlyOwnerReactions() bool {
+	if x != nil {
+		return x.OnlyOwnerReactions
+	}
+	return false
+}
+
+type SlackMentionTrigger struct {
+	state                          protoimpl.MessageState `protogen:"open.v1"`
+	Channel                        string                 `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`
+	Channels                       []string               `protobuf:"bytes,2,rep,name=channels,proto3" json:"channels,omitempty"`
+	BlockUnauthenticatedSlackUsers bool                   `protobuf:"varint,3,opt,name=block_unauthenticated_slack_users,json=blockUnauthenticatedSlackUsers,proto3" json:"block_unauthenticated_slack_users,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
+}
+
+func (x *SlackMentionTrigger) Reset() {
+	*x = SlackMentionTrigger{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SlackMentionTrigger) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SlackMentionTrigger) ProtoMessage() {}
+
+func (x *SlackMentionTrigger) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SlackMentionTrigger.ProtoReflect.Descriptor instead.
+func (*SlackMentionTrigger) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *SlackMentionTrigger) GetChannel() string {
+	if x != nil {
+		return x.Channel
+	}
+	return ""
+}
+
+func (x *SlackMentionTrigger) GetChannels() []string {
+	if x != nil {
+		return x.Channels
+	}
+	return nil
+}
+
+func (x *SlackMentionTrigger) GetBlockUnauthenticatedSlackUsers() bool {
+	if x != nil {
+		return x.BlockUnauthenticatedSlackUsers
+	}
+	return false
+}
+
+type SlackAnyReactionAddedTrigger struct {
+	state                          protoimpl.MessageState `protogen:"open.v1"`
+	Channel                        string                 `protobuf:"bytes,1,opt,name=channel,proto3" json:"channel,omitempty"`
+	Channels                       []string               `protobuf:"bytes,2,rep,name=channels,proto3" json:"channels,omitempty"`
+	BlockUnauthenticatedSlackUsers bool                   `protobuf:"varint,3,opt,name=block_unauthenticated_slack_users,json=blockUnauthenticatedSlackUsers,proto3" json:"block_unauthenticated_slack_users,omitempty"`
+	// See SlackReactionAddedTrigger.only_owner_reactions.
+	OnlyOwnerReactions bool `protobuf:"varint,4,opt,name=only_owner_reactions,json=onlyOwnerReactions,proto3" json:"only_owner_reactions,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *SlackAnyReactionAddedTrigger) Reset() {
+	*x = SlackAnyReactionAddedTrigger{}
+	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SlackAnyReactionAddedTrigger) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SlackAnyReactionAddedTrigger) ProtoMessage() {}
+
+func (x *SlackAnyReactionAddedTrigger) ProtoReflect() protoreflect.Message {
+	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SlackAnyReactionAddedTrigger.ProtoReflect.Descriptor instead.
+func (*SlackAnyReactionAddedTrigger) Descriptor() ([]byte, []int) {
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *SlackAnyReactionAddedTrigger) GetChannel() string {
+	if x != nil {
+		return x.Channel
+	}
+	return ""
+}
+
+func (x *SlackAnyReactionAddedTrigger) GetChannels() []string {
+	if x != nil {
+		return x.Channels
+	}
+	return nil
+}
+
+func (x *SlackAnyReactionAddedTrigger) GetBlockUnauthenticatedSlackUsers() bool {
+	if x != nil {
+		return x.BlockUnauthenticatedSlackUsers
+	}
+	return false
+}
+
+func (x *SlackAnyReactionAddedTrigger) GetOnlyOwnerReactions() bool {
+	if x != nil {
+		return x.OnlyOwnerReactions
+	}
+	return false
+}
+
 // LinearTrigger fires when Linear events occur.
 type LinearTrigger struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2911,7 +3271,7 @@ type LinearTrigger struct {
 
 func (x *LinearTrigger) Reset() {
 	*x = LinearTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2923,7 +3283,7 @@ func (x *LinearTrigger) String() string {
 func (*LinearTrigger) ProtoMessage() {}
 
 func (x *LinearTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[25]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2936,7 +3296,7 @@ func (x *LinearTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearTrigger.ProtoReflect.Descriptor instead.
 func (*LinearTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{25}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LinearTrigger) GetEvent() isLinearTrigger_Event {
@@ -3017,7 +3377,7 @@ type LinearIssueCreatedEvent struct {
 
 func (x *LinearIssueCreatedEvent) Reset() {
 	*x = LinearIssueCreatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3029,7 +3389,7 @@ func (x *LinearIssueCreatedEvent) String() string {
 func (*LinearIssueCreatedEvent) ProtoMessage() {}
 
 func (x *LinearIssueCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[26]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3042,7 +3402,7 @@ func (x *LinearIssueCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearIssueCreatedEvent.ProtoReflect.Descriptor instead.
 func (*LinearIssueCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{26}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{30}
 }
 
 type LinearStatusChangedEvent struct {
@@ -3055,7 +3415,7 @@ type LinearStatusChangedEvent struct {
 
 func (x *LinearStatusChangedEvent) Reset() {
 	*x = LinearStatusChangedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3067,7 +3427,7 @@ func (x *LinearStatusChangedEvent) String() string {
 func (*LinearStatusChangedEvent) ProtoMessage() {}
 
 func (x *LinearStatusChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[27]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3080,7 +3440,7 @@ func (x *LinearStatusChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearStatusChangedEvent.ProtoReflect.Descriptor instead.
 func (*LinearStatusChangedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{27}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *LinearStatusChangedEvent) GetStatusIds() []string {
@@ -3100,7 +3460,7 @@ type LinearEndOfCycleEvent struct {
 
 func (x *LinearEndOfCycleEvent) Reset() {
 	*x = LinearEndOfCycleEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3112,7 +3472,7 @@ func (x *LinearEndOfCycleEvent) String() string {
 func (*LinearEndOfCycleEvent) ProtoMessage() {}
 
 func (x *LinearEndOfCycleEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[28]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3125,7 +3485,7 @@ func (x *LinearEndOfCycleEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinearEndOfCycleEvent.ProtoReflect.Descriptor instead.
 func (*LinearEndOfCycleEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{28}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LinearEndOfCycleEvent) GetCycleIds() []string {
@@ -3144,7 +3504,7 @@ type WebhookTrigger struct {
 
 func (x *WebhookTrigger) Reset() {
 	*x = WebhookTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3156,7 +3516,7 @@ func (x *WebhookTrigger) String() string {
 func (*WebhookTrigger) ProtoMessage() {}
 
 func (x *WebhookTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[29]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3169,7 +3529,7 @@ func (x *WebhookTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebhookTrigger.ProtoReflect.Descriptor instead.
 func (*WebhookTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{29}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{33}
 }
 
 // PagerDutyTrigger fires when PagerDuty incident events occur.
@@ -3192,7 +3552,7 @@ type PagerDutyTrigger struct {
 
 func (x *PagerDutyTrigger) Reset() {
 	*x = PagerDutyTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3204,7 +3564,7 @@ func (x *PagerDutyTrigger) String() string {
 func (*PagerDutyTrigger) ProtoMessage() {}
 
 func (x *PagerDutyTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[30]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3217,7 +3577,7 @@ func (x *PagerDutyTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyTrigger.ProtoReflect.Descriptor instead.
 func (*PagerDutyTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{30}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *PagerDutyTrigger) GetEvent() isPagerDutyTrigger_Event {
@@ -3321,7 +3681,7 @@ type PagerDutyIncidentTriggeredEvent struct {
 
 func (x *PagerDutyIncidentTriggeredEvent) Reset() {
 	*x = PagerDutyIncidentTriggeredEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3333,7 +3693,7 @@ func (x *PagerDutyIncidentTriggeredEvent) String() string {
 func (*PagerDutyIncidentTriggeredEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentTriggeredEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[31]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3346,7 +3706,7 @@ func (x *PagerDutyIncidentTriggeredEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentTriggeredEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentTriggeredEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{31}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{35}
 }
 
 type PagerDutyIncidentAcknowledgedEvent struct {
@@ -3357,7 +3717,7 @@ type PagerDutyIncidentAcknowledgedEvent struct {
 
 func (x *PagerDutyIncidentAcknowledgedEvent) Reset() {
 	*x = PagerDutyIncidentAcknowledgedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3369,7 +3729,7 @@ func (x *PagerDutyIncidentAcknowledgedEvent) String() string {
 func (*PagerDutyIncidentAcknowledgedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentAcknowledgedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[32]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3382,7 +3742,7 @@ func (x *PagerDutyIncidentAcknowledgedEvent) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use PagerDutyIncidentAcknowledgedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentAcknowledgedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{32}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{36}
 }
 
 type PagerDutyIncidentResolvedEvent struct {
@@ -3393,7 +3753,7 @@ type PagerDutyIncidentResolvedEvent struct {
 
 func (x *PagerDutyIncidentResolvedEvent) Reset() {
 	*x = PagerDutyIncidentResolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3405,7 +3765,7 @@ func (x *PagerDutyIncidentResolvedEvent) String() string {
 func (*PagerDutyIncidentResolvedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentResolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[33]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3418,7 +3778,7 @@ func (x *PagerDutyIncidentResolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentResolvedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentResolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{33}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{37}
 }
 
 type PagerDutyIncidentEscalatedEvent struct {
@@ -3429,7 +3789,7 @@ type PagerDutyIncidentEscalatedEvent struct {
 
 func (x *PagerDutyIncidentEscalatedEvent) Reset() {
 	*x = PagerDutyIncidentEscalatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3441,7 +3801,7 @@ func (x *PagerDutyIncidentEscalatedEvent) String() string {
 func (*PagerDutyIncidentEscalatedEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentEscalatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[34]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3454,7 +3814,7 @@ func (x *PagerDutyIncidentEscalatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentEscalatedEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentEscalatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{34}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{38}
 }
 
 // Matches any incident event type (triggered, acknowledged, resolved, escalated).
@@ -3466,7 +3826,7 @@ type PagerDutyIncidentAnyEvent struct {
 
 func (x *PagerDutyIncidentAnyEvent) Reset() {
 	*x = PagerDutyIncidentAnyEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3478,7 +3838,7 @@ func (x *PagerDutyIncidentAnyEvent) String() string {
 func (*PagerDutyIncidentAnyEvent) ProtoMessage() {}
 
 func (x *PagerDutyIncidentAnyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[35]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3491,7 +3851,7 @@ func (x *PagerDutyIncidentAnyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PagerDutyIncidentAnyEvent.ProtoReflect.Descriptor instead.
 func (*PagerDutyIncidentAnyEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{35}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{39}
 }
 
 // SentryTrigger fires when Sentry issue webhooks are delivered to the Integration Platform
@@ -3517,7 +3877,7 @@ type SentryTrigger struct {
 
 func (x *SentryTrigger) Reset() {
 	*x = SentryTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3529,7 +3889,7 @@ func (x *SentryTrigger) String() string {
 func (*SentryTrigger) ProtoMessage() {}
 
 func (x *SentryTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[36]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3542,7 +3902,7 @@ func (x *SentryTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryTrigger.ProtoReflect.Descriptor instead.
 func (*SentryTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{36}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *SentryTrigger) GetEvent() isSentryTrigger_Event {
@@ -3661,7 +4021,7 @@ type SentryIssueCreatedEvent struct {
 
 func (x *SentryIssueCreatedEvent) Reset() {
 	*x = SentryIssueCreatedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3673,7 +4033,7 @@ func (x *SentryIssueCreatedEvent) String() string {
 func (*SentryIssueCreatedEvent) ProtoMessage() {}
 
 func (x *SentryIssueCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[37]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3686,7 +4046,7 @@ func (x *SentryIssueCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueCreatedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{37}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{41}
 }
 
 type SentryIssueResolvedEvent struct {
@@ -3697,7 +4057,7 @@ type SentryIssueResolvedEvent struct {
 
 func (x *SentryIssueResolvedEvent) Reset() {
 	*x = SentryIssueResolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3709,7 +4069,7 @@ func (x *SentryIssueResolvedEvent) String() string {
 func (*SentryIssueResolvedEvent) ProtoMessage() {}
 
 func (x *SentryIssueResolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[38]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3722,7 +4082,7 @@ func (x *SentryIssueResolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueResolvedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueResolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{38}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{42}
 }
 
 type SentryIssueAssignedEvent struct {
@@ -3733,7 +4093,7 @@ type SentryIssueAssignedEvent struct {
 
 func (x *SentryIssueAssignedEvent) Reset() {
 	*x = SentryIssueAssignedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3745,7 +4105,7 @@ func (x *SentryIssueAssignedEvent) String() string {
 func (*SentryIssueAssignedEvent) ProtoMessage() {}
 
 func (x *SentryIssueAssignedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[39]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3758,7 +4118,7 @@ func (x *SentryIssueAssignedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueAssignedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueAssignedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{39}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{43}
 }
 
 type SentryIssueArchivedEvent struct {
@@ -3769,7 +4129,7 @@ type SentryIssueArchivedEvent struct {
 
 func (x *SentryIssueArchivedEvent) Reset() {
 	*x = SentryIssueArchivedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3781,7 +4141,7 @@ func (x *SentryIssueArchivedEvent) String() string {
 func (*SentryIssueArchivedEvent) ProtoMessage() {}
 
 func (x *SentryIssueArchivedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[40]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3794,7 +4154,7 @@ func (x *SentryIssueArchivedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueArchivedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueArchivedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{40}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{44}
 }
 
 type SentryIssueUnresolvedEvent struct {
@@ -3805,7 +4165,7 @@ type SentryIssueUnresolvedEvent struct {
 
 func (x *SentryIssueUnresolvedEvent) Reset() {
 	*x = SentryIssueUnresolvedEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3817,7 +4177,7 @@ func (x *SentryIssueUnresolvedEvent) String() string {
 func (*SentryIssueUnresolvedEvent) ProtoMessage() {}
 
 func (x *SentryIssueUnresolvedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[41]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3830,7 +4190,7 @@ func (x *SentryIssueUnresolvedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueUnresolvedEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueUnresolvedEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{41}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{45}
 }
 
 type SentryIssueAnyEvent struct {
@@ -3841,7 +4201,7 @@ type SentryIssueAnyEvent struct {
 
 func (x *SentryIssueAnyEvent) Reset() {
 	*x = SentryIssueAnyEvent{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3853,7 +4213,7 @@ func (x *SentryIssueAnyEvent) String() string {
 func (*SentryIssueAnyEvent) ProtoMessage() {}
 
 func (x *SentryIssueAnyEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[42]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3866,7 +4226,7 @@ func (x *SentryIssueAnyEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SentryIssueAnyEvent.ProtoReflect.Descriptor instead.
 func (*SentryIssueAnyEvent) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{42}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{46}
 }
 
 // MicrosoftTeamsTrigger fires when messages are posted in a configured
@@ -3905,7 +4265,7 @@ type MicrosoftTeamsTrigger struct {
 
 func (x *MicrosoftTeamsTrigger) Reset() {
 	*x = MicrosoftTeamsTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3917,7 +4277,7 @@ func (x *MicrosoftTeamsTrigger) String() string {
 func (*MicrosoftTeamsTrigger) ProtoMessage() {}
 
 func (x *MicrosoftTeamsTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[43]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3930,7 +4290,7 @@ func (x *MicrosoftTeamsTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosoftTeamsTrigger.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{43}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *MicrosoftTeamsTrigger) GetTenantId() string {
@@ -3999,7 +4359,7 @@ type MicrosoftTeamsChannelCreatedTrigger struct {
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) Reset() {
 	*x = MicrosoftTeamsChannelCreatedTrigger{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4011,7 +4371,7 @@ func (x *MicrosoftTeamsChannelCreatedTrigger) String() string {
 func (*MicrosoftTeamsChannelCreatedTrigger) ProtoMessage() {}
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[44]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4024,7 +4384,7 @@ func (x *MicrosoftTeamsChannelCreatedTrigger) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use MicrosoftTeamsChannelCreatedTrigger.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsChannelCreatedTrigger) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{44}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *MicrosoftTeamsChannelCreatedTrigger) GetTenantId() string {
@@ -4057,7 +4417,7 @@ type GitPrAction struct {
 
 func (x *GitPrAction) Reset() {
 	*x = GitPrAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4069,7 +4429,7 @@ func (x *GitPrAction) String() string {
 func (*GitPrAction) ProtoMessage() {}
 
 func (x *GitPrAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[45]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4082,7 +4442,7 @@ func (x *GitPrAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitPrAction.ProtoReflect.Descriptor instead.
 func (*GitPrAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{45}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{49}
 }
 
 // Action: posts a comment/review on a PR. Defaults to the pull request from a
@@ -4105,7 +4465,7 @@ type PrCommentAction struct {
 
 func (x *PrCommentAction) Reset() {
 	*x = PrCommentAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4117,7 +4477,7 @@ func (x *PrCommentAction) String() string {
 func (*PrCommentAction) ProtoMessage() {}
 
 func (x *PrCommentAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[46]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4130,7 +4490,7 @@ func (x *PrCommentAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrCommentAction.ProtoReflect.Descriptor instead.
 func (*PrCommentAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{46}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{50}
 }
 
 // Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
@@ -4178,7 +4538,7 @@ type ManageCheckRunAction struct {
 
 func (x *ManageCheckRunAction) Reset() {
 	*x = ManageCheckRunAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4190,7 +4550,7 @@ func (x *ManageCheckRunAction) String() string {
 func (*ManageCheckRunAction) ProtoMessage() {}
 
 func (x *ManageCheckRunAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[47]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4203,7 +4563,7 @@ func (x *ManageCheckRunAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ManageCheckRunAction.ProtoReflect.Descriptor instead.
 func (*ManageCheckRunAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{47}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{51}
 }
 
 // Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
@@ -4226,7 +4586,7 @@ type RequestReviewersAction struct {
 
 func (x *RequestReviewersAction) Reset() {
 	*x = RequestReviewersAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4238,7 +4598,7 @@ func (x *RequestReviewersAction) String() string {
 func (*RequestReviewersAction) ProtoMessage() {}
 
 func (x *RequestReviewersAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[48]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4251,7 +4611,7 @@ func (x *RequestReviewersAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequestReviewersAction.ProtoReflect.Descriptor instead.
 func (*RequestReviewersAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{48}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{52}
 }
 
 // Deprecated: approve capability is now a field on PrCommentAction.allow_approve.
@@ -4266,7 +4626,7 @@ type ApprovePrAction struct {
 
 func (x *ApprovePrAction) Reset() {
 	*x = ApprovePrAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4278,7 +4638,7 @@ func (x *ApprovePrAction) String() string {
 func (*ApprovePrAction) ProtoMessage() {}
 
 func (x *ApprovePrAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[49]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4291,7 +4651,7 @@ func (x *ApprovePrAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApprovePrAction.ProtoReflect.Descriptor instead.
 func (*ApprovePrAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{49}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{53}
 }
 
 // Action: gives the agent read-only access to public Slack channels the user belongs to.
@@ -4304,7 +4664,7 @@ type ReadSlackAction struct {
 
 func (x *ReadSlackAction) Reset() {
 	*x = ReadSlackAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4316,7 +4676,7 @@ func (x *ReadSlackAction) String() string {
 func (*ReadSlackAction) ProtoMessage() {}
 
 func (x *ReadSlackAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[50]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4329,7 +4689,7 @@ func (x *ReadSlackAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadSlackAction.ProtoReflect.Descriptor instead.
 func (*ReadSlackAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{50}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{54}
 }
 
 // Action: lets the automation mark its own prior PR review threads as addressed
@@ -4345,7 +4705,7 @@ type ResolveReviewThreadsAction struct {
 
 func (x *ResolveReviewThreadsAction) Reset() {
 	*x = ResolveReviewThreadsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4357,7 +4717,7 @@ func (x *ResolveReviewThreadsAction) String() string {
 func (*ResolveReviewThreadsAction) ProtoMessage() {}
 
 func (x *ResolveReviewThreadsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[51]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4370,7 +4730,7 @@ func (x *ResolveReviewThreadsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResolveReviewThreadsAction.ProtoReflect.Descriptor instead.
 func (*ResolveReviewThreadsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{51}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{55}
 }
 
 type SlackAction struct {
@@ -4379,8 +4739,9 @@ type SlackAction struct {
 	// If true, the agent can list and send to any Slack channel or DM dynamically.
 	// When set, channel is ignored and the agent uses ListSlackChannels + SendSlackMessage tools instead of PostToSlack.
 	Generalized bool `protobuf:"varint,2,opt,name=generalized,proto3" json:"generalized,omitempty"`
-	// If true, respond in the thread of the triggering Slack message (only valid for Slack triggers).
-	// When this is set, the channel field is ignored and determined from the trigger.
+	// Ignored (replies thread automatically, CPROD-2013); kept for compatibility with existing configs.
+	//
+	// Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
 	RespondInThread bool `protobuf:"varint,3,opt,name=respond_in_thread,json=respondInThread,proto3" json:"respond_in_thread,omitempty"`
 	// If true, post a parent message with the automation name and reply with output messages in the thread.
 	PostAsThread  bool     `protobuf:"varint,4,opt,name=post_as_thread,json=postAsThread,proto3" json:"post_as_thread,omitempty"`
@@ -4391,7 +4752,7 @@ type SlackAction struct {
 
 func (x *SlackAction) Reset() {
 	*x = SlackAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4403,7 +4764,7 @@ func (x *SlackAction) String() string {
 func (*SlackAction) ProtoMessage() {}
 
 func (x *SlackAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[52]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4416,7 +4777,7 @@ func (x *SlackAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SlackAction.ProtoReflect.Descriptor instead.
 func (*SlackAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{52}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *SlackAction) GetChannel() string {
@@ -4433,6 +4794,7 @@ func (x *SlackAction) GetGeneralized() bool {
 	return false
 }
 
+// Deprecated: Marked as deprecated in aiserver/v1/automations.proto.
 func (x *SlackAction) GetRespondInThread() bool {
 	if x != nil {
 		return x.RespondInThread
@@ -4487,7 +4849,7 @@ type MicrosoftTeamsAction struct {
 
 func (x *MicrosoftTeamsAction) Reset() {
 	*x = MicrosoftTeamsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4499,7 +4861,7 @@ func (x *MicrosoftTeamsAction) String() string {
 func (*MicrosoftTeamsAction) ProtoMessage() {}
 
 func (x *MicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[53]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4512,7 +4874,7 @@ func (x *MicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MicrosoftTeamsAction.ProtoReflect.Descriptor instead.
 func (*MicrosoftTeamsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{53}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *MicrosoftTeamsAction) GetTenantId() string {
@@ -4575,7 +4937,7 @@ type ReadMicrosoftTeamsAction struct {
 
 func (x *ReadMicrosoftTeamsAction) Reset() {
 	*x = ReadMicrosoftTeamsAction{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4587,7 +4949,7 @@ func (x *ReadMicrosoftTeamsAction) String() string {
 func (*ReadMicrosoftTeamsAction) ProtoMessage() {}
 
 func (x *ReadMicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[54]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4600,7 +4962,7 @@ func (x *ReadMicrosoftTeamsAction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadMicrosoftTeamsAction.ProtoReflect.Descriptor instead.
 func (*ReadMicrosoftTeamsAction) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{54}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{58}
 }
 
 type CreateAutomationRequest struct {
@@ -4608,7 +4970,8 @@ type CreateAutomationRequest struct {
 	Name        string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Workflow    *Workflow              `protobuf:"bytes,2,opt,name=workflow,proto3" json:"workflow,omitempty"`
 	Description *string                `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
-	// Scope for the new automation. Defaults to USER when omitted.
+	// Scope for the new automation. When omitted, team requests use the team's
+	// default automation visibility and individual requests use USER.
 	Scope       *AutomationScope `protobuf:"varint,4,opt,name=scope,proto3,enum=aiserver.v1.AutomationScope,oneof" json:"scope,omitempty"`
 	TemplateId  *string          `protobuf:"bytes,5,opt,name=template_id,json=templateId,proto3,oneof" json:"template_id,omitempty"`
 	ManagedType *string          `protobuf:"bytes,6,opt,name=managed_type,json=managedType,proto3,oneof" json:"managed_type,omitempty"`
@@ -4618,14 +4981,16 @@ type CreateAutomationRequest struct {
 	TeamId         *int32                   `protobuf:"varint,8,opt,name=team_id,json=teamId,proto3,oneof" json:"team_id,omitempty"`
 	CreationSource AutomationCreationSource `protobuf:"varint,9,opt,name=creation_source,json=creationSource,proto3,enum=aiserver.v1.AutomationCreationSource" json:"creation_source,omitempty"`
 	// Defaults to true when omitted.
-	Enabled       *bool `protobuf:"varint,10,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Enabled          *bool   `protobuf:"varint,10,opt,name=enabled,proto3,oneof" json:"enabled,omitempty"`
+	SandAgentId      *string `protobuf:"bytes,11,opt,name=sand_agent_id,json=sandAgentId,proto3,oneof" json:"sand_agent_id,omitempty"`
+	SandAutomationId *string `protobuf:"bytes,12,opt,name=sand_automation_id,json=sandAutomationId,proto3,oneof" json:"sand_automation_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *CreateAutomationRequest) Reset() {
 	*x = CreateAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4637,7 +5002,7 @@ func (x *CreateAutomationRequest) String() string {
 func (*CreateAutomationRequest) ProtoMessage() {}
 
 func (x *CreateAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[55]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4650,7 +5015,7 @@ func (x *CreateAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAutomationRequest.ProtoReflect.Descriptor instead.
 func (*CreateAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{55}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *CreateAutomationRequest) GetName() string {
@@ -4723,6 +5088,20 @@ func (x *CreateAutomationRequest) GetEnabled() bool {
 	return false
 }
 
+func (x *CreateAutomationRequest) GetSandAgentId() string {
+	if x != nil && x.SandAgentId != nil {
+		return *x.SandAgentId
+	}
+	return ""
+}
+
+func (x *CreateAutomationRequest) GetSandAutomationId() string {
+	if x != nil && x.SandAutomationId != nil {
+		return *x.SandAutomationId
+	}
+	return ""
+}
+
 type CreateAutomationResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Workflow      *AutomationWithOwner   `protobuf:"bytes,1,opt,name=workflow,proto3" json:"workflow,omitempty"`
@@ -4732,7 +5111,7 @@ type CreateAutomationResponse struct {
 
 func (x *CreateAutomationResponse) Reset() {
 	*x = CreateAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4744,7 +5123,7 @@ func (x *CreateAutomationResponse) String() string {
 func (*CreateAutomationResponse) ProtoMessage() {}
 
 func (x *CreateAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[56]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4757,7 +5136,7 @@ func (x *CreateAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAutomationResponse.ProtoReflect.Descriptor instead.
 func (*CreateAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{56}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *CreateAutomationResponse) GetWorkflow() *AutomationWithOwner {
@@ -4770,14 +5149,17 @@ func (x *CreateAutomationResponse) GetWorkflow() *AutomationWithOwner {
 type GetAutomationRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Automation ID (UUID) of the automation to fetch.
-	AutomationId  string `protobuf:"bytes,2,opt,name=automation_id,json=automationId,proto3" json:"automation_id,omitempty"`
+	AutomationId string `protobuf:"bytes,2,opt,name=automation_id,json=automationId,proto3" json:"automation_id,omitempty"`
+	// Optional selected team to use when authorizing team-visible automations.
+	// Omitted by older clients, which keeps the legacy authenticated-team behavior.
+	TeamId        *int32 `protobuf:"varint,3,opt,name=team_id,json=teamId,proto3,oneof" json:"team_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetAutomationRequest) Reset() {
 	*x = GetAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4789,7 +5171,7 @@ func (x *GetAutomationRequest) String() string {
 func (*GetAutomationRequest) ProtoMessage() {}
 
 func (x *GetAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[57]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4802,7 +5184,7 @@ func (x *GetAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAutomationRequest.ProtoReflect.Descriptor instead.
 func (*GetAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{57}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetAutomationRequest) GetAutomationId() string {
@@ -4810,6 +5192,13 @@ func (x *GetAutomationRequest) GetAutomationId() string {
 		return x.AutomationId
 	}
 	return ""
+}
+
+func (x *GetAutomationRequest) GetTeamId() int32 {
+	if x != nil && x.TeamId != nil {
+		return *x.TeamId
+	}
+	return 0
 }
 
 type RestrictedAutomationSummary struct {
@@ -4826,7 +5215,7 @@ type RestrictedAutomationSummary struct {
 
 func (x *RestrictedAutomationSummary) Reset() {
 	*x = RestrictedAutomationSummary{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4838,7 +5227,7 @@ func (x *RestrictedAutomationSummary) String() string {
 func (*RestrictedAutomationSummary) ProtoMessage() {}
 
 func (x *RestrictedAutomationSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[58]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4851,7 +5240,7 @@ func (x *RestrictedAutomationSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RestrictedAutomationSummary.ProtoReflect.Descriptor instead.
 func (*RestrictedAutomationSummary) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{58}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *RestrictedAutomationSummary) GetAutomationId() string {
@@ -4895,7 +5284,7 @@ type GetAutomationResponse struct {
 
 func (x *GetAutomationResponse) Reset() {
 	*x = GetAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4907,7 +5296,7 @@ func (x *GetAutomationResponse) String() string {
 func (*GetAutomationResponse) ProtoMessage() {}
 
 func (x *GetAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[59]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4920,7 +5309,7 @@ func (x *GetAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAutomationResponse.ProtoReflect.Descriptor instead.
 func (*GetAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{59}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *GetAutomationResponse) GetResult() isGetAutomationResponse_Result {
@@ -4982,7 +5371,7 @@ type UpdateAutomationRequest struct {
 
 func (x *UpdateAutomationRequest) Reset() {
 	*x = UpdateAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4994,7 +5383,7 @@ func (x *UpdateAutomationRequest) String() string {
 func (*UpdateAutomationRequest) ProtoMessage() {}
 
 func (x *UpdateAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[60]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5007,7 +5396,7 @@ func (x *UpdateAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAutomationRequest.ProtoReflect.Descriptor instead.
 func (*UpdateAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{60}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *UpdateAutomationRequest) GetName() string {
@@ -5075,7 +5464,7 @@ type UpdateAutomationResponse struct {
 
 func (x *UpdateAutomationResponse) Reset() {
 	*x = UpdateAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5087,7 +5476,7 @@ func (x *UpdateAutomationResponse) String() string {
 func (*UpdateAutomationResponse) ProtoMessage() {}
 
 func (x *UpdateAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[61]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5100,7 +5489,7 @@ func (x *UpdateAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateAutomationResponse.ProtoReflect.Descriptor instead.
 func (*UpdateAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{61}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *UpdateAutomationResponse) GetWorkflow() *AutomationWithOwner {
@@ -5120,7 +5509,7 @@ type DeleteAutomationRequest struct {
 
 func (x *DeleteAutomationRequest) Reset() {
 	*x = DeleteAutomationRequest{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5132,7 +5521,7 @@ func (x *DeleteAutomationRequest) String() string {
 func (*DeleteAutomationRequest) ProtoMessage() {}
 
 func (x *DeleteAutomationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[62]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5145,7 +5534,7 @@ func (x *DeleteAutomationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAutomationRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAutomationRequest) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{62}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *DeleteAutomationRequest) GetAutomationId() string {
@@ -5163,7 +5552,7 @@ type DeleteAutomationResponse struct {
 
 func (x *DeleteAutomationResponse) Reset() {
 	*x = DeleteAutomationResponse{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5175,7 +5564,7 @@ func (x *DeleteAutomationResponse) String() string {
 func (*DeleteAutomationResponse) ProtoMessage() {}
 
 func (x *DeleteAutomationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[63]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5188,7 +5577,7 @@ func (x *DeleteAutomationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAutomationResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAutomationResponse) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{63}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{67}
 }
 
 type Automation struct {
@@ -5218,7 +5607,7 @@ type Automation struct {
 
 func (x *Automation) Reset() {
 	*x = Automation{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5230,7 +5619,7 @@ func (x *Automation) String() string {
 func (*Automation) ProtoMessage() {}
 
 func (x *Automation) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[64]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5243,7 +5632,7 @@ func (x *Automation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Automation.ProtoReflect.Descriptor instead.
 func (*Automation) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{64}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *Automation) GetName() string {
@@ -5369,7 +5758,7 @@ type AutomationMcpAuthState struct {
 
 func (x *AutomationMcpAuthState) Reset() {
 	*x = AutomationMcpAuthState{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5381,7 +5770,7 @@ func (x *AutomationMcpAuthState) String() string {
 func (*AutomationMcpAuthState) ProtoMessage() {}
 
 func (x *AutomationMcpAuthState) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[65]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5394,7 +5783,7 @@ func (x *AutomationMcpAuthState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AutomationMcpAuthState.ProtoReflect.Descriptor instead.
 func (*AutomationMcpAuthState) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{65}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *AutomationMcpAuthState) GetServerId() int64 {
@@ -5436,7 +5825,7 @@ type AutomationWithOwner struct {
 
 func (x *AutomationWithOwner) Reset() {
 	*x = AutomationWithOwner{}
-	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5448,7 +5837,7 @@ func (x *AutomationWithOwner) String() string {
 func (*AutomationWithOwner) ProtoMessage() {}
 
 func (x *AutomationWithOwner) ProtoReflect() protoreflect.Message {
-	mi := &file_aiserver_v1_automations_proto_msgTypes[66]
+	mi := &file_aiserver_v1_automations_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5461,7 +5850,7 @@ func (x *AutomationWithOwner) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AutomationWithOwner.ProtoReflect.Descriptor instead.
 func (*AutomationWithOwner) Descriptor() ([]byte, []int) {
-	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{66}
+	return file_aiserver_v1_automations_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *AutomationWithOwner) GetWorkflow() *Automation {
@@ -5503,7 +5892,7 @@ var File_aiserver_v1_automations_proto protoreflect.FileDescriptor
 
 const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\n" +
-	"\x1daiserver/v1/automations.proto\x12\vaiserver.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x84\a\n" +
+	"\x1daiserver/v1/automations.proto\x12\vaiserver.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xb3\b\n" +
 	"\aTrigger\x12.\n" +
 	"\x04cron\x18\x01 \x01(\v2\x18.aiserver.v1.CronTriggerH\x00R\x04cron\x12+\n" +
 	"\x03git\x18\x02 \x01(\v2\x17.aiserver.v1.GitTriggerH\x00R\x03git\x12@\n" +
@@ -5515,7 +5904,9 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x06sentry\x18\x0f \x01(\v2\x1a.aiserver.v1.SentryTriggerH\x00R\x06sentry\x12\\\n" +
 	"\x17microsoft_teams_trigger\x18\x10 \x01(\v2\".aiserver.v1.MicrosoftTeamsTriggerH\x00R\x15microsoftTeamsTrigger\x12y\n" +
 	"\x1fmicrosoft_teams_channel_created\x18\x11 \x01(\v20.aiserver.v1.MicrosoftTeamsChannelCreatedTriggerH\x00R\x1cmicrosoftTeamsChannelCreated\x12Z\n" +
-	"\x14slack_reaction_added\x18\x12 \x01(\v2&.aiserver.v1.SlackReactionAddedTriggerH\x00R\x12slackReactionAdded\x127\n" +
+	"\x14slack_reaction_added\x18\x12 \x01(\v2&.aiserver.v1.SlackReactionAddedTriggerH\x00R\x12slackReactionAdded\x12G\n" +
+	"\rslack_mention\x18\x13 \x01(\v2 .aiserver.v1.SlackMentionTriggerH\x00R\fslackMention\x12d\n" +
+	"\x18slack_any_reaction_added\x18\x14 \x01(\v2).aiserver.v1.SlackAnyReactionAddedTriggerH\x00R\x15slackAnyReactionAdded\x127\n" +
 	"\x15agentic_filter_prompt\x18\x0e \x01(\tH\x01R\x13agenticFilterPrompt\x88\x01\x01B\t\n" +
 	"\atriggerB\x18\n" +
 	"\x16_agentic_filter_promptJ\x04\b\n" +
@@ -5554,7 +5945,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x15environment_public_id\x18\x03 \x01(\tH\x02R\x13environmentPublicId\x88\x01\x01B\x0f\n" +
 	"\r_skip_installB\x11\n" +
 	"\x0f_private_workerB\x18\n" +
-	"\x16_environment_public_id\"\xf5\x06\n" +
+	"\x16_environment_public_id\"\xcf\a\n" +
 	"\bWorkflow\x120\n" +
 	"\btriggers\x18\n" +
 	" \x03(\v2\x14.aiserver.v1.TriggerR\btriggers\x12-\n" +
@@ -5568,7 +5959,8 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x17slack_notified_channels\x18\x0f \x03(\tR\x15slackNotifiedChannels\x12r\n" +
 	"\x1eslack_completion_reaction_mode\x18\x10 \x01(\x0e2(.aiserver.v1.SlackCompletionReactionModeH\x04R\x1bslackCompletionReactionMode\x88\x01\x01\x12W\n" +
 	"&slack_completion_reaction_custom_emoji\x18\x11 \x01(\tH\x05R\"slackCompletionReactionCustomEmoji\x88\x01\x01\x12C\n" +
-	"\x0emanaged_config\x18\x12 \x01(\v2\x17.google.protobuf.StructH\x06R\rmanagedConfig\x88\x01\x01B\b\n" +
+	"\x0emanaged_config\x18\x12 \x01(\v2\x17.google.protobuf.StructH\x06R\rmanagedConfig\x88\x01\x01\x12X\n" +
+	"\x16disabled_default_tools\x18\x13 \x03(\x0e2\".aiserver.v1.AutomationDefaultToolR\x14disabledDefaultToolsB\b\n" +
 	"\x06_modelB\r\n" +
 	"\v_git_configB\x10\n" +
 	"\x0e_agent_optionsB\x11\n" +
@@ -5594,7 +5986,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x06branch\x18\x04 \x01(\tR\x06branch\x12\x14\n" +
 	"\x05repos\x18\x05 \x03(\tR\x05reposJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03\"'\n" +
 	"\vCronTrigger\x12\x12\n" +
-	"\x04cron\x18\x01 \x01(\tR\x04cronJ\x04\b\x02\x10\x03\"\x9e\x06\n" +
+	"\x04cron\x18\x01 \x01(\tR\x04cronJ\x04\b\x02\x10\x03\"\xe1\a\n" +
 	"\n" +
 	"GitTrigger\x12E\n" +
 	"\fpull_request\x18\x01 \x01(\v2 .aiserver.v1.GitPullRequestEventH\x00R\vpullRequest\x12/\n" +
@@ -5607,7 +5999,9 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x13pull_request_review\x18\t \x01(\v2&.aiserver.v1.GitPullRequestReviewEventH\x00R\x11pullRequestReview\x12H\n" +
 	"\rreview_thread\x18\n" +
 	" \x01(\v2!.aiserver.v1.GitReviewThreadEventH\x00R\freviewThread\x12E\n" +
-	"\fworkflow_run\x18\v \x01(\v2 .aiserver.v1.GitWorkflowRunEventH\x00R\vworkflowRun\x12%\n" +
+	"\fworkflow_run\x18\v \x01(\v2 .aiserver.v1.GitWorkflowRunEventH\x00R\vworkflowRun\x12t\n" +
+	"\x1dpull_request_review_requested\x18\f \x01(\v2/.aiserver.v1.GitPullRequestReviewRequestedEventH\x00R\x1apullRequestReviewRequested\x12K\n" +
+	"\x0eissue_assigned\x18\r \x01(\v2\".aiserver.v1.GitIssueAssignedEventH\x00R\rissueAssigned\x12%\n" +
 	"\x0euser_allowlist\x18\x03 \x03(\tR\ruserAllowlistB\a\n" +
 	"\x05event\"\x90\x03\n" +
 	"\x13GitPullRequestEvent\x12\x12\n" +
@@ -5622,16 +6016,21 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	" \x01(\bR\x16commentContainsIsRegex\x12\x1d\n" +
 	"\n" +
 	"label_name\x18\b \x01(\tR\tlabelName\x12\x12\n" +
-	"\x04orgs\x18\t \x03(\tR\x04orgs\"P\n" +
+	"\x04orgs\x18\t \x03(\tR\x04orgs\":\n" +
+	"\"GitPullRequestReviewRequestedEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\"-\n" +
+	"\x15GitIssueAssignedEvent\x12\x14\n" +
+	"\x05repos\x18\x01 \x03(\tR\x05repos\"P\n" +
 	"\fGitPushEvent\x12\x12\n" +
 	"\x04repo\x18\x01 \x01(\tR\x04repo\x12\x16\n" +
 	"\x06branch\x18\x02 \x01(\tR\x06branch\x12\x14\n" +
-	"\x05repos\x18\x03 \x03(\tR\x05repos\"\xba\x01\n" +
+	"\x05repos\x18\x03 \x03(\tR\x05repos\"\xd7\x01\n" +
 	"\x13GitCICompletedEvent\x12\x14\n" +
 	"\x05repos\x18\x01 \x03(\tR\x05repos\x12C\n" +
 	"\tcondition\x18\x02 \x01(\x0e2%.aiserver.v1.GitCICompletionConditionR\tcondition\x120\n" +
 	"\x14ignore_base_failures\x18\x03 \x01(\bR\x12ignoreBaseFailures\x12\x16\n" +
-	"\x06branch\x18\x04 \x01(\tR\x06branch\"i\n" +
+	"\x06branch\x18\x04 \x01(\tR\x06branch\x12\x1b\n" +
+	"\tpr_number\x18\x05 \x01(\x05R\bprNumber\"i\n" +
 	"\x14GitIssueLabeledEvent\x12\x14\n" +
 	"\x05repos\x18\x01 \x03(\tR\x05repos\x12\x1d\n" +
 	"\n" +
@@ -5687,13 +6086,23 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"'_slack_completion_reaction_custom_emojiB\x11\n" +
 	"\x0f_top_level_onlyJ\x04\b\x02\x10\x03\"P\n" +
 	"\x1aSlackChannelCreatedTrigger\x122\n" +
-	"\x15channel_name_contains\x18\x01 \x01(\tR\x13channelNameContains\"\x9b\x02\n" +
+	"\x15channel_name_contains\x18\x01 \x01(\tR\x13channelNameContains\"\xcd\x02\n" +
 	"\x19SlackReactionAddedTrigger\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1d\n" +
 	"\n" +
 	"emoji_name\x18\x03 \x01(\tR\temojiName\x12\x1a\n" +
 	"\bchannels\x18\x05 \x03(\tR\bchannels\x12I\n" +
-	"!block_unauthenticated_slack_users\x18\x06 \x01(\bR\x1eblockUnauthenticatedSlackUsersJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\b\x10\tR\x1eslack_completion_reaction_modeR&slack_completion_reaction_custom_emoji\"\xbf\x02\n" +
+	"!block_unauthenticated_slack_users\x18\x06 \x01(\bR\x1eblockUnauthenticatedSlackUsers\x120\n" +
+	"\x14only_owner_reactions\x18\t \x01(\bR\x12onlyOwnerReactionsJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\b\x10\tR\x1eslack_completion_reaction_modeR&slack_completion_reaction_custom_emoji\"\x96\x01\n" +
+	"\x13SlackMentionTrigger\x12\x18\n" +
+	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1a\n" +
+	"\bchannels\x18\x02 \x03(\tR\bchannels\x12I\n" +
+	"!block_unauthenticated_slack_users\x18\x03 \x01(\bR\x1eblockUnauthenticatedSlackUsers\"\xd1\x01\n" +
+	"\x1cSlackAnyReactionAddedTrigger\x12\x18\n" +
+	"\achannel\x18\x01 \x01(\tR\achannel\x12\x1a\n" +
+	"\bchannels\x18\x02 \x03(\tR\bchannels\x12I\n" +
+	"!block_unauthenticated_slack_users\x18\x03 \x01(\bR\x1eblockUnauthenticatedSlackUsers\x120\n" +
+	"\x14only_owner_reactions\x18\x04 \x01(\bR\x12onlyOwnerReactions\"\xbf\x02\n" +
 	"\rLinearTrigger\x12K\n" +
 	"\rissue_created\x18\x01 \x01(\v2$.aiserver.v1.LinearIssueCreatedEventH\x00R\fissueCreated\x12N\n" +
 	"\x0estatus_changed\x18\x02 \x01(\v2%.aiserver.v1.LinearStatusChangedEventH\x00R\rstatusChanged\x12F\n" +
@@ -5764,11 +6173,11 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x16RequestReviewersAction\"\x15\n" +
 	"\x0fApprovePrAction:\x02\x18\x01\"\x11\n" +
 	"\x0fReadSlackAction\"\x1c\n" +
-	"\x1aResolveReviewThreadsAction\"\xb7\x01\n" +
+	"\x1aResolveReviewThreadsAction\"\xbb\x01\n" +
 	"\vSlackAction\x12\x18\n" +
 	"\achannel\x18\x01 \x01(\tR\achannel\x12 \n" +
-	"\vgeneralized\x18\x02 \x01(\bR\vgeneralized\x12*\n" +
-	"\x11respond_in_thread\x18\x03 \x01(\bR\x0frespondInThread\x12$\n" +
+	"\vgeneralized\x18\x02 \x01(\bR\vgeneralized\x12.\n" +
+	"\x11respond_in_thread\x18\x03 \x01(\bB\x02\x18\x01R\x0frespondInThread\x12$\n" +
 	"\x0epost_as_thread\x18\x04 \x01(\bR\fpostAsThread\x12\x1a\n" +
 	"\bchannels\x18\x05 \x03(\tR\bchannels\"\x80\x02\n" +
 	"\x14MicrosoftTeamsAction\x12\x1b\n" +
@@ -5781,7 +6190,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\vgeneralized\x18\x05 \x01(\bR\vgeneralized\x12*\n" +
 	"\x11respond_in_thread\x18\x06 \x01(\bR\x0frespondInThread\x12$\n" +
 	"\x0epost_as_thread\x18\a \x01(\bR\fpostAsThread\"\x1a\n" +
-	"\x18ReadMicrosoftTeamsAction\"\x96\x04\n" +
+	"\x18ReadMicrosoftTeamsAction\"\x9b\x05\n" +
 	"\x17CreateAutomationRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x121\n" +
 	"\bworkflow\x18\x02 \x01(\v2\x15.aiserver.v1.WorkflowR\bworkflow\x12%\n" +
@@ -5794,7 +6203,9 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\ateam_id\x18\b \x01(\x05H\x05R\x06teamId\x88\x01\x01\x12N\n" +
 	"\x0fcreation_source\x18\t \x01(\x0e2%.aiserver.v1.AutomationCreationSourceR\x0ecreationSource\x12\x1d\n" +
 	"\aenabled\x18\n" +
-	" \x01(\bH\x06R\aenabled\x88\x01\x01B\x0e\n" +
+	" \x01(\bH\x06R\aenabled\x88\x01\x01\x12'\n" +
+	"\rsand_agent_id\x18\v \x01(\tH\aR\vsandAgentId\x88\x01\x01\x121\n" +
+	"\x12sand_automation_id\x18\f \x01(\tH\bR\x10sandAutomationId\x88\x01\x01B\x0e\n" +
 	"\f_descriptionB\b\n" +
 	"\x06_scopeB\x0e\n" +
 	"\f_template_idB\x0f\n" +
@@ -5803,11 +6214,16 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\n" +
 	"\b_team_idB\n" +
 	"\n" +
-	"\b_enabled\"X\n" +
+	"\b_enabledB\x10\n" +
+	"\x0e_sand_agent_idB\x15\n" +
+	"\x13_sand_automation_id\"X\n" +
 	"\x18CreateAutomationResponse\x12<\n" +
-	"\bworkflow\x18\x01 \x01(\v2 .aiserver.v1.AutomationWithOwnerR\bworkflow\"A\n" +
+	"\bworkflow\x18\x01 \x01(\v2 .aiserver.v1.AutomationWithOwnerR\bworkflow\"k\n" +
 	"\x14GetAutomationRequest\x12#\n" +
-	"\rautomation_id\x18\x02 \x01(\tR\fautomationIdJ\x04\b\x01\x10\x02\"\x8f\x01\n" +
+	"\rautomation_id\x18\x02 \x01(\tR\fautomationId\x12\x1c\n" +
+	"\ateam_id\x18\x03 \x01(\x05H\x00R\x06teamId\x88\x01\x01B\n" +
+	"\n" +
+	"\b_team_idJ\x04\b\x01\x10\x02\"\x8f\x01\n" +
 	"\x1bRestrictedAutomationSummary\x12#\n" +
 	"\rautomation_id\x18\x01 \x01(\tR\fautomationId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -5888,7 +6304,10 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\x0fmcp_auth_states\x18\x04 \x03(\v2#.aiserver.v1.AutomationMcpAuthStateR\rmcpAuthStates\x12\x1c\n" +
 	"\ateam_id\x18\x05 \x01(\x05H\x00R\x06teamId\x88\x01\x01B\n" +
 	"\n" +
-	"\b_team_id*\xc7\x01\n" +
+	"\b_team_id*i\n" +
+	"\x15AutomationDefaultTool\x12'\n" +
+	"#AUTOMATION_DEFAULT_TOOL_UNSPECIFIED\x10\x00\x12'\n" +
+	"#AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR\x10\x01*\xc7\x01\n" +
 	"\x1bSlackCompletionReactionMode\x12.\n" +
 	"*SLACK_COMPLETION_REACTION_MODE_UNSPECIFIED\x10\x00\x12%\n" +
 	"!SLACK_COMPLETION_REACTION_MODE_ON\x10\x01\x12&\n" +
@@ -5920,7 +6339,7 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"\rPromptRunMode\x12\x1f\n" +
 	"\x1bPROMPT_RUN_MODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19PROMPT_RUN_MODE_SAME_CHAT\x10\x01\x12\x1d\n" +
-	"\x19PROMPT_RUN_MODE_NEW_AGENT\x10\x02*\xc8\x02\n" +
+	"\x19PROMPT_RUN_MODE_NEW_AGENT\x10\x02*\xec\x02\n" +
 	"\x14GitPullRequestAction\x12'\n" +
 	"#GIT_PULL_REQUEST_ACTION_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eGIT_PULL_REQUEST_ACTION_OPENED\x10\x01\x12\"\n" +
@@ -5929,7 +6348,8 @@ const file_aiserver_v1_automations_proto_rawDesc = "" +
 	"!GIT_PULL_REQUEST_ACTION_COMMENTED\x10\x04\x12(\n" +
 	"$GIT_PULL_REQUEST_ACTION_DRAFT_OPENED\x10\x05\x12#\n" +
 	"\x1fGIT_PULL_REQUEST_ACTION_LABELED\x10\x06\x12%\n" +
-	"!GIT_PULL_REQUEST_ACTION_UNLABELED\x10\a*\xbe\x01\n" +
+	"!GIT_PULL_REQUEST_ACTION_UNLABELED\x10\a\x12\"\n" +
+	"\x1eGIT_PULL_REQUEST_ACTION_CLOSED\x10\b*\xbe\x01\n" +
 	"\x18GitCICompletionCondition\x12+\n" +
 	"'GIT_CI_COMPLETION_CONDITION_UNSPECIFIED\x10\x00\x12'\n" +
 	"#GIT_CI_COMPLETION_CONDITION_FAILURE\x10\x01\x12'\n" +
@@ -5964,179 +6384,189 @@ func file_aiserver_v1_automations_proto_rawDescGZIP() []byte {
 	return file_aiserver_v1_automations_proto_rawDescData
 }
 
-var file_aiserver_v1_automations_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_aiserver_v1_automations_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_aiserver_v1_automations_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
+var file_aiserver_v1_automations_proto_msgTypes = make([]protoimpl.MessageInfo, 71)
 var file_aiserver_v1_automations_proto_goTypes = []any{
-	(SlackCompletionReactionMode)(0),            // 0: aiserver.v1.SlackCompletionReactionMode
-	(AutomationScope)(0),                        // 1: aiserver.v1.AutomationScope
-	(AutomationCreationSource)(0),               // 2: aiserver.v1.AutomationCreationSource
-	(AutomationManagedBy)(0),                    // 3: aiserver.v1.AutomationManagedBy
-	(PromptEffortLevel)(0),                      // 4: aiserver.v1.PromptEffortLevel
-	(PromptRunMode)(0),                          // 5: aiserver.v1.PromptRunMode
-	(GitPullRequestAction)(0),                   // 6: aiserver.v1.GitPullRequestAction
-	(GitCICompletionCondition)(0),               // 7: aiserver.v1.GitCICompletionCondition
-	(GitWorkflowRunConclusion)(0),               // 8: aiserver.v1.GitWorkflowRunConclusion
-	(McpAuthState)(0),                           // 9: aiserver.v1.McpAuthState
-	(*Trigger)(nil),                             // 10: aiserver.v1.Trigger
-	(*Action)(nil),                              // 11: aiserver.v1.Action
-	(*McpAction)(nil),                           // 12: aiserver.v1.McpAction
-	(*McpServerConfig)(nil),                     // 13: aiserver.v1.McpServerConfig
-	(*AgentPrivateWorkerLabel)(nil),             // 14: aiserver.v1.AgentPrivateWorkerLabel
-	(*AgentPrivateWorkerConfig)(nil),            // 15: aiserver.v1.AgentPrivateWorkerConfig
-	(*AgentOptions)(nil),                        // 16: aiserver.v1.AgentOptions
-	(*Workflow)(nil),                            // 17: aiserver.v1.Workflow
-	(*Prompt)(nil),                              // 18: aiserver.v1.Prompt
-	(*GitConfig)(nil),                           // 19: aiserver.v1.GitConfig
-	(*CronTrigger)(nil),                         // 20: aiserver.v1.CronTrigger
-	(*GitTrigger)(nil),                          // 21: aiserver.v1.GitTrigger
-	(*GitPullRequestEvent)(nil),                 // 22: aiserver.v1.GitPullRequestEvent
-	(*GitPushEvent)(nil),                        // 23: aiserver.v1.GitPushEvent
-	(*GitCICompletedEvent)(nil),                 // 24: aiserver.v1.GitCICompletedEvent
-	(*GitIssueLabeledEvent)(nil),                // 25: aiserver.v1.GitIssueLabeledEvent
-	(*GitIssueCommentEvent)(nil),                // 26: aiserver.v1.GitIssueCommentEvent
-	(*GitPullRequestReviewCommentEvent)(nil),    // 27: aiserver.v1.GitPullRequestReviewCommentEvent
-	(*GitPullRequestReviewEvent)(nil),           // 28: aiserver.v1.GitPullRequestReviewEvent
-	(*GitReviewThreadEvent)(nil),                // 29: aiserver.v1.GitReviewThreadEvent
-	(*GitWorkflowRunEvent)(nil),                 // 30: aiserver.v1.GitWorkflowRunEvent
-	(*GitLabelEvent)(nil),                       // 31: aiserver.v1.GitLabelEvent
-	(*SlackTrigger)(nil),                        // 32: aiserver.v1.SlackTrigger
-	(*SlackChannelCreatedTrigger)(nil),          // 33: aiserver.v1.SlackChannelCreatedTrigger
-	(*SlackReactionAddedTrigger)(nil),           // 34: aiserver.v1.SlackReactionAddedTrigger
-	(*LinearTrigger)(nil),                       // 35: aiserver.v1.LinearTrigger
-	(*LinearIssueCreatedEvent)(nil),             // 36: aiserver.v1.LinearIssueCreatedEvent
-	(*LinearStatusChangedEvent)(nil),            // 37: aiserver.v1.LinearStatusChangedEvent
-	(*LinearEndOfCycleEvent)(nil),               // 38: aiserver.v1.LinearEndOfCycleEvent
-	(*WebhookTrigger)(nil),                      // 39: aiserver.v1.WebhookTrigger
-	(*PagerDutyTrigger)(nil),                    // 40: aiserver.v1.PagerDutyTrigger
-	(*PagerDutyIncidentTriggeredEvent)(nil),     // 41: aiserver.v1.PagerDutyIncidentTriggeredEvent
-	(*PagerDutyIncidentAcknowledgedEvent)(nil),  // 42: aiserver.v1.PagerDutyIncidentAcknowledgedEvent
-	(*PagerDutyIncidentResolvedEvent)(nil),      // 43: aiserver.v1.PagerDutyIncidentResolvedEvent
-	(*PagerDutyIncidentEscalatedEvent)(nil),     // 44: aiserver.v1.PagerDutyIncidentEscalatedEvent
-	(*PagerDutyIncidentAnyEvent)(nil),           // 45: aiserver.v1.PagerDutyIncidentAnyEvent
-	(*SentryTrigger)(nil),                       // 46: aiserver.v1.SentryTrigger
-	(*SentryIssueCreatedEvent)(nil),             // 47: aiserver.v1.SentryIssueCreatedEvent
-	(*SentryIssueResolvedEvent)(nil),            // 48: aiserver.v1.SentryIssueResolvedEvent
-	(*SentryIssueAssignedEvent)(nil),            // 49: aiserver.v1.SentryIssueAssignedEvent
-	(*SentryIssueArchivedEvent)(nil),            // 50: aiserver.v1.SentryIssueArchivedEvent
-	(*SentryIssueUnresolvedEvent)(nil),          // 51: aiserver.v1.SentryIssueUnresolvedEvent
-	(*SentryIssueAnyEvent)(nil),                 // 52: aiserver.v1.SentryIssueAnyEvent
-	(*MicrosoftTeamsTrigger)(nil),               // 53: aiserver.v1.MicrosoftTeamsTrigger
-	(*MicrosoftTeamsChannelCreatedTrigger)(nil), // 54: aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
-	(*GitPrAction)(nil),                         // 55: aiserver.v1.GitPrAction
-	(*PrCommentAction)(nil),                     // 56: aiserver.v1.PrCommentAction
-	(*ManageCheckRunAction)(nil),                // 57: aiserver.v1.ManageCheckRunAction
-	(*RequestReviewersAction)(nil),              // 58: aiserver.v1.RequestReviewersAction
-	(*ApprovePrAction)(nil),                     // 59: aiserver.v1.ApprovePrAction
-	(*ReadSlackAction)(nil),                     // 60: aiserver.v1.ReadSlackAction
-	(*ResolveReviewThreadsAction)(nil),          // 61: aiserver.v1.ResolveReviewThreadsAction
-	(*SlackAction)(nil),                         // 62: aiserver.v1.SlackAction
-	(*MicrosoftTeamsAction)(nil),                // 63: aiserver.v1.MicrosoftTeamsAction
-	(*ReadMicrosoftTeamsAction)(nil),            // 64: aiserver.v1.ReadMicrosoftTeamsAction
-	(*CreateAutomationRequest)(nil),             // 65: aiserver.v1.CreateAutomationRequest
-	(*CreateAutomationResponse)(nil),            // 66: aiserver.v1.CreateAutomationResponse
-	(*GetAutomationRequest)(nil),                // 67: aiserver.v1.GetAutomationRequest
-	(*RestrictedAutomationSummary)(nil),         // 68: aiserver.v1.RestrictedAutomationSummary
-	(*GetAutomationResponse)(nil),               // 69: aiserver.v1.GetAutomationResponse
-	(*UpdateAutomationRequest)(nil),             // 70: aiserver.v1.UpdateAutomationRequest
-	(*UpdateAutomationResponse)(nil),            // 71: aiserver.v1.UpdateAutomationResponse
-	(*DeleteAutomationRequest)(nil),             // 72: aiserver.v1.DeleteAutomationRequest
-	(*DeleteAutomationResponse)(nil),            // 73: aiserver.v1.DeleteAutomationResponse
-	(*Automation)(nil),                          // 74: aiserver.v1.Automation
-	(*AutomationMcpAuthState)(nil),              // 75: aiserver.v1.AutomationMcpAuthState
-	(*AutomationWithOwner)(nil),                 // 76: aiserver.v1.AutomationWithOwner
-	(*structpb.Struct)(nil),                     // 77: google.protobuf.Struct
+	(AutomationDefaultTool)(0),                  // 0: aiserver.v1.AutomationDefaultTool
+	(SlackCompletionReactionMode)(0),            // 1: aiserver.v1.SlackCompletionReactionMode
+	(AutomationScope)(0),                        // 2: aiserver.v1.AutomationScope
+	(AutomationCreationSource)(0),               // 3: aiserver.v1.AutomationCreationSource
+	(AutomationManagedBy)(0),                    // 4: aiserver.v1.AutomationManagedBy
+	(PromptEffortLevel)(0),                      // 5: aiserver.v1.PromptEffortLevel
+	(PromptRunMode)(0),                          // 6: aiserver.v1.PromptRunMode
+	(GitPullRequestAction)(0),                   // 7: aiserver.v1.GitPullRequestAction
+	(GitCICompletionCondition)(0),               // 8: aiserver.v1.GitCICompletionCondition
+	(GitWorkflowRunConclusion)(0),               // 9: aiserver.v1.GitWorkflowRunConclusion
+	(McpAuthState)(0),                           // 10: aiserver.v1.McpAuthState
+	(*Trigger)(nil),                             // 11: aiserver.v1.Trigger
+	(*Action)(nil),                              // 12: aiserver.v1.Action
+	(*McpAction)(nil),                           // 13: aiserver.v1.McpAction
+	(*McpServerConfig)(nil),                     // 14: aiserver.v1.McpServerConfig
+	(*AgentPrivateWorkerLabel)(nil),             // 15: aiserver.v1.AgentPrivateWorkerLabel
+	(*AgentPrivateWorkerConfig)(nil),            // 16: aiserver.v1.AgentPrivateWorkerConfig
+	(*AgentOptions)(nil),                        // 17: aiserver.v1.AgentOptions
+	(*Workflow)(nil),                            // 18: aiserver.v1.Workflow
+	(*Prompt)(nil),                              // 19: aiserver.v1.Prompt
+	(*GitConfig)(nil),                           // 20: aiserver.v1.GitConfig
+	(*CronTrigger)(nil),                         // 21: aiserver.v1.CronTrigger
+	(*GitTrigger)(nil),                          // 22: aiserver.v1.GitTrigger
+	(*GitPullRequestEvent)(nil),                 // 23: aiserver.v1.GitPullRequestEvent
+	(*GitPullRequestReviewRequestedEvent)(nil),  // 24: aiserver.v1.GitPullRequestReviewRequestedEvent
+	(*GitIssueAssignedEvent)(nil),               // 25: aiserver.v1.GitIssueAssignedEvent
+	(*GitPushEvent)(nil),                        // 26: aiserver.v1.GitPushEvent
+	(*GitCICompletedEvent)(nil),                 // 27: aiserver.v1.GitCICompletedEvent
+	(*GitIssueLabeledEvent)(nil),                // 28: aiserver.v1.GitIssueLabeledEvent
+	(*GitIssueCommentEvent)(nil),                // 29: aiserver.v1.GitIssueCommentEvent
+	(*GitPullRequestReviewCommentEvent)(nil),    // 30: aiserver.v1.GitPullRequestReviewCommentEvent
+	(*GitPullRequestReviewEvent)(nil),           // 31: aiserver.v1.GitPullRequestReviewEvent
+	(*GitReviewThreadEvent)(nil),                // 32: aiserver.v1.GitReviewThreadEvent
+	(*GitWorkflowRunEvent)(nil),                 // 33: aiserver.v1.GitWorkflowRunEvent
+	(*GitLabelEvent)(nil),                       // 34: aiserver.v1.GitLabelEvent
+	(*SlackTrigger)(nil),                        // 35: aiserver.v1.SlackTrigger
+	(*SlackChannelCreatedTrigger)(nil),          // 36: aiserver.v1.SlackChannelCreatedTrigger
+	(*SlackReactionAddedTrigger)(nil),           // 37: aiserver.v1.SlackReactionAddedTrigger
+	(*SlackMentionTrigger)(nil),                 // 38: aiserver.v1.SlackMentionTrigger
+	(*SlackAnyReactionAddedTrigger)(nil),        // 39: aiserver.v1.SlackAnyReactionAddedTrigger
+	(*LinearTrigger)(nil),                       // 40: aiserver.v1.LinearTrigger
+	(*LinearIssueCreatedEvent)(nil),             // 41: aiserver.v1.LinearIssueCreatedEvent
+	(*LinearStatusChangedEvent)(nil),            // 42: aiserver.v1.LinearStatusChangedEvent
+	(*LinearEndOfCycleEvent)(nil),               // 43: aiserver.v1.LinearEndOfCycleEvent
+	(*WebhookTrigger)(nil),                      // 44: aiserver.v1.WebhookTrigger
+	(*PagerDutyTrigger)(nil),                    // 45: aiserver.v1.PagerDutyTrigger
+	(*PagerDutyIncidentTriggeredEvent)(nil),     // 46: aiserver.v1.PagerDutyIncidentTriggeredEvent
+	(*PagerDutyIncidentAcknowledgedEvent)(nil),  // 47: aiserver.v1.PagerDutyIncidentAcknowledgedEvent
+	(*PagerDutyIncidentResolvedEvent)(nil),      // 48: aiserver.v1.PagerDutyIncidentResolvedEvent
+	(*PagerDutyIncidentEscalatedEvent)(nil),     // 49: aiserver.v1.PagerDutyIncidentEscalatedEvent
+	(*PagerDutyIncidentAnyEvent)(nil),           // 50: aiserver.v1.PagerDutyIncidentAnyEvent
+	(*SentryTrigger)(nil),                       // 51: aiserver.v1.SentryTrigger
+	(*SentryIssueCreatedEvent)(nil),             // 52: aiserver.v1.SentryIssueCreatedEvent
+	(*SentryIssueResolvedEvent)(nil),            // 53: aiserver.v1.SentryIssueResolvedEvent
+	(*SentryIssueAssignedEvent)(nil),            // 54: aiserver.v1.SentryIssueAssignedEvent
+	(*SentryIssueArchivedEvent)(nil),            // 55: aiserver.v1.SentryIssueArchivedEvent
+	(*SentryIssueUnresolvedEvent)(nil),          // 56: aiserver.v1.SentryIssueUnresolvedEvent
+	(*SentryIssueAnyEvent)(nil),                 // 57: aiserver.v1.SentryIssueAnyEvent
+	(*MicrosoftTeamsTrigger)(nil),               // 58: aiserver.v1.MicrosoftTeamsTrigger
+	(*MicrosoftTeamsChannelCreatedTrigger)(nil), // 59: aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
+	(*GitPrAction)(nil),                         // 60: aiserver.v1.GitPrAction
+	(*PrCommentAction)(nil),                     // 61: aiserver.v1.PrCommentAction
+	(*ManageCheckRunAction)(nil),                // 62: aiserver.v1.ManageCheckRunAction
+	(*RequestReviewersAction)(nil),              // 63: aiserver.v1.RequestReviewersAction
+	(*ApprovePrAction)(nil),                     // 64: aiserver.v1.ApprovePrAction
+	(*ReadSlackAction)(nil),                     // 65: aiserver.v1.ReadSlackAction
+	(*ResolveReviewThreadsAction)(nil),          // 66: aiserver.v1.ResolveReviewThreadsAction
+	(*SlackAction)(nil),                         // 67: aiserver.v1.SlackAction
+	(*MicrosoftTeamsAction)(nil),                // 68: aiserver.v1.MicrosoftTeamsAction
+	(*ReadMicrosoftTeamsAction)(nil),            // 69: aiserver.v1.ReadMicrosoftTeamsAction
+	(*CreateAutomationRequest)(nil),             // 70: aiserver.v1.CreateAutomationRequest
+	(*CreateAutomationResponse)(nil),            // 71: aiserver.v1.CreateAutomationResponse
+	(*GetAutomationRequest)(nil),                // 72: aiserver.v1.GetAutomationRequest
+	(*RestrictedAutomationSummary)(nil),         // 73: aiserver.v1.RestrictedAutomationSummary
+	(*GetAutomationResponse)(nil),               // 74: aiserver.v1.GetAutomationResponse
+	(*UpdateAutomationRequest)(nil),             // 75: aiserver.v1.UpdateAutomationRequest
+	(*UpdateAutomationResponse)(nil),            // 76: aiserver.v1.UpdateAutomationResponse
+	(*DeleteAutomationRequest)(nil),             // 77: aiserver.v1.DeleteAutomationRequest
+	(*DeleteAutomationResponse)(nil),            // 78: aiserver.v1.DeleteAutomationResponse
+	(*Automation)(nil),                          // 79: aiserver.v1.Automation
+	(*AutomationMcpAuthState)(nil),              // 80: aiserver.v1.AutomationMcpAuthState
+	(*AutomationWithOwner)(nil),                 // 81: aiserver.v1.AutomationWithOwner
+	(*structpb.Struct)(nil),                     // 82: google.protobuf.Struct
 }
 var file_aiserver_v1_automations_proto_depIdxs = []int32{
-	20, // 0: aiserver.v1.Trigger.cron:type_name -> aiserver.v1.CronTrigger
-	21, // 1: aiserver.v1.Trigger.git:type_name -> aiserver.v1.GitTrigger
-	32, // 2: aiserver.v1.Trigger.slack_trigger:type_name -> aiserver.v1.SlackTrigger
-	35, // 3: aiserver.v1.Trigger.linear:type_name -> aiserver.v1.LinearTrigger
-	39, // 4: aiserver.v1.Trigger.webhook:type_name -> aiserver.v1.WebhookTrigger
-	33, // 5: aiserver.v1.Trigger.slack_channel_created:type_name -> aiserver.v1.SlackChannelCreatedTrigger
-	40, // 6: aiserver.v1.Trigger.pagerduty:type_name -> aiserver.v1.PagerDutyTrigger
-	46, // 7: aiserver.v1.Trigger.sentry:type_name -> aiserver.v1.SentryTrigger
-	53, // 8: aiserver.v1.Trigger.microsoft_teams_trigger:type_name -> aiserver.v1.MicrosoftTeamsTrigger
-	54, // 9: aiserver.v1.Trigger.microsoft_teams_channel_created:type_name -> aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
-	34, // 10: aiserver.v1.Trigger.slack_reaction_added:type_name -> aiserver.v1.SlackReactionAddedTrigger
-	55, // 11: aiserver.v1.Action.git_pr:type_name -> aiserver.v1.GitPrAction
-	56, // 12: aiserver.v1.Action.pr_comment:type_name -> aiserver.v1.PrCommentAction
-	62, // 13: aiserver.v1.Action.slack:type_name -> aiserver.v1.SlackAction
-	12, // 14: aiserver.v1.Action.mcp:type_name -> aiserver.v1.McpAction
-	57, // 15: aiserver.v1.Action.manage_check_run:type_name -> aiserver.v1.ManageCheckRunAction
-	58, // 16: aiserver.v1.Action.request_reviewers:type_name -> aiserver.v1.RequestReviewersAction
-	60, // 17: aiserver.v1.Action.read_slack:type_name -> aiserver.v1.ReadSlackAction
-	59, // 18: aiserver.v1.Action.approve_pr:type_name -> aiserver.v1.ApprovePrAction
-	61, // 19: aiserver.v1.Action.resolve_review_threads:type_name -> aiserver.v1.ResolveReviewThreadsAction
-	63, // 20: aiserver.v1.Action.microsoft_teams:type_name -> aiserver.v1.MicrosoftTeamsAction
-	64, // 21: aiserver.v1.Action.read_microsoft_teams:type_name -> aiserver.v1.ReadMicrosoftTeamsAction
-	13, // 22: aiserver.v1.McpAction.server:type_name -> aiserver.v1.McpServerConfig
-	14, // 23: aiserver.v1.AgentPrivateWorkerConfig.labels:type_name -> aiserver.v1.AgentPrivateWorkerLabel
-	15, // 24: aiserver.v1.AgentOptions.private_worker:type_name -> aiserver.v1.AgentPrivateWorkerConfig
-	10, // 25: aiserver.v1.Workflow.triggers:type_name -> aiserver.v1.Trigger
-	11, // 26: aiserver.v1.Workflow.actions:type_name -> aiserver.v1.Action
-	18, // 27: aiserver.v1.Workflow.prompts:type_name -> aiserver.v1.Prompt
-	19, // 28: aiserver.v1.Workflow.git_config:type_name -> aiserver.v1.GitConfig
-	16, // 29: aiserver.v1.Workflow.agent_options:type_name -> aiserver.v1.AgentOptions
-	0,  // 30: aiserver.v1.Workflow.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
-	77, // 31: aiserver.v1.Workflow.managed_config:type_name -> google.protobuf.Struct
-	4,  // 32: aiserver.v1.Prompt.effort_level:type_name -> aiserver.v1.PromptEffortLevel
-	5,  // 33: aiserver.v1.Prompt.run_mode:type_name -> aiserver.v1.PromptRunMode
-	22, // 34: aiserver.v1.GitTrigger.pull_request:type_name -> aiserver.v1.GitPullRequestEvent
-	23, // 35: aiserver.v1.GitTrigger.push:type_name -> aiserver.v1.GitPushEvent
-	24, // 36: aiserver.v1.GitTrigger.ci_completed:type_name -> aiserver.v1.GitCICompletedEvent
-	25, // 37: aiserver.v1.GitTrigger.issue_labeled:type_name -> aiserver.v1.GitIssueLabeledEvent
-	31, // 38: aiserver.v1.GitTrigger.label:type_name -> aiserver.v1.GitLabelEvent
-	26, // 39: aiserver.v1.GitTrigger.issue_comment:type_name -> aiserver.v1.GitIssueCommentEvent
-	27, // 40: aiserver.v1.GitTrigger.pull_request_review_comment:type_name -> aiserver.v1.GitPullRequestReviewCommentEvent
-	28, // 41: aiserver.v1.GitTrigger.pull_request_review:type_name -> aiserver.v1.GitPullRequestReviewEvent
-	29, // 42: aiserver.v1.GitTrigger.review_thread:type_name -> aiserver.v1.GitReviewThreadEvent
-	30, // 43: aiserver.v1.GitTrigger.workflow_run:type_name -> aiserver.v1.GitWorkflowRunEvent
-	6,  // 44: aiserver.v1.GitPullRequestEvent.pr_action:type_name -> aiserver.v1.GitPullRequestAction
-	7,  // 45: aiserver.v1.GitCICompletedEvent.condition:type_name -> aiserver.v1.GitCICompletionCondition
-	8,  // 46: aiserver.v1.GitWorkflowRunEvent.conclusion:type_name -> aiserver.v1.GitWorkflowRunConclusion
-	0,  // 47: aiserver.v1.SlackTrigger.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
-	36, // 48: aiserver.v1.LinearTrigger.issue_created:type_name -> aiserver.v1.LinearIssueCreatedEvent
-	37, // 49: aiserver.v1.LinearTrigger.status_changed:type_name -> aiserver.v1.LinearStatusChangedEvent
-	38, // 50: aiserver.v1.LinearTrigger.end_of_cycle:type_name -> aiserver.v1.LinearEndOfCycleEvent
-	41, // 51: aiserver.v1.PagerDutyTrigger.incident_triggered:type_name -> aiserver.v1.PagerDutyIncidentTriggeredEvent
-	42, // 52: aiserver.v1.PagerDutyTrigger.incident_acknowledged:type_name -> aiserver.v1.PagerDutyIncidentAcknowledgedEvent
-	43, // 53: aiserver.v1.PagerDutyTrigger.incident_resolved:type_name -> aiserver.v1.PagerDutyIncidentResolvedEvent
-	44, // 54: aiserver.v1.PagerDutyTrigger.incident_escalated:type_name -> aiserver.v1.PagerDutyIncidentEscalatedEvent
-	45, // 55: aiserver.v1.PagerDutyTrigger.incident_any:type_name -> aiserver.v1.PagerDutyIncidentAnyEvent
-	47, // 56: aiserver.v1.SentryTrigger.issue_created:type_name -> aiserver.v1.SentryIssueCreatedEvent
-	48, // 57: aiserver.v1.SentryTrigger.issue_resolved:type_name -> aiserver.v1.SentryIssueResolvedEvent
-	49, // 58: aiserver.v1.SentryTrigger.issue_assigned:type_name -> aiserver.v1.SentryIssueAssignedEvent
-	50, // 59: aiserver.v1.SentryTrigger.issue_archived:type_name -> aiserver.v1.SentryIssueArchivedEvent
-	51, // 60: aiserver.v1.SentryTrigger.issue_unresolved:type_name -> aiserver.v1.SentryIssueUnresolvedEvent
-	52, // 61: aiserver.v1.SentryTrigger.issue_any:type_name -> aiserver.v1.SentryIssueAnyEvent
-	17, // 62: aiserver.v1.CreateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
-	1,  // 63: aiserver.v1.CreateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
-	2,  // 64: aiserver.v1.CreateAutomationRequest.creation_source:type_name -> aiserver.v1.AutomationCreationSource
-	76, // 65: aiserver.v1.CreateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	76, // 66: aiserver.v1.GetAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	68, // 67: aiserver.v1.GetAutomationResponse.restricted_summary:type_name -> aiserver.v1.RestrictedAutomationSummary
-	17, // 68: aiserver.v1.UpdateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
-	1,  // 69: aiserver.v1.UpdateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
-	76, // 70: aiserver.v1.UpdateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
-	17, // 71: aiserver.v1.Automation.workflow:type_name -> aiserver.v1.Workflow
-	1,  // 72: aiserver.v1.Automation.scope:type_name -> aiserver.v1.AutomationScope
-	3,  // 73: aiserver.v1.Automation.managed_by:type_name -> aiserver.v1.AutomationManagedBy
-	9,  // 74: aiserver.v1.AutomationMcpAuthState.auth_state:type_name -> aiserver.v1.McpAuthState
-	74, // 75: aiserver.v1.AutomationWithOwner.workflow:type_name -> aiserver.v1.Automation
-	75, // 76: aiserver.v1.AutomationWithOwner.mcp_auth_states:type_name -> aiserver.v1.AutomationMcpAuthState
-	65, // 77: aiserver.v1.AutomationsService.CreateAutomation:input_type -> aiserver.v1.CreateAutomationRequest
-	67, // 78: aiserver.v1.AutomationsService.GetAutomation:input_type -> aiserver.v1.GetAutomationRequest
-	70, // 79: aiserver.v1.AutomationsService.UpdateAutomation:input_type -> aiserver.v1.UpdateAutomationRequest
-	72, // 80: aiserver.v1.AutomationsService.DeleteAutomation:input_type -> aiserver.v1.DeleteAutomationRequest
-	66, // 81: aiserver.v1.AutomationsService.CreateAutomation:output_type -> aiserver.v1.CreateAutomationResponse
-	69, // 82: aiserver.v1.AutomationsService.GetAutomation:output_type -> aiserver.v1.GetAutomationResponse
-	71, // 83: aiserver.v1.AutomationsService.UpdateAutomation:output_type -> aiserver.v1.UpdateAutomationResponse
-	73, // 84: aiserver.v1.AutomationsService.DeleteAutomation:output_type -> aiserver.v1.DeleteAutomationResponse
-	81, // [81:85] is the sub-list for method output_type
-	77, // [77:81] is the sub-list for method input_type
-	77, // [77:77] is the sub-list for extension type_name
-	77, // [77:77] is the sub-list for extension extendee
-	0,  // [0:77] is the sub-list for field type_name
+	21, // 0: aiserver.v1.Trigger.cron:type_name -> aiserver.v1.CronTrigger
+	22, // 1: aiserver.v1.Trigger.git:type_name -> aiserver.v1.GitTrigger
+	35, // 2: aiserver.v1.Trigger.slack_trigger:type_name -> aiserver.v1.SlackTrigger
+	40, // 3: aiserver.v1.Trigger.linear:type_name -> aiserver.v1.LinearTrigger
+	44, // 4: aiserver.v1.Trigger.webhook:type_name -> aiserver.v1.WebhookTrigger
+	36, // 5: aiserver.v1.Trigger.slack_channel_created:type_name -> aiserver.v1.SlackChannelCreatedTrigger
+	45, // 6: aiserver.v1.Trigger.pagerduty:type_name -> aiserver.v1.PagerDutyTrigger
+	51, // 7: aiserver.v1.Trigger.sentry:type_name -> aiserver.v1.SentryTrigger
+	58, // 8: aiserver.v1.Trigger.microsoft_teams_trigger:type_name -> aiserver.v1.MicrosoftTeamsTrigger
+	59, // 9: aiserver.v1.Trigger.microsoft_teams_channel_created:type_name -> aiserver.v1.MicrosoftTeamsChannelCreatedTrigger
+	37, // 10: aiserver.v1.Trigger.slack_reaction_added:type_name -> aiserver.v1.SlackReactionAddedTrigger
+	38, // 11: aiserver.v1.Trigger.slack_mention:type_name -> aiserver.v1.SlackMentionTrigger
+	39, // 12: aiserver.v1.Trigger.slack_any_reaction_added:type_name -> aiserver.v1.SlackAnyReactionAddedTrigger
+	60, // 13: aiserver.v1.Action.git_pr:type_name -> aiserver.v1.GitPrAction
+	61, // 14: aiserver.v1.Action.pr_comment:type_name -> aiserver.v1.PrCommentAction
+	67, // 15: aiserver.v1.Action.slack:type_name -> aiserver.v1.SlackAction
+	13, // 16: aiserver.v1.Action.mcp:type_name -> aiserver.v1.McpAction
+	62, // 17: aiserver.v1.Action.manage_check_run:type_name -> aiserver.v1.ManageCheckRunAction
+	63, // 18: aiserver.v1.Action.request_reviewers:type_name -> aiserver.v1.RequestReviewersAction
+	65, // 19: aiserver.v1.Action.read_slack:type_name -> aiserver.v1.ReadSlackAction
+	64, // 20: aiserver.v1.Action.approve_pr:type_name -> aiserver.v1.ApprovePrAction
+	66, // 21: aiserver.v1.Action.resolve_review_threads:type_name -> aiserver.v1.ResolveReviewThreadsAction
+	68, // 22: aiserver.v1.Action.microsoft_teams:type_name -> aiserver.v1.MicrosoftTeamsAction
+	69, // 23: aiserver.v1.Action.read_microsoft_teams:type_name -> aiserver.v1.ReadMicrosoftTeamsAction
+	14, // 24: aiserver.v1.McpAction.server:type_name -> aiserver.v1.McpServerConfig
+	15, // 25: aiserver.v1.AgentPrivateWorkerConfig.labels:type_name -> aiserver.v1.AgentPrivateWorkerLabel
+	16, // 26: aiserver.v1.AgentOptions.private_worker:type_name -> aiserver.v1.AgentPrivateWorkerConfig
+	11, // 27: aiserver.v1.Workflow.triggers:type_name -> aiserver.v1.Trigger
+	12, // 28: aiserver.v1.Workflow.actions:type_name -> aiserver.v1.Action
+	19, // 29: aiserver.v1.Workflow.prompts:type_name -> aiserver.v1.Prompt
+	20, // 30: aiserver.v1.Workflow.git_config:type_name -> aiserver.v1.GitConfig
+	17, // 31: aiserver.v1.Workflow.agent_options:type_name -> aiserver.v1.AgentOptions
+	1,  // 32: aiserver.v1.Workflow.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
+	82, // 33: aiserver.v1.Workflow.managed_config:type_name -> google.protobuf.Struct
+	0,  // 34: aiserver.v1.Workflow.disabled_default_tools:type_name -> aiserver.v1.AutomationDefaultTool
+	5,  // 35: aiserver.v1.Prompt.effort_level:type_name -> aiserver.v1.PromptEffortLevel
+	6,  // 36: aiserver.v1.Prompt.run_mode:type_name -> aiserver.v1.PromptRunMode
+	23, // 37: aiserver.v1.GitTrigger.pull_request:type_name -> aiserver.v1.GitPullRequestEvent
+	26, // 38: aiserver.v1.GitTrigger.push:type_name -> aiserver.v1.GitPushEvent
+	27, // 39: aiserver.v1.GitTrigger.ci_completed:type_name -> aiserver.v1.GitCICompletedEvent
+	28, // 40: aiserver.v1.GitTrigger.issue_labeled:type_name -> aiserver.v1.GitIssueLabeledEvent
+	34, // 41: aiserver.v1.GitTrigger.label:type_name -> aiserver.v1.GitLabelEvent
+	29, // 42: aiserver.v1.GitTrigger.issue_comment:type_name -> aiserver.v1.GitIssueCommentEvent
+	30, // 43: aiserver.v1.GitTrigger.pull_request_review_comment:type_name -> aiserver.v1.GitPullRequestReviewCommentEvent
+	31, // 44: aiserver.v1.GitTrigger.pull_request_review:type_name -> aiserver.v1.GitPullRequestReviewEvent
+	32, // 45: aiserver.v1.GitTrigger.review_thread:type_name -> aiserver.v1.GitReviewThreadEvent
+	33, // 46: aiserver.v1.GitTrigger.workflow_run:type_name -> aiserver.v1.GitWorkflowRunEvent
+	24, // 47: aiserver.v1.GitTrigger.pull_request_review_requested:type_name -> aiserver.v1.GitPullRequestReviewRequestedEvent
+	25, // 48: aiserver.v1.GitTrigger.issue_assigned:type_name -> aiserver.v1.GitIssueAssignedEvent
+	7,  // 49: aiserver.v1.GitPullRequestEvent.pr_action:type_name -> aiserver.v1.GitPullRequestAction
+	8,  // 50: aiserver.v1.GitCICompletedEvent.condition:type_name -> aiserver.v1.GitCICompletionCondition
+	9,  // 51: aiserver.v1.GitWorkflowRunEvent.conclusion:type_name -> aiserver.v1.GitWorkflowRunConclusion
+	1,  // 52: aiserver.v1.SlackTrigger.slack_completion_reaction_mode:type_name -> aiserver.v1.SlackCompletionReactionMode
+	41, // 53: aiserver.v1.LinearTrigger.issue_created:type_name -> aiserver.v1.LinearIssueCreatedEvent
+	42, // 54: aiserver.v1.LinearTrigger.status_changed:type_name -> aiserver.v1.LinearStatusChangedEvent
+	43, // 55: aiserver.v1.LinearTrigger.end_of_cycle:type_name -> aiserver.v1.LinearEndOfCycleEvent
+	46, // 56: aiserver.v1.PagerDutyTrigger.incident_triggered:type_name -> aiserver.v1.PagerDutyIncidentTriggeredEvent
+	47, // 57: aiserver.v1.PagerDutyTrigger.incident_acknowledged:type_name -> aiserver.v1.PagerDutyIncidentAcknowledgedEvent
+	48, // 58: aiserver.v1.PagerDutyTrigger.incident_resolved:type_name -> aiserver.v1.PagerDutyIncidentResolvedEvent
+	49, // 59: aiserver.v1.PagerDutyTrigger.incident_escalated:type_name -> aiserver.v1.PagerDutyIncidentEscalatedEvent
+	50, // 60: aiserver.v1.PagerDutyTrigger.incident_any:type_name -> aiserver.v1.PagerDutyIncidentAnyEvent
+	52, // 61: aiserver.v1.SentryTrigger.issue_created:type_name -> aiserver.v1.SentryIssueCreatedEvent
+	53, // 62: aiserver.v1.SentryTrigger.issue_resolved:type_name -> aiserver.v1.SentryIssueResolvedEvent
+	54, // 63: aiserver.v1.SentryTrigger.issue_assigned:type_name -> aiserver.v1.SentryIssueAssignedEvent
+	55, // 64: aiserver.v1.SentryTrigger.issue_archived:type_name -> aiserver.v1.SentryIssueArchivedEvent
+	56, // 65: aiserver.v1.SentryTrigger.issue_unresolved:type_name -> aiserver.v1.SentryIssueUnresolvedEvent
+	57, // 66: aiserver.v1.SentryTrigger.issue_any:type_name -> aiserver.v1.SentryIssueAnyEvent
+	18, // 67: aiserver.v1.CreateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
+	2,  // 68: aiserver.v1.CreateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
+	3,  // 69: aiserver.v1.CreateAutomationRequest.creation_source:type_name -> aiserver.v1.AutomationCreationSource
+	81, // 70: aiserver.v1.CreateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	81, // 71: aiserver.v1.GetAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	73, // 72: aiserver.v1.GetAutomationResponse.restricted_summary:type_name -> aiserver.v1.RestrictedAutomationSummary
+	18, // 73: aiserver.v1.UpdateAutomationRequest.workflow:type_name -> aiserver.v1.Workflow
+	2,  // 74: aiserver.v1.UpdateAutomationRequest.scope:type_name -> aiserver.v1.AutomationScope
+	81, // 75: aiserver.v1.UpdateAutomationResponse.workflow:type_name -> aiserver.v1.AutomationWithOwner
+	18, // 76: aiserver.v1.Automation.workflow:type_name -> aiserver.v1.Workflow
+	2,  // 77: aiserver.v1.Automation.scope:type_name -> aiserver.v1.AutomationScope
+	4,  // 78: aiserver.v1.Automation.managed_by:type_name -> aiserver.v1.AutomationManagedBy
+	10, // 79: aiserver.v1.AutomationMcpAuthState.auth_state:type_name -> aiserver.v1.McpAuthState
+	79, // 80: aiserver.v1.AutomationWithOwner.workflow:type_name -> aiserver.v1.Automation
+	80, // 81: aiserver.v1.AutomationWithOwner.mcp_auth_states:type_name -> aiserver.v1.AutomationMcpAuthState
+	70, // 82: aiserver.v1.AutomationsService.CreateAutomation:input_type -> aiserver.v1.CreateAutomationRequest
+	72, // 83: aiserver.v1.AutomationsService.GetAutomation:input_type -> aiserver.v1.GetAutomationRequest
+	75, // 84: aiserver.v1.AutomationsService.UpdateAutomation:input_type -> aiserver.v1.UpdateAutomationRequest
+	77, // 85: aiserver.v1.AutomationsService.DeleteAutomation:input_type -> aiserver.v1.DeleteAutomationRequest
+	71, // 86: aiserver.v1.AutomationsService.CreateAutomation:output_type -> aiserver.v1.CreateAutomationResponse
+	74, // 87: aiserver.v1.AutomationsService.GetAutomation:output_type -> aiserver.v1.GetAutomationResponse
+	76, // 88: aiserver.v1.AutomationsService.UpdateAutomation:output_type -> aiserver.v1.UpdateAutomationResponse
+	78, // 89: aiserver.v1.AutomationsService.DeleteAutomation:output_type -> aiserver.v1.DeleteAutomationResponse
+	86, // [86:90] is the sub-list for method output_type
+	82, // [82:86] is the sub-list for method input_type
+	82, // [82:82] is the sub-list for extension type_name
+	82, // [82:82] is the sub-list for extension extendee
+	0,  // [0:82] is the sub-list for field type_name
 }
 
 func init() { file_aiserver_v1_automations_proto_init() }
@@ -6156,6 +6586,8 @@ func file_aiserver_v1_automations_proto_init() {
 		(*Trigger_MicrosoftTeamsTrigger)(nil),
 		(*Trigger_MicrosoftTeamsChannelCreated)(nil),
 		(*Trigger_SlackReactionAdded)(nil),
+		(*Trigger_SlackMention)(nil),
+		(*Trigger_SlackAnyReactionAdded)(nil),
 	}
 	file_aiserver_v1_automations_proto_msgTypes[1].OneofWrappers = []any{
 		(*Action_GitPr)(nil),
@@ -6185,21 +6617,23 @@ func file_aiserver_v1_automations_proto_init() {
 		(*GitTrigger_PullRequestReview)(nil),
 		(*GitTrigger_ReviewThread)(nil),
 		(*GitTrigger_WorkflowRun)(nil),
+		(*GitTrigger_PullRequestReviewRequested)(nil),
+		(*GitTrigger_IssueAssigned)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[22].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[25].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[24].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[29].OneofWrappers = []any{
 		(*LinearTrigger_IssueCreated)(nil),
 		(*LinearTrigger_StatusChanged)(nil),
 		(*LinearTrigger_EndOfCycle)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[30].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[34].OneofWrappers = []any{
 		(*PagerDutyTrigger_IncidentTriggered)(nil),
 		(*PagerDutyTrigger_IncidentAcknowledged)(nil),
 		(*PagerDutyTrigger_IncidentResolved)(nil),
 		(*PagerDutyTrigger_IncidentEscalated)(nil),
 		(*PagerDutyTrigger_IncidentAny)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[36].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[40].OneofWrappers = []any{
 		(*SentryTrigger_IssueCreated)(nil),
 		(*SentryTrigger_IssueResolved)(nil),
 		(*SentryTrigger_IssueAssigned)(nil),
@@ -6207,22 +6641,23 @@ func file_aiserver_v1_automations_proto_init() {
 		(*SentryTrigger_IssueUnresolved)(nil),
 		(*SentryTrigger_IssueAny)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[55].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[59].OneofWrappers = []any{
+	file_aiserver_v1_automations_proto_msgTypes[59].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[61].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[63].OneofWrappers = []any{
 		(*GetAutomationResponse_Workflow)(nil),
 		(*GetAutomationResponse_RestrictedSummary)(nil),
 	}
-	file_aiserver_v1_automations_proto_msgTypes[60].OneofWrappers = []any{}
 	file_aiserver_v1_automations_proto_msgTypes[64].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[65].OneofWrappers = []any{}
-	file_aiserver_v1_automations_proto_msgTypes[66].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[68].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[69].OneofWrappers = []any{}
+	file_aiserver_v1_automations_proto_msgTypes[70].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_aiserver_v1_automations_proto_rawDesc), len(file_aiserver_v1_automations_proto_rawDesc)),
-			NumEnums:      10,
-			NumMessages:   67,
+			NumEnums:      11,
+			NumMessages:   71,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/provider/data_source_platform_workflow.go
+++ b/internal/provider/data_source_platform_workflow.go
@@ -62,7 +62,37 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 			},
 			"model": schema.StringAttribute{
 				Computed:    true,
-				Description: "Model name.",
+				Description: "Legacy model slug.",
+			},
+			"model_selection": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Structured model choice (catalog model ID plus parameters such as the Auto tier). Null when the automation only stores a legacy model slug.",
+				Attributes: map[string]schema.Attribute{
+					"model_id": schema.StringAttribute{
+						Computed:    true,
+						Description: "Catalog model ID (e.g. auto-smart).",
+					},
+					"parameters": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Parameter values selecting the model variant (e.g. optimize_for = cost).",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									Computed:    true,
+									Description: "Parameter ID.",
+								},
+								"value": schema.StringAttribute{
+									Computed:    true,
+									Description: "Parameter value.",
+								},
+							},
+						},
+					},
+					"max_mode": schema.BoolAttribute{
+						Computed:    true,
+						Description: "Whether the model runs in max mode.",
+					},
+				},
 			},
 			"git_repo": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/data_source_platform_workflow.go
+++ b/internal/provider/data_source_platform_workflow.go
@@ -41,7 +41,7 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 			},
 			"scope": schema.StringAttribute{
 				Computed:    true,
-				Description: `Automation ownership scope: "user" or "team".`,
+				Description: `Automation ownership scope: "user", "team", "team_visible", "team_editable_user", or "team_editable".`,
 			},
 			"team_id": schema.Int64Attribute{
 				Optional:    true,
@@ -450,7 +450,7 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 								"team_ids": schema.ListAttribute{
 									Computed:    true,
 									ElementType: types.StringType,
-									Description: "AAD group IDs to scope to. Empty fires for any team in the tenant.",
+									Description: "AAD group IDs of the teams watched.",
 								},
 								"channel_name_contains": schema.StringAttribute{
 									Computed:    true,
@@ -522,8 +522,9 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 									Description: "If true, agent can list and send to any Slack channel or DM dynamically.",
 								},
 								"respond_in_thread": schema.BoolAttribute{
-									Computed:    true,
-									Description: "If true, respond in the thread of the triggering Slack message (Slack triggers only).",
+									Computed:           true,
+									Description:        "Deprecated: ignored by the server, which always replies in the triggering Slack thread.",
+									DeprecationMessage: "The server ignores respond_in_thread and always replies in the triggering Slack thread.",
 								},
 								"post_as_thread": schema.BoolAttribute{
 									Computed:    true,
@@ -647,7 +648,11 @@ func (d *platformWorkflowDataSource) Read(ctx context.Context, req datasource.Re
 		return
 	}
 
-	withOwner := workflowResp.Msg.GetWorkflow()
+	withOwner, err := automationFromGetResponse(workflowResp.Msg)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read automation", err.Error())
+		return
+	}
 	state, err := protoToModel(ctx, withOwner)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read automation", err.Error())

--- a/internal/provider/data_source_platform_workflow.go
+++ b/internal/provider/data_source_platform_workflow.go
@@ -35,9 +35,18 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 				Computed:    true,
 				Description: "Display name for the automation.",
 			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Free-text description of the automation.",
+			},
 			"scope": schema.StringAttribute{
 				Computed:    true,
 				Description: `Automation ownership scope: "user" or "team".`,
+			},
+			"team_id": schema.Int64Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Numeric Cursor team ID. Set it to read a team-visible automation under a specific team; otherwise the team owning the automation is reported.",
 			},
 			"enabled": schema.BoolAttribute{
 				Computed:    true,
@@ -85,6 +94,11 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 			"memory_enabled": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Whether the AutomationMemory tool is enabled for persistent memory across runs.",
+			},
+			"disabled_default_tools": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: `Default automation tools withheld from the agent (e.g. "open_git_pr").`,
 			},
 			"trigger": schema.ListNestedAttribute{
 				Computed:    true,
@@ -200,6 +214,70 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 								},
 							},
 						},
+						"slack_channel_created": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger when a public Slack channel is created.",
+							Attributes: map[string]schema.Attribute{
+								"channel_name_contains": schema.StringAttribute{
+									Computed:    true,
+									Description: "Channel name filter (case-insensitive).",
+								},
+							},
+						},
+						"slack_reaction_added": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger when a specific emoji reaction is added in a Slack channel.",
+							Attributes: map[string]schema.Attribute{
+								"channel": schema.StringAttribute{
+									Computed:    true,
+									Description: "Slack channel ID.",
+								},
+								"emoji_name": schema.StringAttribute{
+									Computed:    true,
+									Description: "Slack emoji short name without colons.",
+								},
+								"block_unauthenticated_slack_users": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether only Slack users who linked Cursor can trigger.",
+								},
+								"only_owner_reactions": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether only the automation owner's reactions trigger it.",
+								},
+							},
+						},
+						"slack_mention": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger when the Cursor Slack app is mentioned in a channel.",
+							Attributes: map[string]schema.Attribute{
+								"channel": schema.StringAttribute{
+									Computed:    true,
+									Description: "Slack channel ID.",
+								},
+								"block_unauthenticated_slack_users": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether only Slack users who linked Cursor can trigger.",
+								},
+							},
+						},
+						"slack_any_reaction_added": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger when any emoji reaction is added in a Slack channel.",
+							Attributes: map[string]schema.Attribute{
+								"channel": schema.StringAttribute{
+									Computed:    true,
+									Description: "Slack channel ID.",
+								},
+								"block_unauthenticated_slack_users": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether only Slack users who linked Cursor can trigger.",
+								},
+								"only_owner_reactions": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether only the automation owner's reactions trigger it.",
+								},
+							},
+						},
 						"linear": schema.SingleNestedAttribute{
 							Computed:    true,
 							Description: "Trigger on Linear events.",
@@ -247,6 +325,83 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 							Computed:    true,
 							Description: "Trigger on generic webhook POST requests.",
 							Attributes:  map[string]schema.Attribute{},
+						},
+						"pagerduty": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger on PagerDuty incident events.",
+							Attributes: map[string]schema.Attribute{
+								"incident_triggered": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on triggered incidents.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_acknowledged": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on acknowledged incidents.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_resolved": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on resolved incidents.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_escalated": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on escalated incidents.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_any": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on any incident event.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"service_ids": schema.ListAttribute{
+									Computed:    true,
+									ElementType: types.StringType,
+									Description: "PagerDuty service IDs scoping the trigger.",
+								},
+							},
+						},
+						"sentry": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Trigger on Sentry issue webhooks.",
+							Attributes: map[string]schema.Attribute{
+								"issue_created": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on created issues.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_resolved": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on resolved issues.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_assigned": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on assigned issues.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_archived": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on archived issues.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_unresolved": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on issues marked unresolved.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_any": schema.SingleNestedAttribute{
+									Computed:    true,
+									Description: "Set when the trigger fires on any issue event.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"project_ids": schema.ListAttribute{
+									Computed:    true,
+									ElementType: types.StringType,
+									Description: "Sentry project IDs scoping the trigger.",
+								},
+							},
 						},
 						"microsoft_teams": schema.SingleNestedAttribute{
 							Computed:    true,
@@ -381,6 +536,21 @@ func (d *platformWorkflowDataSource) Schema(_ context.Context, _ datasource.Sche
 							Description: "Give the agent read-only access to public Slack channels (ListSlackChannels, ReadSlackMessages tools).",
 							Attributes:  map[string]schema.Attribute{},
 						},
+						"manage_check_run": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Create and resolve a GitHub check run on the PR for each automation run.",
+							Attributes:  map[string]schema.Attribute{},
+						},
+						"approve_pr": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Deprecated: allow the agent to approve the PR. Superseded by pr_comment.allow_approve.",
+							Attributes:  map[string]schema.Attribute{},
+						},
+						"resolve_review_threads": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Let the agent resolve its own prior PR review threads (ResolveReviewThreads tool).",
+							Attributes:  map[string]schema.Attribute{},
+						},
 						"microsoft_teams": schema.SingleNestedAttribute{
 							Computed:    true,
 							Description: "Post messages to a Microsoft Teams channel.",
@@ -467,18 +637,35 @@ func (d *platformWorkflowDataSource) Read(ctx context.Context, req datasource.Re
 
 	workflowResp, err := d.client.automations.GetAutomation(
 		ctx,
-		connect.NewRequest(&v1.GetAutomationRequest{AutomationId: workflowID}),
+		connect.NewRequest(&v1.GetAutomationRequest{
+			AutomationId: workflowID,
+			TeamId:       optionalTeamID(config.TeamID),
+		}),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read automation", connectErrorMessage(err))
 		return
 	}
 
-	state, err := protoToModel(ctx, workflowResp.Msg.GetWorkflow())
+	withOwner := workflowResp.Msg.GetWorkflow()
+	state, err := protoToModel(ctx, withOwner)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read automation", err.Error())
 		return
 	}
+	state.TeamID = dataSourceTeamID(config.TeamID, withOwner)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// dataSourceTeamID keeps a configured team_id as-is and otherwise reports the
+// team that owns the automation, if any.
+func dataSourceTeamID(configured types.Int64, withOwner *v1.AutomationWithOwner) types.Int64 {
+	if !configured.IsNull() && !configured.IsUnknown() {
+		return configured
+	}
+	if withOwner.TeamId != nil {
+		return types.Int64Value(int64(withOwner.GetTeamId()))
+	}
+	return types.Int64Null()
 }

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -833,9 +833,9 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 									Description: "AAD tenant GUID hosting the team.",
 								},
 								"team_ids": schema.ListAttribute{
-									Optional:    true,
+									Required:    true,
 									ElementType: types.StringType,
-									Description: "Optional AAD group IDs to scope to. Empty fires for any team in the tenant.",
+									Description: "AAD group IDs of the teams to watch. At least one is required.",
 								},
 								"channel_name_contains": schema.StringAttribute{
 									Optional:    true,
@@ -911,9 +911,10 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 									Description: "If true, agent can list and send to any Slack channel or DM dynamically.",
 								},
 								"respond_in_thread": schema.BoolAttribute{
-									Optional:    true,
-									Computed:    true,
-									Description: "If true, respond in the thread of the triggering Slack message (Slack triggers only).",
+									Optional:           true,
+									Computed:           true,
+									Description:        "Deprecated: the server ignores this flag and always replies in the triggering Slack thread. Kept for compatibility with existing configurations.",
+									DeprecationMessage: "The server ignores respond_in_thread and always replies in the triggering Slack thread; remove it from your configuration.",
 								},
 								"post_as_thread": schema.BoolAttribute{
 									Optional:    true,
@@ -1102,6 +1103,19 @@ func optionalTeamID(value types.Int64) *int32 {
 	return &teamID
 }
 
+// automationFromGetResponse unwraps GetAutomationResponse, turning the
+// restricted-summary variant (the token can see that the automation exists but
+// not its definition) into a clear error instead of an "empty response" one.
+func automationFromGetResponse(msg *v1.GetAutomationResponse) (*v1.AutomationWithOwner, error) {
+	if summary := msg.GetRestrictedSummary(); summary != nil {
+		return nil, fmt.Errorf(
+			"automation %s (%q, owned by %q) is only visible as a restricted summary: the configured token cannot read its definition. Use a token belonging to the owner or a team admin, or set team_id to the owning team",
+			summary.GetAutomationId(), summary.GetName(), summary.GetOwnerName(),
+		)
+	}
+	return msg.GetWorkflow(), nil
+}
+
 func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state platformWorkflowModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -1135,7 +1149,12 @@ func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	updatedState, err := protoToModel(ctx, workflowResp.Msg.GetWorkflow())
+	withOwner, err := automationFromGetResponse(workflowResp.Msg)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read automation", err.Error())
+		return
+	}
+	updatedState, err := protoToModel(ctx, withOwner)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read automation", err.Error())
 		return
@@ -1999,6 +2018,9 @@ func actionModelToProto(a *actionModel) (*v1.Action, error) {
 		if !a.MicrosoftTeams.PostAsThread.IsNull() && !a.MicrosoftTeams.PostAsThread.IsUnknown() {
 			teams.PostAsThread = a.MicrosoftTeams.PostAsThread.ValueBool()
 		}
+		if teams.RespondInThread && teams.PostAsThread {
+			return nil, fmt.Errorf("microsoft_teams cannot set both respond_in_thread and post_as_thread")
+		}
 		return &v1.Action{Action: &v1.Action_MicrosoftTeams{MicrosoftTeams: teams}}, nil
 	}
 	if a.ReadMicrosoftTeams != nil {
@@ -2455,6 +2477,9 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		teamIDs, err := readStringList(ctx, mtc.TeamIDs, "microsoft_teams_channel_created.team_ids")
 		if err != nil {
 			return nil, err
+		}
+		if len(teamIDs) == 0 {
+			return nil, fmt.Errorf("microsoft_teams_channel_created must specify at least one team_id")
 		}
 		mctt.TeamIds = teamIDs
 		if !mtc.ChannelNameContains.IsNull() && !mtc.ChannelNameContains.IsUnknown() {

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"google.golang.org/protobuf/encoding/protowire"
 )
@@ -119,30 +120,45 @@ func parseCustomErrorDetailsTitleDetail(b []byte) (string, string) {
 // ---------------------------------------------------------------------------
 
 type platformWorkflowModel struct {
-	ID                   types.String        `tfsdk:"id"`
-	Name                 types.String        `tfsdk:"name"`
-	Description          types.String        `tfsdk:"description"`
-	Scope                types.String        `tfsdk:"scope"`
-	TeamID               types.Int64         `tfsdk:"team_id"`
-	Enabled              types.Bool          `tfsdk:"enabled"`
-	Prompt               types.String        `tfsdk:"prompt"`
-	EffortLevel          types.String        `tfsdk:"effort_level"`
-	Model                types.String        `tfsdk:"model"`
-	GitRepo              types.String        `tfsdk:"git_repo"`
-	GitBranch            types.String        `tfsdk:"git_branch"`
-	SkipInstall          types.Bool          `tfsdk:"skip_install"`
-	EnvironmentPublicID  types.String        `tfsdk:"environment_public_id"`
-	PrivateWorker        *privateWorkerModel `tfsdk:"private_worker"`
-	MemoryEnabled        types.Bool          `tfsdk:"memory_enabled"`
-	DisabledDefaultTools types.List          `tfsdk:"disabled_default_tools"`
-	Triggers             []triggerModel      `tfsdk:"trigger"`
-	Actions              []actionModel       `tfsdk:"action"`
-	CreatedAt            types.Int64         `tfsdk:"created_at"`
-	UpdatedAt            types.Int64         `tfsdk:"updated_at"`
+	ID                   types.String         `tfsdk:"id"`
+	Name                 types.String         `tfsdk:"name"`
+	Description          types.String         `tfsdk:"description"`
+	Scope                types.String         `tfsdk:"scope"`
+	TeamID               types.Int64          `tfsdk:"team_id"`
+	Enabled              types.Bool           `tfsdk:"enabled"`
+	Prompt               types.String         `tfsdk:"prompt"`
+	EffortLevel          types.String         `tfsdk:"effort_level"`
+	Model                types.String         `tfsdk:"model"`
+	ModelSelection       *modelSelectionModel `tfsdk:"model_selection"`
+	GitRepo              types.String         `tfsdk:"git_repo"`
+	GitBranch            types.String         `tfsdk:"git_branch"`
+	SkipInstall          types.Bool           `tfsdk:"skip_install"`
+	EnvironmentPublicID  types.String         `tfsdk:"environment_public_id"`
+	PrivateWorker        *privateWorkerModel  `tfsdk:"private_worker"`
+	MemoryEnabled        types.Bool           `tfsdk:"memory_enabled"`
+	DisabledDefaultTools types.List           `tfsdk:"disabled_default_tools"`
+	Triggers             []triggerModel       `tfsdk:"trigger"`
+	Actions              []actionModel        `tfsdk:"action"`
+	CreatedAt            types.Int64          `tfsdk:"created_at"`
+	UpdatedAt            types.Int64          `tfsdk:"updated_at"`
 }
 
 type privateWorkerModel struct {
 	Labels types.Map `tfsdk:"labels"`
+}
+
+// modelSelectionModel mirrors AutomationModelSelection: the structured twin of
+// the legacy `model` slug, able to carry parameters the slug cannot (e.g. the
+// Auto tier via optimize_for).
+type modelSelectionModel struct {
+	ModelID    types.String                   `tfsdk:"model_id"`
+	Parameters []modelSelectionParameterModel `tfsdk:"parameters"`
+	MaxMode    types.Bool                     `tfsdk:"max_mode"`
+}
+
+type modelSelectionParameterModel struct {
+	ID    types.String `tfsdk:"id"`
+	Value types.String `tfsdk:"value"`
 }
 
 type triggerModel struct {
@@ -365,6 +381,11 @@ type platformWorkflowResource struct {
 	client *apiClient
 }
 
+var (
+	_ resource.ResourceWithImportState    = (*platformWorkflowResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*platformWorkflowResource)(nil)
+)
+
 func NewPlatformWorkflowResource() resource.Resource {
 	return &platformWorkflowResource{}
 }
@@ -432,9 +453,47 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 			"model": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Model to use (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model.",
+				Description: "Legacy model slug (e.g. claude-4.6-opus-high-thinking, gpt-4o). If unset, the server assigns a default model. Cannot be combined with model_selection: when model_selection is set the server derives this value from it.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					modelUseStateUnlessSelectionChanged{},
+				},
+			},
+			"model_selection": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: `Structured model choice: a catalog model ID plus parameters the legacy model slug cannot carry. Use it to pick an Auto tier, e.g. model_id = "auto-smart" with parameters = [{ id = "optimize_for", value = "cost" }] (Auto Cost) or value = "balanced" (Auto Balance) or "intelligence". Takes priority over model at run time; leave model unset when using it.`,
+				Attributes: map[string]schema.Attribute{
+					"model_id": schema.StringAttribute{
+						Required:    true,
+						Description: `Catalog model ID (e.g. "auto-smart"). Use the canonical ID: the server rejects unknown IDs and rewrites aliases, which would show up as a diff.`,
+					},
+					"parameters": schema.ListNestedAttribute{
+						Optional:    true,
+						Computed:    true,
+						Description: `Parameter values selecting a model variant, e.g. { id = "optimize_for", value = "cost" }. Parameter IDs must be unique. When omitted the server picks the model's default variant and reports its parameters here.`,
+						PlanModifiers: []planmodifier.List{
+							modelSelectionParametersUseStateUnlessModelChanged{},
+						},
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									Required:    true,
+									Description: "Parameter ID (e.g. optimize_for).",
+								},
+								"value": schema.StringAttribute{
+									Required:    true,
+									Description: `Parameter value. Enum parameters take one of their enum values (e.g. "cost", "balanced", "intelligence" for optimize_for); booleans take "true"/"false".`,
+								},
+							},
+						},
+					},
+					"max_mode": schema.BoolAttribute{
+						Optional:    true,
+						Computed:    true,
+						Description: "Run the model in max mode. Defaults to true and is reported back as true; the server currently rejects false.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
+					},
 				},
 			},
 			"git_repo": schema.StringAttribute{
@@ -1092,6 +1151,7 @@ func preserveConfiguredValues(ctx context.Context, state *platformWorkflowModel,
 	preserveEquivalentGitPullRequestOrgs(ctx, state, reference)
 	preserveEquivalentGitCICompletionConditions(state, reference)
 	preserveEquivalentEnvironmentPublicID(state, reference)
+	preserveEquivalentModelSelection(state, reference)
 	state.TeamID = reference.TeamID
 }
 
@@ -1271,6 +1331,145 @@ func (r *platformWorkflowResource) ImportState(ctx context.Context, req resource
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
+// ValidateConfig rejects model together with model_selection: the server
+// overwrites model from the validated selection, so a configured slug that
+// disagrees with it could never be applied consistently.
+func (r *platformWorkflowResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var model types.String
+	var selection types.Object
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("model"), &model)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("model_selection"), &selection)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !model.IsNull() && !selection.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("model"),
+			"Conflicting model configuration",
+			"model cannot be set together with model_selection; the server derives model from model_selection. Remove model.",
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// model / model_selection plan modifiers
+// ---------------------------------------------------------------------------
+
+// modelSelectionAttrs extracts the parts of a model_selection object value,
+// tolerating unknown nested values.
+type modelSelectionAttrs struct {
+	set        bool
+	modelID    types.String
+	parameters types.List
+	maxMode    types.Bool
+}
+
+func modelSelectionAttrsFrom(obj types.Object) modelSelectionAttrs {
+	if obj.IsNull() || obj.IsUnknown() {
+		return modelSelectionAttrs{}
+	}
+	attrs := obj.Attributes()
+	out := modelSelectionAttrs{set: true}
+	if v, ok := attrs["model_id"].(types.String); ok {
+		out.modelID = v
+	}
+	if v, ok := attrs["parameters"].(types.List); ok {
+		out.parameters = v
+	}
+	if v, ok := attrs["max_mode"].(types.Bool); ok {
+		out.maxMode = v
+	}
+	return out
+}
+
+// modelSelectionChangedForPlan reports whether the planned model_selection
+// differs from state in a way that makes the server re-derive model (and the
+// default variant parameters). Unknown planned parameters/max_mode are treated
+// as unchanged: they are only unknown because they were not configured, and the
+// server keeps them when model_id is unchanged.
+func modelSelectionChangedForPlan(ctx context.Context, plan tfsdk.Plan, state tfsdk.State) bool {
+	var planObj, stateObj types.Object
+	if diags := plan.GetAttribute(ctx, path.Root("model_selection"), &planObj); diags.HasError() {
+		return true
+	}
+	if diags := state.GetAttribute(ctx, path.Root("model_selection"), &stateObj); diags.HasError() {
+		return true
+	}
+	if planObj.IsUnknown() {
+		return true
+	}
+	p := modelSelectionAttrsFrom(planObj)
+	s := modelSelectionAttrsFrom(stateObj)
+	if p.set != s.set {
+		return true
+	}
+	if !p.set {
+		return false
+	}
+	if p.modelID.IsUnknown() || !p.modelID.Equal(s.modelID) {
+		return true
+	}
+	if !p.maxMode.IsUnknown() && !p.maxMode.Equal(s.maxMode) {
+		return true
+	}
+	if !p.parameters.IsUnknown() && !p.parameters.Equal(s.parameters) {
+		return true
+	}
+	return false
+}
+
+// modelUseStateUnlessSelectionChanged behaves like UseStateForUnknown for the
+// computed model slug, except when model_selection changed: the server then
+// rewrites model from the new selection, so the value must stay unknown.
+type modelUseStateUnlessSelectionChanged struct{}
+
+func (modelUseStateUnlessSelectionChanged) Description(_ context.Context) string {
+	return "Keeps the prior model unless model_selection changed."
+}
+
+func (m modelUseStateUnlessSelectionChanged) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (modelUseStateUnlessSelectionChanged) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+	if !req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
+		return
+	}
+	if modelSelectionChangedForPlan(ctx, req.Plan, req.State) {
+		return
+	}
+	resp.PlanValue = req.StateValue
+}
+
+// modelSelectionParametersUseStateUnlessModelChanged keeps the server-reported
+// default-variant parameters across plans while model_id (and max_mode) stay
+// the same; a new model_id gets fresh defaults, so the value stays unknown.
+type modelSelectionParametersUseStateUnlessModelChanged struct{}
+
+func (modelSelectionParametersUseStateUnlessModelChanged) Description(_ context.Context) string {
+	return "Keeps the prior parameters unless model_selection.model_id changed."
+}
+
+func (m modelSelectionParametersUseStateUnlessModelChanged) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (modelSelectionParametersUseStateUnlessModelChanged) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+	if !req.PlanValue.IsUnknown() || req.StateValue.IsUnknown() {
+		return
+	}
+	if modelSelectionChangedForPlan(ctx, req.Plan, req.State) {
+		return
+	}
+	resp.PlanValue = req.StateValue
+}
+
 func (r *platformWorkflowResource) updateEnabled(ctx context.Context, state platformWorkflowModel, enabled bool) (platformWorkflowModel, error) {
 	workflowID, err := parseWorkflowID(state.ID)
 	if err != nil {
@@ -1447,6 +1646,100 @@ func preserveEquivalentEnvironmentPublicID(state *platformWorkflowModel, referen
 	}
 
 	state.EnvironmentPublicID = reference.EnvironmentPublicID
+}
+
+// modelSelectionToProto mirrors the server's save-time checks that can be done
+// without the catalog (validateStructuredModelSelectionForSave /
+// validateModelSelection): non-empty model_id, no incomplete or duplicate
+// parameters, and max_mode = false is not supported yet.
+func modelSelectionToProto(ms *modelSelectionModel) (*v1.AutomationModelSelection, error) {
+	if ms.ModelID.IsNull() || ms.ModelID.IsUnknown() || strings.TrimSpace(ms.ModelID.ValueString()) == "" {
+		return nil, fmt.Errorf("model_selection.model_id is required")
+	}
+	selection := &v1.AutomationModelSelection{ModelId: strings.TrimSpace(ms.ModelID.ValueString())}
+
+	seen := make(map[string]struct{}, len(ms.Parameters))
+	for i, p := range ms.Parameters {
+		if p.ID.IsUnknown() || p.Value.IsUnknown() {
+			continue
+		}
+		id := strings.TrimSpace(p.ID.ValueString())
+		value := strings.TrimSpace(p.Value.ValueString())
+		if id == "" || value == "" {
+			return nil, fmt.Errorf("model_selection.parameters[%d] must set both id and value", i)
+		}
+		if _, dup := seen[id]; dup {
+			return nil, fmt.Errorf("model_selection.parameters contains duplicate parameter %q", id)
+		}
+		seen[id] = struct{}{}
+		selection.Parameters = append(selection.Parameters, &v1.AutomationModelSelection_ParameterValue{Id: id, Value: value})
+	}
+
+	if !ms.MaxMode.IsNull() && !ms.MaxMode.IsUnknown() {
+		if !ms.MaxMode.ValueBool() {
+			return nil, fmt.Errorf("model_selection.max_mode = false is not supported by the server yet; omit it or set it to true")
+		}
+		maxMode := true
+		selection.MaxMode = &maxMode
+	}
+	return selection, nil
+}
+
+func protoModelSelectionToModel(selection *v1.AutomationModelSelection) *modelSelectionModel {
+	if selection == nil || strings.TrimSpace(selection.GetModelId()) == "" {
+		return nil
+	}
+	ms := &modelSelectionModel{
+		ModelID: types.StringValue(selection.GetModelId()),
+		MaxMode: types.BoolNull(),
+	}
+	if selection.MaxMode != nil {
+		ms.MaxMode = types.BoolValue(selection.GetMaxMode())
+	}
+	for _, p := range selection.GetParameters() {
+		ms.Parameters = append(ms.Parameters, modelSelectionParameterModel{
+			ID:    types.StringValue(p.GetId()),
+			Value: types.StringValue(p.GetValue()),
+		})
+	}
+	return ms
+}
+
+// Preserve the practitioner's model_selection spelling (model_id whitespace,
+// parameter order and whitespace) when the server echoes an equivalent
+// canonical selection, avoiding post-apply state mismatches.
+func preserveEquivalentModelSelection(state *platformWorkflowModel, reference platformWorkflowModel) {
+	if state == nil || state.ModelSelection == nil || reference.ModelSelection == nil {
+		return
+	}
+	current, ref := state.ModelSelection, reference.ModelSelection
+	if !ref.ModelID.IsNull() && !ref.ModelID.IsUnknown() &&
+		strings.TrimSpace(ref.ModelID.ValueString()) == current.ModelID.ValueString() {
+		current.ModelID = ref.ModelID
+	}
+	if ref.Parameters != nil && modelSelectionParametersEquivalent(current.Parameters, ref.Parameters) {
+		current.Parameters = ref.Parameters
+	}
+}
+
+func modelSelectionParametersEquivalent(current, reference []modelSelectionParameterModel) bool {
+	if len(current) != len(reference) {
+		return false
+	}
+	values := make(map[string]string, len(current))
+	for _, p := range current {
+		values[p.ID.ValueString()] = p.Value.ValueString()
+	}
+	for _, p := range reference {
+		if p.ID.IsUnknown() || p.Value.IsUnknown() {
+			return false
+		}
+		value, ok := values[strings.TrimSpace(p.ID.ValueString())]
+		if !ok || value != strings.TrimSpace(p.Value.ValueString()) {
+			return false
+		}
+	}
+	return true
 }
 
 func gitPullRequestOrgsEqualFold(ctx context.Context, current, reference types.List) bool {
@@ -1719,8 +2012,15 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 	}
 	w.Prompts = []*v1.Prompt{prompt}
 
-	// Model
-	if !m.Model.IsNull() && !m.Model.IsUnknown() {
+	// Model / ModelSelection. When a selection is set the server derives the
+	// slug from it, so the (possibly state-carried) slug is not sent.
+	if m.ModelSelection != nil {
+		selection, err := modelSelectionToProto(m.ModelSelection)
+		if err != nil {
+			return nil, err
+		}
+		w.ModelSelection = selection
+	} else if !m.Model.IsNull() && !m.Model.IsUnknown() {
 		model := m.Model.ValueString()
 		w.Model = &model
 	}
@@ -2717,6 +3017,7 @@ func protoToModel(ctx context.Context, withOwner *v1.AutomationWithOwner) (platf
 	} else {
 		m.Model = types.StringNull()
 	}
+	m.ModelSelection = protoModelSelectionToModel(wf.GetModelSelection())
 
 	// GitConfig
 	if gc := wf.GetGitConfig(); gc != nil {

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -119,23 +119,26 @@ func parseCustomErrorDetailsTitleDetail(b []byte) (string, string) {
 // ---------------------------------------------------------------------------
 
 type platformWorkflowModel struct {
-	ID                  types.String        `tfsdk:"id"`
-	Name                types.String        `tfsdk:"name"`
-	Scope               types.String        `tfsdk:"scope"`
-	Enabled             types.Bool          `tfsdk:"enabled"`
-	Prompt              types.String        `tfsdk:"prompt"`
-	EffortLevel         types.String        `tfsdk:"effort_level"`
-	Model               types.String        `tfsdk:"model"`
-	GitRepo             types.String        `tfsdk:"git_repo"`
-	GitBranch           types.String        `tfsdk:"git_branch"`
-	SkipInstall         types.Bool          `tfsdk:"skip_install"`
-	EnvironmentPublicID types.String        `tfsdk:"environment_public_id"`
-	PrivateWorker       *privateWorkerModel `tfsdk:"private_worker"`
-	MemoryEnabled       types.Bool          `tfsdk:"memory_enabled"`
-	Triggers            []triggerModel      `tfsdk:"trigger"`
-	Actions             []actionModel       `tfsdk:"action"`
-	CreatedAt           types.Int64         `tfsdk:"created_at"`
-	UpdatedAt           types.Int64         `tfsdk:"updated_at"`
+	ID                   types.String        `tfsdk:"id"`
+	Name                 types.String        `tfsdk:"name"`
+	Description          types.String        `tfsdk:"description"`
+	Scope                types.String        `tfsdk:"scope"`
+	TeamID               types.Int64         `tfsdk:"team_id"`
+	Enabled              types.Bool          `tfsdk:"enabled"`
+	Prompt               types.String        `tfsdk:"prompt"`
+	EffortLevel          types.String        `tfsdk:"effort_level"`
+	Model                types.String        `tfsdk:"model"`
+	GitRepo              types.String        `tfsdk:"git_repo"`
+	GitBranch            types.String        `tfsdk:"git_branch"`
+	SkipInstall          types.Bool          `tfsdk:"skip_install"`
+	EnvironmentPublicID  types.String        `tfsdk:"environment_public_id"`
+	PrivateWorker        *privateWorkerModel `tfsdk:"private_worker"`
+	MemoryEnabled        types.Bool          `tfsdk:"memory_enabled"`
+	DisabledDefaultTools types.List          `tfsdk:"disabled_default_tools"`
+	Triggers             []triggerModel      `tfsdk:"trigger"`
+	Actions              []actionModel       `tfsdk:"action"`
+	CreatedAt            types.Int64         `tfsdk:"created_at"`
+	UpdatedAt            types.Int64         `tfsdk:"updated_at"`
 }
 
 type privateWorkerModel struct {
@@ -148,12 +151,24 @@ type triggerModel struct {
 	GitCICompleted               *gitCICompletedModel                      `tfsdk:"git_ci_completed"`
 	Cron                         *cronModel                                `tfsdk:"cron"`
 	Slack                        *slackTriggerModel                        `tfsdk:"slack"`
+	SlackChannelCreated          *slackChannelCreatedTriggerModel          `tfsdk:"slack_channel_created"`
+	SlackReactionAdded           *slackReactionAddedTriggerModel           `tfsdk:"slack_reaction_added"`
+	SlackMention                 *slackMentionTriggerModel                 `tfsdk:"slack_mention"`
+	SlackAnyReactionAdded        *slackAnyReactionAddedTriggerModel        `tfsdk:"slack_any_reaction_added"`
 	Linear                       *linearTriggerModel                       `tfsdk:"linear"`
 	Webhook                      *webhookTriggerModel                      `tfsdk:"webhook"`
+	PagerDuty                    *pagerDutyTriggerModel                    `tfsdk:"pagerduty"`
+	Sentry                       *sentryTriggerModel                       `tfsdk:"sentry"`
 	MicrosoftTeams               *microsoftTeamsTriggerModel               `tfsdk:"microsoft_teams"`
 	MicrosoftTeamsChannelCreated *microsoftTeamsChannelCreatedTriggerModel `tfsdk:"microsoft_teams_channel_created"`
 	UserAllowlist                types.List                                `tfsdk:"user_allowlist"`
 }
+
+// triggerTypeNames lists the trigger block names in schema order, used for
+// the "exactly one trigger type" error message.
+const triggerTypeNames = "git_pull_request, git_push, git_ci_completed, cron, slack, slack_channel_created, slack_reaction_added, slack_mention, slack_any_reaction_added, linear, webhook, pagerduty, sentry, microsoft_teams, or microsoft_teams_channel_created"
+
+const actionTypeNames = "pr_comment, git_pr, request_reviewers, mcp, slack, read_slack, microsoft_teams, read_microsoft_teams, manage_check_run, approve_pr, or resolve_review_threads"
 
 type gitPullRequestModel struct {
 	Orgs                   types.List   `tfsdk:"orgs"`
@@ -188,6 +203,50 @@ type slackTriggerModel struct {
 	CompletionReactionMode         types.String `tfsdk:"completion_reaction_mode"`
 	CompletionReactionCustomEmoji  types.String `tfsdk:"completion_reaction_custom_emoji"`
 }
+
+type slackChannelCreatedTriggerModel struct {
+	ChannelNameContains types.String `tfsdk:"channel_name_contains"`
+}
+
+type slackReactionAddedTriggerModel struct {
+	Channel                        types.String `tfsdk:"channel"`
+	EmojiName                      types.String `tfsdk:"emoji_name"`
+	BlockUnauthenticatedSlackUsers types.Bool   `tfsdk:"block_unauthenticated_slack_users"`
+	OnlyOwnerReactions             types.Bool   `tfsdk:"only_owner_reactions"`
+}
+
+type slackMentionTriggerModel struct {
+	Channel                        types.String `tfsdk:"channel"`
+	BlockUnauthenticatedSlackUsers types.Bool   `tfsdk:"block_unauthenticated_slack_users"`
+}
+
+type slackAnyReactionAddedTriggerModel struct {
+	Channel                        types.String `tfsdk:"channel"`
+	BlockUnauthenticatedSlackUsers types.Bool   `tfsdk:"block_unauthenticated_slack_users"`
+	OnlyOwnerReactions             types.Bool   `tfsdk:"only_owner_reactions"`
+}
+
+type pagerDutyTriggerModel struct {
+	IncidentTriggered    *emptyEventModel `tfsdk:"incident_triggered"`
+	IncidentAcknowledged *emptyEventModel `tfsdk:"incident_acknowledged"`
+	IncidentResolved     *emptyEventModel `tfsdk:"incident_resolved"`
+	IncidentEscalated    *emptyEventModel `tfsdk:"incident_escalated"`
+	IncidentAny          *emptyEventModel `tfsdk:"incident_any"`
+	ServiceIDs           types.List       `tfsdk:"service_ids"`
+}
+
+type sentryTriggerModel struct {
+	IssueCreated    *emptyEventModel `tfsdk:"issue_created"`
+	IssueResolved   *emptyEventModel `tfsdk:"issue_resolved"`
+	IssueAssigned   *emptyEventModel `tfsdk:"issue_assigned"`
+	IssueArchived   *emptyEventModel `tfsdk:"issue_archived"`
+	IssueUnresolved *emptyEventModel `tfsdk:"issue_unresolved"`
+	IssueAny        *emptyEventModel `tfsdk:"issue_any"`
+	ProjectIDs      types.List       `tfsdk:"project_ids"`
+}
+
+// emptyEventModel is a marker block: presence selects the event type.
+type emptyEventModel struct{}
 
 type linearTriggerModel struct {
 	IssueCreated  *linearIssueCreatedModel  `tfsdk:"issue_created"`
@@ -230,14 +289,29 @@ type microsoftTeamsChannelCreatedTriggerModel struct {
 }
 
 type actionModel struct {
-	PrComment          *prCommentActionModel          `tfsdk:"pr_comment"`
-	GitPr              *gitPrActionModel              `tfsdk:"git_pr"`
-	RequestReviewers   *requestReviewersActionModel   `tfsdk:"request_reviewers"`
-	Mcp                *mcpActionModel                `tfsdk:"mcp"`
-	Slack              *slackActionModel              `tfsdk:"slack"`
-	ReadSlack          *readSlackActionModel          `tfsdk:"read_slack"`
-	MicrosoftTeams     *microsoftTeamsActionModel     `tfsdk:"microsoft_teams"`
-	ReadMicrosoftTeams *readMicrosoftTeamsActionModel `tfsdk:"read_microsoft_teams"`
+	PrComment            *prCommentActionModel            `tfsdk:"pr_comment"`
+	GitPr                *gitPrActionModel                `tfsdk:"git_pr"`
+	RequestReviewers     *requestReviewersActionModel     `tfsdk:"request_reviewers"`
+	Mcp                  *mcpActionModel                  `tfsdk:"mcp"`
+	Slack                *slackActionModel                `tfsdk:"slack"`
+	ReadSlack            *readSlackActionModel            `tfsdk:"read_slack"`
+	MicrosoftTeams       *microsoftTeamsActionModel       `tfsdk:"microsoft_teams"`
+	ReadMicrosoftTeams   *readMicrosoftTeamsActionModel   `tfsdk:"read_microsoft_teams"`
+	ManageCheckRun       *manageCheckRunActionModel       `tfsdk:"manage_check_run"`
+	ApprovePr            *approvePrActionModel            `tfsdk:"approve_pr"`
+	ResolveReviewThreads *resolveReviewThreadsActionModel `tfsdk:"resolve_review_threads"`
+}
+
+type manageCheckRunActionModel struct {
+	// Empty: check runs are always system-managed.
+}
+
+type approvePrActionModel struct {
+	// Empty: deprecated in favour of pr_comment.allow_approve.
+}
+
+type resolveReviewThreadsActionModel struct {
+	// Empty: adds the ResolveReviewThreads tool.
 }
 
 type prCommentActionModel struct {
@@ -301,7 +375,7 @@ func (r *platformWorkflowResource) Metadata(_ context.Context, req resource.Meta
 
 func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, Microsoft Teams) and actions (PR comments, PRs, reviewers, MCP servers, Slack, Microsoft Teams).",
+		Description: "Manages a Cursor Automation: a prompt plus triggers (pull requests, pushes, CI completions, cron, Slack, Linear, webhooks, PagerDuty, Sentry, Microsoft Teams) and actions (PR comments, PRs, reviewers, check runs, MCP servers, Slack, Microsoft Teams).",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
@@ -313,6 +387,23 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Display name for the automation.",
+			},
+			"description": schema.StringAttribute{
+				Optional:    true,
+				Description: "Optional free-text description shown in the Cursor dashboard.",
+			},
+			"team_id": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Numeric Cursor team ID to create and read the automation under. When unset, the team associated with the token is used. Requires a user token that is a member (or org admin) of the team; service-account tokens must leave this unset. Changing it between two set values forces a new automation because an automation cannot move between teams.",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.RequiresReplaceIf(
+						func(_ context.Context, req planmodifier.Int64Request, resp *int64planmodifier.RequiresReplaceIfFuncResponse) {
+							resp.RequiresReplace = !req.StateValue.IsNull() && !req.PlanValue.IsNull() && !req.PlanValue.Equal(req.StateValue)
+						},
+						"Replaces the automation when team_id changes from one team to another.",
+						"Replaces the automation when `team_id` changes from one team to another.",
+					),
+				},
 			},
 			"scope": schema.StringAttribute{
 				Optional:    true,
@@ -381,6 +472,11 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 			"memory_enabled": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Enable the AutomationMemory tool, giving the agent persistent memory across runs.",
+			},
+			"disabled_default_tools": schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: `Default automation tools to withhold from the agent. Supported values: "open_git_pr". Leave unset to keep the platform defaults.`,
 			},
 			"trigger": schema.ListNestedAttribute{
 				Required:    true,
@@ -503,6 +599,70 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 								},
 							},
 						},
+						"slack_channel_created": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger when a public Slack channel is created.",
+							Attributes: map[string]schema.Attribute{
+								"channel_name_contains": schema.StringAttribute{
+									Optional:    true,
+									Description: "Only trigger if the new channel name contains this text (case-insensitive).",
+								},
+							},
+						},
+						"slack_reaction_added": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger when a specific emoji reaction is added to a message in a Slack channel.",
+							Attributes: map[string]schema.Attribute{
+								"channel": schema.StringAttribute{
+									Required:    true,
+									Description: "Slack channel ID.",
+								},
+								"emoji_name": schema.StringAttribute{
+									Required:    true,
+									Description: `Slack emoji short name without colons, lowercase (e.g. "thumbsup", "white_check_mark").`,
+								},
+								"block_unauthenticated_slack_users": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).",
+								},
+								"only_owner_reactions": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, only the automation owner's own linked Slack user can trigger it. Stricter than block_unauthenticated_slack_users.",
+								},
+							},
+						},
+						"slack_mention": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger when the Cursor Slack app is mentioned in a Slack channel.",
+							Attributes: map[string]schema.Attribute{
+								"channel": schema.StringAttribute{
+									Required:    true,
+									Description: "Slack channel ID.",
+								},
+								"block_unauthenticated_slack_users": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).",
+								},
+							},
+						},
+						"slack_any_reaction_added": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger when any emoji reaction is added to a message in a Slack channel.",
+							Attributes: map[string]schema.Attribute{
+								"channel": schema.StringAttribute{
+									Required:    true,
+									Description: "Slack channel ID.",
+								},
+								"block_unauthenticated_slack_users": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, only Slack users who linked Cursor can trigger. Omit/false = anyone (default).",
+								},
+								"only_owner_reactions": schema.BoolAttribute{
+									Optional:    true,
+									Description: "If true, only the automation owner's own linked Slack user can trigger it. Stricter than block_unauthenticated_slack_users.",
+								},
+							},
+						},
 						"linear": schema.SingleNestedAttribute{
 							Optional:    true,
 							Description: "Trigger on Linear events.",
@@ -550,6 +710,83 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 							Optional:    true,
 							Description: "Trigger on generic webhook POST requests.",
 							Attributes:  map[string]schema.Attribute{},
+						},
+						"pagerduty": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger on PagerDuty incident events. Exactly one of incident_triggered, incident_acknowledged, incident_resolved, incident_escalated, or incident_any must be set.",
+							Attributes: map[string]schema.Attribute{
+								"incident_triggered": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when an incident is triggered.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_acknowledged": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when an incident is acknowledged.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_resolved": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when an incident is resolved.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_escalated": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when an incident is escalated.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"incident_any": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger on any incident event (triggered, acknowledged, resolved, escalated).",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"service_ids": schema.ListAttribute{
+									Optional:    true,
+									ElementType: types.StringType,
+									Description: "Optional PagerDuty service IDs to scope the trigger to. Empty fires for all services.",
+								},
+							},
+						},
+						"sentry": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Trigger on Sentry issue webhooks. Exactly one of issue_created, issue_resolved, issue_assigned, issue_archived, issue_unresolved, or issue_any must be set. The Cursor Sentry integration must be connected for the owner before the automation can be saved.",
+							Attributes: map[string]schema.Attribute{
+								"issue_created": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when a Sentry issue is created.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_resolved": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when a Sentry issue is resolved.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_assigned": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when a Sentry issue is assigned.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_archived": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when a Sentry issue is archived.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_unresolved": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger when a Sentry issue is marked unresolved.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"issue_any": schema.SingleNestedAttribute{
+									Optional:    true,
+									Description: "Trigger on any Sentry issue event.",
+									Attributes:  map[string]schema.Attribute{},
+								},
+								"project_ids": schema.ListAttribute{
+									Optional:    true,
+									ElementType: types.StringType,
+									Description: "Optional Sentry numeric project IDs (as strings) to scope the trigger to. Empty matches all projects in the organization.",
+								},
+							},
 						},
 						"microsoft_teams": schema.SingleNestedAttribute{
 							Optional:    true,
@@ -690,6 +927,22 @@ func (r *platformWorkflowResource) Schema(_ context.Context, _ resource.SchemaRe
 							Description: "Give the agent read-only access to public Slack channels (ListSlackChannels, ReadSlackMessages tools).",
 							Attributes:  map[string]schema.Attribute{},
 						},
+						"manage_check_run": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Create and resolve a GitHub check run on the PR for each automation run. Only relevant for git_pull_request triggers; the check run lifecycle is always system-managed.",
+							Attributes:  map[string]schema.Attribute{},
+						},
+						"approve_pr": schema.SingleNestedAttribute{
+							Optional:           true,
+							Description:        "Deprecated: allow the agent to approve the PR. Use pr_comment.allow_approve instead.",
+							DeprecationMessage: "approve_pr is deprecated server-side; set pr_comment.allow_approve = true instead.",
+							Attributes:         map[string]schema.Attribute{},
+						},
+						"resolve_review_threads": schema.SingleNestedAttribute{
+							Optional:    true,
+							Description: "Let the agent mark its own prior PR review threads as addressed and resolve them on GitHub (ResolveReviewThreads tool).",
+							Attributes:  map[string]schema.Attribute{},
+						},
 						"microsoft_teams": schema.SingleNestedAttribute{
 							Optional:    true,
 							Description: "Post messages to a Microsoft Teams channel.",
@@ -785,14 +1038,20 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	createResp, err := r.client.automations.CreateAutomation(
-		ctx,
-		connect.NewRequest(&v1.CreateAutomationRequest{
-			Name:     plan.Name.ValueString(),
-			Scope:    scope,
-			Workflow: workflow,
-		}),
-	)
+	createReq := &v1.CreateAutomationRequest{
+		Name:     plan.Name.ValueString(),
+		Scope:    scope,
+		Workflow: workflow,
+	}
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+		description := plan.Description.ValueString()
+		createReq.Description = &description
+	}
+	if teamID := optionalTeamID(plan.TeamID); teamID != nil {
+		createReq.TeamId = teamID
+	}
+
+	createResp, err := r.client.automations.CreateAutomation(ctx, connect.NewRequest(createReq))
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create automation", connectErrorMessage(err))
 		return
@@ -803,9 +1062,7 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 		resp.Diagnostics.AddError("Failed to read automation", err.Error())
 		return
 	}
-	preserveEquivalentGitPullRequestOrgs(ctx, &state, plan)
-	preserveEquivalentGitCICompletionConditions(&state, plan)
-	preserveEquivalentEnvironmentPublicID(&state, plan)
+	preserveConfiguredValues(ctx, &state, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -822,11 +1079,27 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 			)
 			return
 		}
-		preserveEquivalentGitPullRequestOrgs(ctx, &updated, plan)
-		preserveEquivalentGitCICompletionConditions(&updated, plan)
-		preserveEquivalentEnvironmentPublicID(&updated, plan)
+		preserveConfiguredValues(ctx, &updated, plan)
 		resp.Diagnostics.Append(resp.State.Set(ctx, &updated)...)
 	}
+}
+
+// preserveConfiguredValues rewrites server-normalised values back to the
+// practitioner-supplied form when equivalent, and carries over attributes the
+// API does not echo back (team_id).
+func preserveConfiguredValues(ctx context.Context, state *platformWorkflowModel, reference platformWorkflowModel) {
+	preserveEquivalentGitPullRequestOrgs(ctx, state, reference)
+	preserveEquivalentGitCICompletionConditions(state, reference)
+	preserveEquivalentEnvironmentPublicID(state, reference)
+	state.TeamID = reference.TeamID
+}
+
+func optionalTeamID(value types.Int64) *int32 {
+	if value.IsNull() || value.IsUnknown() {
+		return nil
+	}
+	teamID := int32(value.ValueInt64())
+	return &teamID
 }
 
 func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -848,7 +1121,10 @@ func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 
 	workflowResp, err := r.client.automations.GetAutomation(
 		ctx,
-		connect.NewRequest(&v1.GetAutomationRequest{AutomationId: workflowID}),
+		connect.NewRequest(&v1.GetAutomationRequest{
+			AutomationId: workflowID,
+			TeamId:       optionalTeamID(state.TeamID),
+		}),
 	)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeNotFound {
@@ -864,9 +1140,7 @@ func (r *platformWorkflowResource) Read(ctx context.Context, req resource.ReadRe
 		resp.Diagnostics.AddError("Failed to read automation", err.Error())
 		return
 	}
-	preserveEquivalentGitPullRequestOrgs(ctx, &updatedState, state)
-	preserveEquivalentGitCICompletionConditions(&updatedState, state)
-	preserveEquivalentEnvironmentPublicID(&updatedState, state)
+	preserveConfiguredValues(ctx, &updatedState, state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
@@ -909,6 +1183,12 @@ func (r *platformWorkflowResource) Update(ctx context.Context, req resource.Upda
 		name := plan.Name.ValueString()
 		updateReq.Name = &name
 	}
+	if shouldUpdateDescription(plan.Description, state.Description) {
+		// A removed description is sent as "" so the server clears it; the
+		// empty value reads back as null, matching the plan.
+		description := plan.Description.ValueString()
+		updateReq.Description = &description
+	}
 
 	if shouldUpdateEnabled(plan.Enabled, state.Enabled) {
 		enabled := plan.Enabled.ValueBool()
@@ -934,9 +1214,7 @@ func (r *platformWorkflowResource) Update(ctx context.Context, req resource.Upda
 		resp.Diagnostics.AddError("Failed to read automation", err.Error())
 		return
 	}
-	preserveEquivalentGitPullRequestOrgs(ctx, &updatedState, plan)
-	preserveEquivalentGitCICompletionConditions(&updatedState, plan)
-	preserveEquivalentEnvironmentPublicID(&updatedState, plan)
+	preserveConfiguredValues(ctx, &updatedState, plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &updatedState)...)
 }
@@ -1019,6 +1297,19 @@ func shouldUpdateEnabled(plan types.Bool, state types.Bool) bool {
 		return true
 	}
 	return plan.ValueBool() != state.ValueBool()
+}
+
+func shouldUpdateDescription(plan types.String, state types.String) bool {
+	if plan.IsUnknown() {
+		return false
+	}
+	if plan.IsNull() {
+		return !state.IsNull() && !state.IsUnknown() && state.ValueString() != ""
+	}
+	if state.IsNull() || state.IsUnknown() {
+		return plan.ValueString() != ""
+	}
+	return plan.ValueString() != state.ValueString()
 }
 
 func shouldUpdateScope(plan types.String, state types.String) bool {
@@ -1467,6 +1758,19 @@ func modelToWorkflow(ctx context.Context, m *platformWorkflowModel) (*v1.Workflo
 		w.MemoryEnabled = &enabled
 	}
 
+	// DisabledDefaultTools
+	disabledTools, err := readStringList(ctx, m.DisabledDefaultTools, "disabled_default_tools")
+	if err != nil {
+		return nil, err
+	}
+	for _, tool := range disabledTools {
+		parsed, err := parseAutomationDefaultTool(tool)
+		if err != nil {
+			return nil, err
+		}
+		w.DisabledDefaultTools = append(w.DisabledDefaultTools, parsed)
+	}
+
 	// Triggers
 	for i, t := range m.Triggers {
 		trigger, err := triggerModelToProto(ctx, &t)
@@ -1605,11 +1909,17 @@ func actionModelToProto(a *actionModel) (*v1.Action, error) {
 	if a.ReadMicrosoftTeams != nil {
 		count++
 	}
-	if count == 0 {
-		return nil, fmt.Errorf("must specify exactly one of pr_comment, git_pr, request_reviewers, mcp, slack, read_slack, microsoft_teams, or read_microsoft_teams")
+	if a.ManageCheckRun != nil {
+		count++
 	}
-	if count > 1 {
-		return nil, fmt.Errorf("must specify exactly one of pr_comment, git_pr, request_reviewers, mcp, slack, read_slack, microsoft_teams, or read_microsoft_teams")
+	if a.ApprovePr != nil {
+		count++
+	}
+	if a.ResolveReviewThreads != nil {
+		count++
+	}
+	if count != 1 {
+		return nil, fmt.Errorf("must specify exactly one of %s", actionTypeNames)
 	}
 
 	if a.PrComment != nil {
@@ -1694,6 +2004,15 @@ func actionModelToProto(a *actionModel) (*v1.Action, error) {
 	if a.ReadMicrosoftTeams != nil {
 		return &v1.Action{Action: &v1.Action_ReadMicrosoftTeams{ReadMicrosoftTeams: &v1.ReadMicrosoftTeamsAction{}}}, nil
 	}
+	if a.ManageCheckRun != nil {
+		return &v1.Action{Action: &v1.Action_ManageCheckRun{ManageCheckRun: &v1.ManageCheckRunAction{}}}, nil
+	}
+	if a.ApprovePr != nil {
+		return &v1.Action{Action: &v1.Action_ApprovePr{ApprovePr: &v1.ApprovePrAction{}}}, nil
+	}
+	if a.ResolveReviewThreads != nil {
+		return &v1.Action{Action: &v1.Action_ResolveReviewThreads{ResolveReviewThreads: &v1.ResolveReviewThreadsAction{}}}, nil
+	}
 
 	return nil, fmt.Errorf("no action type specified")
 }
@@ -1730,11 +2049,26 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 	if t.MicrosoftTeamsChannelCreated != nil {
 		count++
 	}
-	if count == 0 {
-		return nil, fmt.Errorf("must specify exactly one of git_pull_request, git_push, git_ci_completed, cron, slack, linear, webhook, microsoft_teams, or microsoft_teams_channel_created")
+	if t.SlackChannelCreated != nil {
+		count++
 	}
-	if count > 1 {
-		return nil, fmt.Errorf("must specify exactly one of git_pull_request, git_push, git_ci_completed, cron, slack, linear, webhook, microsoft_teams, or microsoft_teams_channel_created")
+	if t.SlackReactionAdded != nil {
+		count++
+	}
+	if t.SlackMention != nil {
+		count++
+	}
+	if t.SlackAnyReactionAdded != nil {
+		count++
+	}
+	if t.PagerDuty != nil {
+		count++
+	}
+	if t.Sentry != nil {
+		count++
+	}
+	if count != 1 {
+		return nil, fmt.Errorf("must specify exactly one of %s", triggerTypeNames)
 	}
 
 	// Git pull request
@@ -1876,6 +2210,137 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		trigger.Trigger = &v1.Trigger_SlackTrigger{SlackTrigger: st}
 	}
 
+	// Slack channel created
+	if scc := t.SlackChannelCreated; scc != nil {
+		st := &v1.SlackChannelCreatedTrigger{}
+		if !scc.ChannelNameContains.IsNull() && !scc.ChannelNameContains.IsUnknown() {
+			st.ChannelNameContains = scc.ChannelNameContains.ValueString()
+		}
+		trigger.Trigger = &v1.Trigger_SlackChannelCreated{SlackChannelCreated: st}
+	}
+
+	// Slack reaction added
+	if sra := t.SlackReactionAdded; sra != nil {
+		channel, err := requiredSlackChannel(sra.Channel, "slack_reaction_added")
+		if err != nil {
+			return nil, err
+		}
+		emojiName, err := validateSlackEmojiShortName(sra.EmojiName)
+		if err != nil {
+			return nil, err
+		}
+		st := &v1.SlackReactionAddedTrigger{
+			Channel:                        channel,
+			EmojiName:                      emojiName,
+			BlockUnauthenticatedSlackUsers: boolIsTrue(sra.BlockUnauthenticatedSlackUsers),
+			OnlyOwnerReactions:             boolIsTrue(sra.OnlyOwnerReactions),
+		}
+		trigger.Trigger = &v1.Trigger_SlackReactionAdded{SlackReactionAdded: st}
+	}
+
+	// Slack mention
+	if sm := t.SlackMention; sm != nil {
+		channel, err := requiredSlackChannel(sm.Channel, "slack_mention")
+		if err != nil {
+			return nil, err
+		}
+		st := &v1.SlackMentionTrigger{
+			Channel:                        channel,
+			BlockUnauthenticatedSlackUsers: boolIsTrue(sm.BlockUnauthenticatedSlackUsers),
+		}
+		trigger.Trigger = &v1.Trigger_SlackMention{SlackMention: st}
+	}
+
+	// Slack any reaction added
+	if sar := t.SlackAnyReactionAdded; sar != nil {
+		channel, err := requiredSlackChannel(sar.Channel, "slack_any_reaction_added")
+		if err != nil {
+			return nil, err
+		}
+		st := &v1.SlackAnyReactionAddedTrigger{
+			Channel:                        channel,
+			BlockUnauthenticatedSlackUsers: boolIsTrue(sar.BlockUnauthenticatedSlackUsers),
+			OnlyOwnerReactions:             boolIsTrue(sar.OnlyOwnerReactions),
+		}
+		trigger.Trigger = &v1.Trigger_SlackAnyReactionAdded{SlackAnyReactionAdded: st}
+	}
+
+	// PagerDuty
+	if pd := t.PagerDuty; pd != nil {
+		pt := &v1.PagerDutyTrigger{}
+		serviceIDs, err := readStringList(ctx, pd.ServiceIDs, "pagerduty.service_ids")
+		if err != nil {
+			return nil, err
+		}
+		pt.ServiceIds = serviceIDs
+
+		eventCount := 0
+		if pd.IncidentTriggered != nil {
+			eventCount++
+			pt.Event = &v1.PagerDutyTrigger_IncidentTriggered{IncidentTriggered: &v1.PagerDutyIncidentTriggeredEvent{}}
+		}
+		if pd.IncidentAcknowledged != nil {
+			eventCount++
+			pt.Event = &v1.PagerDutyTrigger_IncidentAcknowledged{IncidentAcknowledged: &v1.PagerDutyIncidentAcknowledgedEvent{}}
+		}
+		if pd.IncidentResolved != nil {
+			eventCount++
+			pt.Event = &v1.PagerDutyTrigger_IncidentResolved{IncidentResolved: &v1.PagerDutyIncidentResolvedEvent{}}
+		}
+		if pd.IncidentEscalated != nil {
+			eventCount++
+			pt.Event = &v1.PagerDutyTrigger_IncidentEscalated{IncidentEscalated: &v1.PagerDutyIncidentEscalatedEvent{}}
+		}
+		if pd.IncidentAny != nil {
+			eventCount++
+			pt.Event = &v1.PagerDutyTrigger_IncidentAny{IncidentAny: &v1.PagerDutyIncidentAnyEvent{}}
+		}
+		if eventCount != 1 {
+			return nil, fmt.Errorf("pagerduty trigger must specify exactly one of incident_triggered, incident_acknowledged, incident_resolved, incident_escalated, or incident_any")
+		}
+		trigger.Trigger = &v1.Trigger_Pagerduty{Pagerduty: pt}
+	}
+
+	// Sentry
+	if sentry := t.Sentry; sentry != nil {
+		st := &v1.SentryTrigger{}
+		projectIDs, err := readStringList(ctx, sentry.ProjectIDs, "sentry.project_ids")
+		if err != nil {
+			return nil, err
+		}
+		st.ProjectIds = projectIDs
+
+		eventCount := 0
+		if sentry.IssueCreated != nil {
+			eventCount++
+			st.Event = &v1.SentryTrigger_IssueCreated{IssueCreated: &v1.SentryIssueCreatedEvent{}}
+		}
+		if sentry.IssueResolved != nil {
+			eventCount++
+			st.Event = &v1.SentryTrigger_IssueResolved{IssueResolved: &v1.SentryIssueResolvedEvent{}}
+		}
+		if sentry.IssueAssigned != nil {
+			eventCount++
+			st.Event = &v1.SentryTrigger_IssueAssigned{IssueAssigned: &v1.SentryIssueAssignedEvent{}}
+		}
+		if sentry.IssueArchived != nil {
+			eventCount++
+			st.Event = &v1.SentryTrigger_IssueArchived{IssueArchived: &v1.SentryIssueArchivedEvent{}}
+		}
+		if sentry.IssueUnresolved != nil {
+			eventCount++
+			st.Event = &v1.SentryTrigger_IssueUnresolved{IssueUnresolved: &v1.SentryIssueUnresolvedEvent{}}
+		}
+		if sentry.IssueAny != nil {
+			eventCount++
+			st.Event = &v1.SentryTrigger_IssueAny{IssueAny: &v1.SentryIssueAnyEvent{}}
+		}
+		if eventCount != 1 {
+			return nil, fmt.Errorf("sentry trigger must specify exactly one of issue_created, issue_resolved, issue_assigned, issue_archived, issue_unresolved, or issue_any")
+		}
+		trigger.Trigger = &v1.Trigger_Sentry{Sentry: st}
+	}
+
 	// Linear
 	if linear := t.Linear; linear != nil {
 		lt := &v1.LinearTrigger{}
@@ -1987,14 +2452,11 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		mctt := &v1.MicrosoftTeamsChannelCreatedTrigger{
 			TenantId: mtc.TenantID.ValueString(),
 		}
-		if !mtc.TeamIDs.IsNull() && !mtc.TeamIDs.IsUnknown() {
-			var teamIDs []string
-			diags := mtc.TeamIDs.ElementsAs(ctx, &teamIDs, false)
-			if diags.HasError() {
-				return nil, fmt.Errorf("failed to read microsoft_teams_channel_created.team_ids")
-			}
-			mctt.TeamIds = teamIDs
+		teamIDs, err := readStringList(ctx, mtc.TeamIDs, "microsoft_teams_channel_created.team_ids")
+		if err != nil {
+			return nil, err
 		}
+		mctt.TeamIds = teamIDs
 		if !mtc.ChannelNameContains.IsNull() && !mtc.ChannelNameContains.IsUnknown() {
 			mctt.ChannelNameContains = mtc.ChannelNameContains.ValueString()
 		}
@@ -2002,6 +2464,69 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 	}
 
 	return trigger, nil
+}
+
+func boolIsTrue(value types.Bool) bool {
+	return !value.IsNull() && !value.IsUnknown() && value.ValueBool()
+}
+
+// boolOrNull mirrors the existing slack trigger convention of reading proto3
+// booleans back as null when false so unset configs do not drift.
+func boolOrNull(value bool) types.Bool {
+	if value {
+		return types.BoolValue(true)
+	}
+	return types.BoolNull()
+}
+
+func stringOrNull(value string) types.String {
+	if value == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
+}
+
+func requiredSlackChannel(value types.String, block string) (string, error) {
+	if value.IsNull() || value.IsUnknown() || strings.TrimSpace(value.ValueString()) == "" {
+		return "", fmt.Errorf("%s.channel is required", block)
+	}
+	return strings.TrimSpace(value.ValueString()), nil
+}
+
+// validateSlackEmojiShortName requires the canonical form the server stores
+// (lowercase short name, no colons or skin-tone suffix) so the value reads
+// back unchanged instead of drifting after the server normalises it.
+func validateSlackEmojiShortName(value types.String) (string, error) {
+	if value.IsNull() || value.IsUnknown() || strings.TrimSpace(value.ValueString()) == "" {
+		return "", fmt.Errorf("slack_reaction_added.emoji_name is required")
+	}
+	name := value.ValueString()
+	for _, r := range name {
+		isLower := r >= 'a' && r <= 'z'
+		isDigit := r >= '0' && r <= '9'
+		if !isLower && !isDigit && r != '_' && r != '+' && r != '-' {
+			return "", fmt.Errorf("invalid slack_reaction_added.emoji_name %q: use the lowercase Slack short name without colons (e.g. \"thumbsup\")", name)
+		}
+	}
+	return name, nil
+}
+
+func parseAutomationDefaultTool(s string) (v1.AutomationDefaultTool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "open_git_pr":
+		return v1.AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR, nil
+	default:
+		return 0, fmt.Errorf("invalid disabled_default_tools entry %q, must be \"open_git_pr\"", s)
+	}
+}
+
+func automationDefaultToolToString(tool v1.AutomationDefaultTool) string {
+	switch tool {
+	case v1.AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR:
+		return "open_git_pr"
+	default:
+		return ""
+	}
 }
 
 // applySlackCompletionReaction translates the Terraform completion reaction
@@ -2121,12 +2646,28 @@ func protoToModel(ctx context.Context, withOwner *v1.AutomationWithOwner) (platf
 	}
 
 	m := platformWorkflowModel{
-		ID:        types.StringValue(pw.GetAutomationId()),
-		Name:      types.StringValue(pw.GetName()),
-		Scope:     automationScopeToModel(pw.GetScope()),
-		Enabled:   types.BoolValue(pw.GetEnabled()),
-		CreatedAt: types.Int64Value(pw.GetCreatedAt()),
-		UpdatedAt: types.Int64Value(pw.GetUpdatedAt()),
+		ID:          types.StringValue(pw.GetAutomationId()),
+		Name:        types.StringValue(pw.GetName()),
+		Description: stringOrNull(pw.GetDescription()),
+		Scope:       automationScopeToModel(pw.GetScope()),
+		// team_id is not echoed back: the resource keeps the configured value
+		// (see preserveConfiguredValues) and the data source fills it in.
+		TeamID:               types.Int64Null(),
+		Enabled:              types.BoolValue(pw.GetEnabled()),
+		DisabledDefaultTools: types.ListNull(types.StringType),
+		CreatedAt:            types.Int64Value(pw.GetCreatedAt()),
+		UpdatedAt:            types.Int64Value(pw.GetUpdatedAt()),
+	}
+
+	// DisabledDefaultTools
+	var disabledTools []string
+	for _, tool := range wf.GetDisabledDefaultTools() {
+		if name := automationDefaultToolToString(tool); name != "" {
+			disabledTools = append(disabledTools, name)
+		}
+	}
+	if len(disabledTools) > 0 {
+		m.DisabledDefaultTools, _ = types.ListValueFrom(ctx, types.StringType, disabledTools)
 	}
 
 	// Prompt (take the first one)
@@ -2233,7 +2774,10 @@ func protoToModel(ctx context.Context, withOwner *v1.AutomationWithOwner) (platf
 			am.Slack == nil &&
 			am.ReadSlack == nil &&
 			am.MicrosoftTeams == nil &&
-			am.ReadMicrosoftTeams == nil {
+			am.ReadMicrosoftTeams == nil &&
+			am.ManageCheckRun == nil &&
+			am.ApprovePr == nil &&
+			am.ResolveReviewThreads == nil {
 			continue
 		}
 		m.Actions = append(m.Actions, am)
@@ -2311,6 +2855,12 @@ func protoActionToModel(a *v1.Action) actionModel {
 		am.MicrosoftTeams = mt
 	case *v1.Action_ReadMicrosoftTeams:
 		am.ReadMicrosoftTeams = &readMicrosoftTeamsActionModel{}
+	case *v1.Action_ManageCheckRun:
+		am.ManageCheckRun = &manageCheckRunActionModel{}
+	case *v1.Action_ApprovePr:
+		am.ApprovePr = &approvePrActionModel{}
+	case *v1.Action_ResolveReviewThreads:
+		am.ResolveReviewThreads = &resolveReviewThreadsActionModel{}
 	}
 
 	return am
@@ -2439,6 +2989,83 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 		tm.Slack = sm
 		tm.UserAllowlist = types.ListNull(types.StringType)
 
+	case *v1.Trigger_SlackChannelCreated:
+		tm.SlackChannelCreated = &slackChannelCreatedTriggerModel{
+			ChannelNameContains: stringOrNull(trigger.SlackChannelCreated.GetChannelNameContains()),
+		}
+		tm.UserAllowlist = types.ListNull(types.StringType)
+
+	case *v1.Trigger_SlackReactionAdded:
+		sra := trigger.SlackReactionAdded
+		tm.SlackReactionAdded = &slackReactionAddedTriggerModel{
+			Channel:                        types.StringValue(firstSlackChannel(sra.GetChannel(), sra.GetChannels())),
+			EmojiName:                      types.StringValue(sra.GetEmojiName()),
+			BlockUnauthenticatedSlackUsers: boolOrNull(sra.GetBlockUnauthenticatedSlackUsers()),
+			OnlyOwnerReactions:             boolOrNull(sra.GetOnlyOwnerReactions()),
+		}
+		tm.UserAllowlist = types.ListNull(types.StringType)
+
+	case *v1.Trigger_SlackMention:
+		sm := trigger.SlackMention
+		tm.SlackMention = &slackMentionTriggerModel{
+			Channel:                        types.StringValue(firstSlackChannel(sm.GetChannel(), sm.GetChannels())),
+			BlockUnauthenticatedSlackUsers: boolOrNull(sm.GetBlockUnauthenticatedSlackUsers()),
+		}
+		tm.UserAllowlist = types.ListNull(types.StringType)
+
+	case *v1.Trigger_SlackAnyReactionAdded:
+		sar := trigger.SlackAnyReactionAdded
+		tm.SlackAnyReactionAdded = &slackAnyReactionAddedTriggerModel{
+			Channel:                        types.StringValue(firstSlackChannel(sar.GetChannel(), sar.GetChannels())),
+			BlockUnauthenticatedSlackUsers: boolOrNull(sar.GetBlockUnauthenticatedSlackUsers()),
+			OnlyOwnerReactions:             boolOrNull(sar.GetOnlyOwnerReactions()),
+		}
+		tm.UserAllowlist = types.ListNull(types.StringType)
+
+	case *v1.Trigger_Pagerduty:
+		pd := trigger.Pagerduty
+		pm := &pagerDutyTriggerModel{ServiceIDs: types.ListNull(types.StringType)}
+		if len(pd.GetServiceIds()) > 0 {
+			pm.ServiceIDs, _ = types.ListValueFrom(ctx, types.StringType, pd.GetServiceIds())
+		}
+		switch pd.Event.(type) {
+		case *v1.PagerDutyTrigger_IncidentTriggered:
+			pm.IncidentTriggered = &emptyEventModel{}
+		case *v1.PagerDutyTrigger_IncidentAcknowledged:
+			pm.IncidentAcknowledged = &emptyEventModel{}
+		case *v1.PagerDutyTrigger_IncidentResolved:
+			pm.IncidentResolved = &emptyEventModel{}
+		case *v1.PagerDutyTrigger_IncidentEscalated:
+			pm.IncidentEscalated = &emptyEventModel{}
+		case *v1.PagerDutyTrigger_IncidentAny:
+			pm.IncidentAny = &emptyEventModel{}
+		}
+		tm.PagerDuty = pm
+		tm.UserAllowlist = types.ListNull(types.StringType)
+
+	case *v1.Trigger_Sentry:
+		sentry := trigger.Sentry
+		sm := &sentryTriggerModel{ProjectIDs: types.ListNull(types.StringType)}
+		if len(sentry.GetProjectIds()) > 0 {
+			sm.ProjectIDs, _ = types.ListValueFrom(ctx, types.StringType, sentry.GetProjectIds())
+		}
+		switch sentry.Event.(type) {
+		case *v1.SentryTrigger_IssueCreated:
+			sm.IssueCreated = &emptyEventModel{}
+		case *v1.SentryTrigger_IssueResolved:
+			sm.IssueResolved = &emptyEventModel{}
+		case *v1.SentryTrigger_IssueAssigned:
+			sm.IssueAssigned = &emptyEventModel{}
+		case *v1.SentryTrigger_IssueArchived:
+			sm.IssueArchived = &emptyEventModel{}
+		case *v1.SentryTrigger_IssueUnresolved:
+			sm.IssueUnresolved = &emptyEventModel{}
+		case *v1.SentryTrigger_IssueAny:
+			sm.IssueAny = &emptyEventModel{}
+		}
+		tm.Sentry = sm
+		tm.UserAllowlist = types.ListNull(types.StringType)
+
 	case *v1.Trigger_Linear:
 		linear := trigger.Linear
 		lm := &linearTriggerModel{}
@@ -2542,6 +3169,18 @@ func protoTriggerToModel(ctx context.Context, t *v1.Trigger) (triggerModel, erro
 	}
 
 	return tm, nil
+}
+
+// firstSlackChannel mirrors the server's preferRepeated: the repeated
+// `channels` field wins over the singular `channel` when populated. Only the
+// first channel is exposed, matching the existing `slack` trigger.
+func firstSlackChannel(channel string, channels []string) string {
+	for _, c := range channels {
+		if strings.TrimSpace(c) != "" {
+			return strings.TrimSpace(c)
+		}
+	}
+	return channel
 }
 
 func prActionToString(a v1.GitPullRequestAction) string {

--- a/internal/provider/resource_platform_workflow.go
+++ b/internal/provider/resource_platform_workflow.go
@@ -1103,7 +1103,7 @@ func (r *platformWorkflowResource) Create(ctx context.Context, req resource.Crea
 		Scope:    scope,
 		Workflow: workflow,
 	}
-	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+	if !plan.Description.IsNull() && !plan.Description.IsUnknown() && plan.Description.ValueString() != "" {
 		description := plan.Description.ValueString()
 		createReq.Description = &description
 	}
@@ -1152,7 +1152,16 @@ func preserveConfiguredValues(ctx context.Context, state *platformWorkflowModel,
 	preserveEquivalentGitCICompletionConditions(state, reference)
 	preserveEquivalentEnvironmentPublicID(state, reference)
 	preserveEquivalentModelSelection(state, reference)
+	preserveEmptyDescription(state, reference)
 	state.TeamID = reference.TeamID
+}
+
+// An explicitly empty description is never sent and reads back as null; keep
+// the configured "" so the state matches the plan.
+func preserveEmptyDescription(state *platformWorkflowModel, reference platformWorkflowModel) {
+	if state.Description.IsNull() && !reference.Description.IsNull() && !reference.Description.IsUnknown() && reference.Description.ValueString() == "" {
+		state.Description = reference.Description
+	}
 }
 
 func optionalTeamID(value types.Int64) *int32 {
@@ -1340,6 +1349,10 @@ func (r *platformWorkflowResource) ValidateConfig(ctx context.Context, req resou
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("model"), &model)...)
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("model_selection"), &selection)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Unknown values may still resolve to null; only reject when both are known.
+	if model.IsUnknown() || selection.IsUnknown() {
 		return
 	}
 	if !model.IsNull() && !selection.IsNull() {
@@ -1591,6 +1604,22 @@ func readStringList(ctx context.Context, list types.List, fieldName string) ([]s
 	diags := list.ElementsAs(ctx, &values, false)
 	if diags.HasError() {
 		return nil, fmt.Errorf("failed to read %s", fieldName)
+	}
+	return values, nil
+}
+
+// readNonBlankStringList is readStringList plus a check that no entry is empty
+// or whitespace-only. Entries are rejected rather than trimmed so the value
+// the API echoes back always matches the configured one.
+func readNonBlankStringList(ctx context.Context, list types.List, fieldName string) ([]string, error) {
+	values, err := readStringList(ctx, list, fieldName)
+	if err != nil {
+		return nil, err
+	}
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, fmt.Errorf("%s[%d] must not be empty", fieldName, i)
+		}
 	}
 	return values, nil
 }
@@ -2590,7 +2619,7 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 	// PagerDuty
 	if pd := t.PagerDuty; pd != nil {
 		pt := &v1.PagerDutyTrigger{}
-		serviceIDs, err := readStringList(ctx, pd.ServiceIDs, "pagerduty.service_ids")
+		serviceIDs, err := readNonBlankStringList(ctx, pd.ServiceIDs, "pagerduty.service_ids")
 		if err != nil {
 			return nil, err
 		}
@@ -2626,7 +2655,7 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 	// Sentry
 	if sentry := t.Sentry; sentry != nil {
 		st := &v1.SentryTrigger{}
-		projectIDs, err := readStringList(ctx, sentry.ProjectIDs, "sentry.project_ids")
+		projectIDs, err := readNonBlankStringList(ctx, sentry.ProjectIDs, "sentry.project_ids")
 		if err != nil {
 			return nil, err
 		}
@@ -2774,7 +2803,7 @@ func triggerModelToProto(ctx context.Context, t *triggerModel) (*v1.Trigger, err
 		mctt := &v1.MicrosoftTeamsChannelCreatedTrigger{
 			TenantId: mtc.TenantID.ValueString(),
 		}
-		teamIDs, err := readStringList(ctx, mtc.TeamIDs, "microsoft_teams_channel_created.team_ids")
+		teamIDs, err := readNonBlankStringList(ctx, mtc.TeamIDs, "microsoft_teams_channel_created.team_ids")
 		if err != nil {
 			return nil, err
 		}
@@ -2837,7 +2866,9 @@ func validateSlackEmojiShortName(value types.String) (string, error) {
 }
 
 func parseAutomationDefaultTool(s string) (v1.AutomationDefaultTool, error) {
-	switch strings.ToLower(strings.TrimSpace(s)) {
+	// Exact match only: the value is read back as the canonical lowercase name,
+	// so accepting other spellings would drift after apply.
+	switch s {
 	case "open_git_pr":
 		return v1.AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR, nil
 	default:

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -3057,6 +3057,18 @@ func TestDisabledDefaultToolsRoundTrip(t *testing.T) {
 	})
 
 	t.Run("model_to_proto_rejects_unknown_tool", func(t *testing.T) {
+		for _, entry := range []string{"nope", "OPEN_GIT_PR", " open_git_pr"} {
+			m := &platformWorkflowModel{
+				Prompt:               types.StringValue("review code"),
+				DisabledDefaultTools: mustStringList(t, ctx, []string{entry}),
+				Triggers: []triggerModel{
+					{Webhook: &webhookTriggerModel{}, UserAllowlist: types.ListNull(types.StringType)},
+				},
+			}
+			if _, err := modelToWorkflow(ctx, m); err == nil {
+				t.Errorf("expected error for disabled_default_tools entry %q", entry)
+			}
+		}
 		m := &platformWorkflowModel{
 			Prompt:               types.StringValue("review code"),
 			DisabledDefaultTools: mustStringList(t, ctx, []string{"nope"}),
@@ -3635,6 +3647,48 @@ func TestValidateConfigRejectsModelWithModelSelection(t *testing.T) {
 	sel := &modelSelectionModel{ModelID: types.StringValue("auto-smart"), MaxMode: types.BoolNull()}
 	check(t, types.StringValue("auto-smart"), sel, true)
 	check(t, types.StringNull(), sel, false)
+	// An unknown slug (e.g. from a variable) may still resolve to null.
+	check(t, types.StringUnknown(), sel, false)
 	check(t, types.StringValue("gpt-5.5"), nil, false)
 	check(t, types.StringNull(), nil, false)
+}
+
+func TestNonBlankListEntriesRejected(t *testing.T) {
+	ctx := context.Background()
+	blank := mustStringList(t, ctx, []string{"ok", " "})
+
+	cases := map[string]triggerModel{
+		"microsoft_teams_channel_created.team_ids": {MicrosoftTeamsChannelCreated: &microsoftTeamsChannelCreatedTriggerModel{
+			TenantID: types.StringValue("tenant"), TeamIDs: blank,
+		}},
+		"pagerduty.service_ids": {PagerDuty: &pagerDutyTriggerModel{IncidentAny: &emptyEventModel{}, ServiceIDs: blank}},
+		"sentry.project_ids":    {Sentry: &sentryTriggerModel{IssueAny: &emptyEventModel{}, ProjectIDs: blank}},
+	}
+	for field, trigger := range cases {
+		trigger.UserAllowlist = types.ListNull(types.StringType)
+		_, err := triggerModelToProto(ctx, &trigger)
+		if err == nil || !strings.Contains(err.Error(), field+"[1] must not be empty") {
+			t.Errorf("%s: expected blank-entry error, got %v", field, err)
+		}
+	}
+}
+
+func TestPreserveEmptyDescription(t *testing.T) {
+	state := platformWorkflowModel{Description: types.StringNull()}
+	preserveEmptyDescription(&state, platformWorkflowModel{Description: types.StringValue("")})
+	if state.Description.IsNull() || state.Description.ValueString() != "" {
+		t.Fatalf("description = %v, want configured empty string", state.Description)
+	}
+
+	state = platformWorkflowModel{Description: types.StringNull()}
+	preserveEmptyDescription(&state, platformWorkflowModel{Description: types.StringNull()})
+	if !state.Description.IsNull() {
+		t.Fatal("unset description must stay null")
+	}
+
+	state = platformWorkflowModel{Description: types.StringValue("server")}
+	preserveEmptyDescription(&state, platformWorkflowModel{Description: types.StringValue("")})
+	if state.Description.ValueString() != "server" {
+		t.Fatal("a server-provided description must not be overwritten")
+	}
 }

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -2502,3 +2502,685 @@ func TestPrivateWorkerAPILabelOrderDoesNotDrift(t *testing.T) {
 		t.Fatalf("private worker labels were not canonicalized: %#v", labels)
 	}
 }
+
+func TestSlackChannelCreatedTriggerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("welcome new channels"),
+			Triggers: []triggerModel{
+				{
+					SlackChannelCreated: &slackChannelCreatedTriggerModel{
+						ChannelNameContains: types.StringValue("incident"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		scc := wf.Triggers[0].GetSlackChannelCreated()
+		if scc == nil {
+			t.Fatal("expected slack_channel_created trigger in proto")
+		}
+		if scc.GetChannelNameContains() != "incident" {
+			t.Fatalf("ChannelNameContains = %q, want %q", scc.GetChannelNameContains(), "incident")
+		}
+	})
+
+	t.Run("proto_to_model_empty_filter_is_null", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{Trigger: &v1.Trigger_SlackChannelCreated{SlackChannelCreated: &v1.SlackChannelCreatedTrigger{}}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		scc := model.Triggers[0].SlackChannelCreated
+		if scc == nil {
+			t.Fatal("expected slack_channel_created trigger in terraform model")
+		}
+		if !scc.ChannelNameContains.IsNull() {
+			t.Fatalf("expected null channel_name_contains, got %v", scc.ChannelNameContains)
+		}
+	})
+}
+
+func TestSlackReactionAddedTriggerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage reactions"),
+			Triggers: []triggerModel{
+				{
+					SlackReactionAdded: &slackReactionAddedTriggerModel{
+						Channel:                        types.StringValue("C0123456789"),
+						EmojiName:                      types.StringValue("white_check_mark"),
+						BlockUnauthenticatedSlackUsers: types.BoolValue(true),
+						OnlyOwnerReactions:             types.BoolNull(),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		sra := wf.Triggers[0].GetSlackReactionAdded()
+		if sra == nil {
+			t.Fatal("expected slack_reaction_added trigger in proto")
+		}
+		if sra.GetChannel() != "C0123456789" {
+			t.Fatalf("Channel = %q", sra.GetChannel())
+		}
+		if sra.GetEmojiName() != "white_check_mark" {
+			t.Fatalf("EmojiName = %q", sra.GetEmojiName())
+		}
+		if !sra.GetBlockUnauthenticatedSlackUsers() {
+			t.Fatal("expected BlockUnauthenticatedSlackUsers=true")
+		}
+		if sra.GetOnlyOwnerReactions() {
+			t.Fatal("expected OnlyOwnerReactions=false when unset")
+		}
+	})
+
+	t.Run("model_to_proto_rejects_non_canonical_emoji", func(t *testing.T) {
+		for _, emoji := range []string{":thumbsup:", "ThumbsUp", "thumbsup::skin-tone-2", ""} {
+			m := &platformWorkflowModel{
+				Prompt: types.StringValue("triage reactions"),
+				Triggers: []triggerModel{
+					{
+						SlackReactionAdded: &slackReactionAddedTriggerModel{
+							Channel:   types.StringValue("C0123456789"),
+							EmojiName: types.StringValue(emoji),
+						},
+						UserAllowlist: types.ListNull(types.StringType),
+					},
+				},
+			}
+			if _, err := modelToWorkflow(ctx, m); err == nil {
+				t.Errorf("expected error for emoji_name %q", emoji)
+			}
+		}
+	})
+
+	t.Run("model_to_proto_requires_channel", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage reactions"),
+			Triggers: []triggerModel{
+				{
+					SlackReactionAdded: &slackReactionAddedTriggerModel{
+						Channel:   types.StringValue(" "),
+						EmojiName: types.StringValue("eyes"),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+		_, err := modelToWorkflow(ctx, m)
+		if err == nil || !strings.Contains(err.Error(), "slack_reaction_added.channel is required") {
+			t.Fatalf("expected channel required error, got %v", err)
+		}
+	})
+
+	t.Run("proto_to_model_prefers_channels_and_nulls_false_bools", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{Trigger: &v1.Trigger_SlackReactionAdded{SlackReactionAdded: &v1.SlackReactionAddedTrigger{
+							Channel:            "C0123456789",
+							Channels:           []string{"C0123456789"},
+							EmojiName:          "eyes",
+							OnlyOwnerReactions: true,
+						}}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		sra := model.Triggers[0].SlackReactionAdded
+		if sra == nil {
+			t.Fatal("expected slack_reaction_added trigger in terraform model")
+		}
+		if sra.Channel.ValueString() != "C0123456789" {
+			t.Fatalf("Channel = %q", sra.Channel.ValueString())
+		}
+		if sra.EmojiName.ValueString() != "eyes" {
+			t.Fatalf("EmojiName = %q", sra.EmojiName.ValueString())
+		}
+		if !sra.BlockUnauthenticatedSlackUsers.IsNull() {
+			t.Fatal("expected null block_unauthenticated_slack_users when false")
+		}
+		if !sra.OnlyOwnerReactions.ValueBool() {
+			t.Fatal("expected only_owner_reactions=true")
+		}
+	})
+}
+
+func TestSlackMentionAndAnyReactionTriggerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("respond to mentions"),
+			Triggers: []triggerModel{
+				{
+					SlackMention: &slackMentionTriggerModel{
+						Channel:                        types.StringValue("C1"),
+						BlockUnauthenticatedSlackUsers: types.BoolValue(true),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+				{
+					SlackAnyReactionAdded: &slackAnyReactionAddedTriggerModel{
+						Channel:            types.StringValue("C2"),
+						OnlyOwnerReactions: types.BoolValue(true),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		mention := wf.Triggers[0].GetSlackMention()
+		if mention == nil || mention.GetChannel() != "C1" || !mention.GetBlockUnauthenticatedSlackUsers() {
+			t.Fatalf("unexpected slack_mention proto: %v", mention)
+		}
+		anyReaction := wf.Triggers[1].GetSlackAnyReactionAdded()
+		if anyReaction == nil || anyReaction.GetChannel() != "C2" || !anyReaction.GetOnlyOwnerReactions() || anyReaction.GetBlockUnauthenticatedSlackUsers() {
+			t.Fatalf("unexpected slack_any_reaction_added proto: %v", anyReaction)
+		}
+	})
+
+	t.Run("proto_to_model", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{Trigger: &v1.Trigger_SlackMention{SlackMention: &v1.SlackMentionTrigger{Channels: []string{"C1", "C9"}}}},
+						{Trigger: &v1.Trigger_SlackAnyReactionAdded{SlackAnyReactionAdded: &v1.SlackAnyReactionAddedTrigger{
+							Channel:                        "C2",
+							BlockUnauthenticatedSlackUsers: true,
+						}}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		mention := model.Triggers[0].SlackMention
+		if mention == nil || mention.Channel.ValueString() != "C1" || !mention.BlockUnauthenticatedSlackUsers.IsNull() {
+			t.Fatalf("unexpected slack_mention model: %+v", mention)
+		}
+		anyReaction := model.Triggers[1].SlackAnyReactionAdded
+		if anyReaction == nil || anyReaction.Channel.ValueString() != "C2" || !anyReaction.BlockUnauthenticatedSlackUsers.ValueBool() || !anyReaction.OnlyOwnerReactions.IsNull() {
+			t.Fatalf("unexpected slack_any_reaction_added model: %+v", anyReaction)
+		}
+	})
+}
+
+func TestPagerDutyTriggerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("handle incidents"),
+			Triggers: []triggerModel{
+				{
+					PagerDuty: &pagerDutyTriggerModel{
+						IncidentTriggered: &emptyEventModel{},
+						ServiceIDs:        mustStringList(t, ctx, []string{"PABC123"}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		pd := wf.Triggers[0].GetPagerduty()
+		if pd == nil {
+			t.Fatal("expected pagerduty trigger in proto")
+		}
+		if pd.GetIncidentTriggered() == nil {
+			t.Fatal("expected incident_triggered event in proto")
+		}
+		if !reflect.DeepEqual(pd.GetServiceIds(), []string{"PABC123"}) {
+			t.Fatalf("ServiceIds = %v", pd.GetServiceIds())
+		}
+	})
+
+	t.Run("model_to_proto_requires_exactly_one_event", func(t *testing.T) {
+		for name, pd := range map[string]*pagerDutyTriggerModel{
+			"none": {ServiceIDs: types.ListNull(types.StringType)},
+			"two":  {IncidentAny: &emptyEventModel{}, IncidentResolved: &emptyEventModel{}, ServiceIDs: types.ListNull(types.StringType)},
+		} {
+			m := &platformWorkflowModel{
+				Prompt:   types.StringValue("handle incidents"),
+				Triggers: []triggerModel{{PagerDuty: pd, UserAllowlist: types.ListNull(types.StringType)}},
+			}
+			if _, err := modelToWorkflow(ctx, m); err == nil {
+				t.Errorf("%s: expected error", name)
+			}
+		}
+	})
+
+	t.Run("proto_to_model", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{Trigger: &v1.Trigger_Pagerduty{Pagerduty: &v1.PagerDutyTrigger{
+							Event: &v1.PagerDutyTrigger_IncidentAny{IncidentAny: &v1.PagerDutyIncidentAnyEvent{}},
+						}}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		pd := model.Triggers[0].PagerDuty
+		if pd == nil {
+			t.Fatal("expected pagerduty trigger in terraform model")
+		}
+		if pd.IncidentAny == nil || pd.IncidentTriggered != nil {
+			t.Fatalf("unexpected pagerduty events: %+v", pd)
+		}
+		if !pd.ServiceIDs.IsNull() {
+			t.Fatal("expected null service_ids when empty")
+		}
+	})
+}
+
+func TestSentryTriggerRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage sentry issues"),
+			Triggers: []triggerModel{
+				{
+					Sentry: &sentryTriggerModel{
+						IssueCreated: &emptyEventModel{},
+						ProjectIDs:   mustStringList(t, ctx, []string{"123", "456"}),
+					},
+					UserAllowlist: types.ListNull(types.StringType),
+				},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		sentry := wf.Triggers[0].GetSentry()
+		if sentry == nil {
+			t.Fatal("expected sentry trigger in proto")
+		}
+		if sentry.GetIssueCreated() == nil {
+			t.Fatal("expected issue_created event in proto")
+		}
+		if !reflect.DeepEqual(sentry.GetProjectIds(), []string{"123", "456"}) {
+			t.Fatalf("ProjectIds = %v", sentry.GetProjectIds())
+		}
+	})
+
+	t.Run("model_to_proto_requires_exactly_one_event", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("triage sentry issues"),
+			Triggers: []triggerModel{{
+				Sentry:        &sentryTriggerModel{ProjectIDs: types.ListNull(types.StringType)},
+				UserAllowlist: types.ListNull(types.StringType),
+			}},
+		}
+		if _, err := modelToWorkflow(ctx, m); err == nil {
+			t.Fatal("expected error when no sentry event is set")
+		}
+	})
+
+	t.Run("proto_to_model", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Triggers: []*v1.Trigger{
+						{Trigger: &v1.Trigger_Sentry{Sentry: &v1.SentryTrigger{
+							Event:      &v1.SentryTrigger_IssueUnresolved{IssueUnresolved: &v1.SentryIssueUnresolvedEvent{}},
+							ProjectIds: []string{"123"},
+						}}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		sentry := model.Triggers[0].Sentry
+		if sentry == nil {
+			t.Fatal("expected sentry trigger in terraform model")
+		}
+		if sentry.IssueUnresolved == nil || sentry.IssueAny != nil {
+			t.Fatalf("unexpected sentry events: %+v", sentry)
+		}
+		var projectIDs []string
+		if diags := sentry.ProjectIDs.ElementsAs(ctx, &projectIDs, false); diags.HasError() {
+			t.Fatalf("failed to read project_ids: %v", diags)
+		}
+		if !reflect.DeepEqual(projectIDs, []string{"123"}) {
+			t.Fatalf("project_ids = %v", projectIDs)
+		}
+	})
+}
+
+func TestEmptyActionsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}, UserAllowlist: types.ListNull(types.StringType)},
+			},
+			Actions: []actionModel{
+				{ManageCheckRun: &manageCheckRunActionModel{}},
+				{ApprovePr: &approvePrActionModel{}},
+				{ResolveReviewThreads: &resolveReviewThreadsActionModel{}},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if len(wf.Actions) != 3 {
+			t.Fatalf("expected 3 actions, got %d", len(wf.Actions))
+		}
+		if wf.Actions[0].GetManageCheckRun() == nil {
+			t.Error("expected manage_check_run action")
+		}
+		if wf.Actions[1].GetApprovePr() == nil {
+			t.Error("expected approve_pr action")
+		}
+		if wf.Actions[2].GetResolveReviewThreads() == nil {
+			t.Error("expected resolve_review_threads action")
+		}
+	})
+
+	t.Run("model_to_proto_rejects_multiple_action_types", func(t *testing.T) {
+		_, err := actionModelToProto(&actionModel{
+			ManageCheckRun:       &manageCheckRunActionModel{},
+			ResolveReviewThreads: &resolveReviewThreadsActionModel{},
+		})
+		if err == nil || !strings.Contains(err.Error(), "exactly one of") {
+			t.Fatalf("expected exactly-one error, got %v", err)
+		}
+	})
+
+	t.Run("proto_to_model", func(t *testing.T) {
+		input := &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Actions: []*v1.Action{
+						{Action: &v1.Action_ManageCheckRun{ManageCheckRun: &v1.ManageCheckRunAction{}}},
+						{Action: &v1.Action_ApprovePr{ApprovePr: &v1.ApprovePrAction{}}},
+						{Action: &v1.Action_ResolveReviewThreads{ResolveReviewThreads: &v1.ResolveReviewThreadsAction{}}},
+					},
+				},
+			},
+		}
+
+		model, err := protoToModel(ctx, input)
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		if len(model.Actions) != 3 {
+			t.Fatalf("expected 3 actions, got %d", len(model.Actions))
+		}
+		if model.Actions[0].ManageCheckRun == nil || model.Actions[1].ApprovePr == nil || model.Actions[2].ResolveReviewThreads == nil {
+			t.Fatalf("unexpected actions: %+v", model.Actions)
+		}
+	})
+}
+
+func TestDisabledDefaultToolsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt:               types.StringValue("review code"),
+			DisabledDefaultTools: mustStringList(t, ctx, []string{"open_git_pr"}),
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}, UserAllowlist: types.ListNull(types.StringType)},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		want := []v1.AutomationDefaultTool{v1.AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR}
+		if !reflect.DeepEqual(wf.GetDisabledDefaultTools(), want) {
+			t.Fatalf("DisabledDefaultTools = %v, want %v", wf.GetDisabledDefaultTools(), want)
+		}
+	})
+
+	t.Run("model_to_proto_rejects_unknown_tool", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt:               types.StringValue("review code"),
+			DisabledDefaultTools: mustStringList(t, ctx, []string{"nope"}),
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}, UserAllowlist: types.ListNull(types.StringType)},
+			},
+		}
+		if _, err := modelToWorkflow(ctx, m); err == nil {
+			t.Fatal("expected error for unknown disabled_default_tools entry")
+		}
+	})
+
+	t.Run("proto_to_model", func(t *testing.T) {
+		model, err := protoToModel(ctx, &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					DisabledDefaultTools: []v1.AutomationDefaultTool{v1.AutomationDefaultTool_AUTOMATION_DEFAULT_TOOL_OPEN_GIT_PR},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		var tools []string
+		if diags := model.DisabledDefaultTools.ElementsAs(ctx, &tools, false); diags.HasError() {
+			t.Fatalf("failed to read disabled_default_tools: %v", diags)
+		}
+		if !reflect.DeepEqual(tools, []string{"open_git_pr"}) {
+			t.Fatalf("disabled_default_tools = %v", tools)
+		}
+
+		empty, err := protoToModel(ctx, &v1.AutomationWithOwner{Workflow: &v1.Automation{Workflow: &v1.Workflow{}}})
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		if !empty.DisabledDefaultTools.IsNull() {
+			t.Fatal("expected null disabled_default_tools when the server returns none")
+		}
+	})
+}
+
+func TestDescriptionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	described := "Reviews PRs"
+	model, err := protoToModel(ctx, &v1.AutomationWithOwner{
+		Workflow: &v1.Automation{Description: &described, Workflow: &v1.Workflow{}},
+	})
+	if err != nil {
+		t.Fatalf("protoToModel() error: %v", err)
+	}
+	if model.Description.ValueString() != described {
+		t.Fatalf("Description = %q", model.Description.ValueString())
+	}
+
+	empty := ""
+	model, err = protoToModel(ctx, &v1.AutomationWithOwner{
+		Workflow: &v1.Automation{Description: &empty, Workflow: &v1.Workflow{}},
+	})
+	if err != nil {
+		t.Fatalf("protoToModel() error: %v", err)
+	}
+	if !model.Description.IsNull() {
+		t.Fatal("expected null description when the server returns an empty string")
+	}
+
+	cases := []struct {
+		name  string
+		plan  types.String
+		state types.String
+		want  bool
+	}{
+		{"unchanged", types.StringValue("a"), types.StringValue("a"), false},
+		{"changed", types.StringValue("b"), types.StringValue("a"), true},
+		{"added", types.StringValue("a"), types.StringNull(), true},
+		{"removed", types.StringNull(), types.StringValue("a"), true},
+		{"both_unset", types.StringNull(), types.StringNull(), false},
+		{"unknown_plan", types.StringUnknown(), types.StringValue("a"), false},
+	}
+	for _, tc := range cases {
+		if got := shouldUpdateDescription(tc.plan, tc.state); got != tc.want {
+			t.Errorf("%s: shouldUpdateDescription = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestTeamIDIsCarriedOverNotReadBack(t *testing.T) {
+	ctx := context.Background()
+
+	serverTeam := int32(42)
+	state, err := protoToModel(ctx, &v1.AutomationWithOwner{
+		TeamId:   &serverTeam,
+		Workflow: &v1.Automation{Workflow: &v1.Workflow{}},
+	})
+	if err != nil {
+		t.Fatalf("protoToModel() error: %v", err)
+	}
+	if !state.TeamID.IsNull() {
+		t.Fatal("protoToModel should not populate team_id from the server response")
+	}
+
+	plan := platformWorkflowModel{TeamID: types.Int64Value(7)}
+	preserveConfiguredValues(ctx, &state, plan)
+	if state.TeamID.ValueInt64() != 7 {
+		t.Fatalf("team_id = %v, want configured 7", state.TeamID)
+	}
+
+	if got := optionalTeamID(types.Int64Null()); got != nil {
+		t.Fatalf("optionalTeamID(null) = %v, want nil", *got)
+	}
+	if got := optionalTeamID(types.Int64Value(7)); got == nil || *got != 7 {
+		t.Fatalf("optionalTeamID(7) = %v", got)
+	}
+
+	if got := dataSourceTeamID(types.Int64Null(), &v1.AutomationWithOwner{TeamId: &serverTeam}); got.ValueInt64() != 42 {
+		t.Fatalf("dataSourceTeamID(unset) = %v, want server 42", got)
+	}
+	if got := dataSourceTeamID(types.Int64Value(7), &v1.AutomationWithOwner{TeamId: &serverTeam}); got.ValueInt64() != 7 {
+		t.Fatalf("dataSourceTeamID(configured) = %v, want 7", got)
+	}
+	if got := dataSourceTeamID(types.Int64Null(), &v1.AutomationWithOwner{}); !got.IsNull() {
+		t.Fatalf("dataSourceTeamID(no team) = %v, want null", got)
+	}
+}
+
+// TestDataSourceSchemaMirrorsResourceSchema guards the six-location sync rule:
+// every trigger and action block the resource exposes must exist in the data
+// source with the same nested attribute names.
+func TestDataSourceSchemaMirrorsResourceSchema(t *testing.T) {
+	ctx := context.Background()
+
+	r := &platformWorkflowResource{}
+	rResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, rResp)
+
+	d := &platformWorkflowDataSource{}
+	dResp := &datasource.SchemaResponse{}
+	d.Schema(ctx, datasource.SchemaRequest{}, dResp)
+
+	rAttrs := rResp.Schema.Attributes
+	dAttrs := dResp.Schema.Attributes
+	for name := range rAttrs {
+		if _, ok := dAttrs[name]; !ok {
+			t.Errorf("data source is missing top-level attribute %q", name)
+		}
+	}
+	for name := range dAttrs {
+		if _, ok := rAttrs[name]; !ok {
+			t.Errorf("resource is missing top-level attribute %q", name)
+		}
+	}
+
+	for _, block := range []string{"trigger", "action"} {
+		rNested := rAttrs[block].(schema.ListNestedAttribute).NestedObject.Attributes
+		dNested := dAttrs[block].(datasourceschema.ListNestedAttribute).NestedObject.Attributes
+		for name, rAttr := range rNested {
+			dAttr, ok := dNested[name]
+			if !ok {
+				t.Errorf("data source %s is missing %q", block, name)
+				continue
+			}
+			rSingle, rIsSingle := rAttr.(schema.SingleNestedAttribute)
+			dSingle, dIsSingle := dAttr.(datasourceschema.SingleNestedAttribute)
+			if rIsSingle != dIsSingle {
+				t.Errorf("%s.%s: nested kind differs between resource and data source", block, name)
+				continue
+			}
+			if !rIsSingle {
+				continue
+			}
+			for field := range rSingle.Attributes {
+				if _, ok := dSingle.Attributes[field]; !ok {
+					t.Errorf("data source %s.%s is missing %q", block, name, field)
+				}
+			}
+			for field := range dSingle.Attributes {
+				if _, ok := rSingle.Attributes[field]; !ok {
+					t.Errorf("resource %s.%s is missing %q", block, name, field)
+				}
+			}
+		}
+		for name := range dNested {
+			if _, ok := rNested[name]; !ok {
+				t.Errorf("resource %s is missing %q", block, name)
+			}
+		}
+	}
+}

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -2973,6 +2973,63 @@ func TestEmptyActionsRoundTrip(t *testing.T) {
 	})
 }
 
+func TestMicrosoftTeamsActionRejectsRespondAndPostAsThread(t *testing.T) {
+	_, err := actionModelToProto(&actionModel{
+		MicrosoftTeams: &microsoftTeamsActionModel{
+			TenantID:        types.StringValue("tenant"),
+			TeamID:          types.StringValue("team"),
+			ChannelIDs:      types.ListNull(types.StringType),
+			RespondInThread: types.BoolValue(true),
+			PostAsThread:    types.BoolValue(true),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "respond_in_thread and post_as_thread") {
+		t.Fatalf("expected respond_in_thread/post_as_thread error, got %v", err)
+	}
+}
+
+func TestMicrosoftTeamsChannelCreatedRequiresTeamIDs(t *testing.T) {
+	ctx := context.Background()
+
+	m := &platformWorkflowModel{
+		Prompt: types.StringValue("welcome channels"),
+		Triggers: []triggerModel{{
+			MicrosoftTeamsChannelCreated: &microsoftTeamsChannelCreatedTriggerModel{
+				TenantID: types.StringValue("tenant"),
+				TeamIDs:  types.ListNull(types.StringType),
+			},
+			UserAllowlist: types.ListNull(types.StringType),
+		}},
+	}
+	if _, err := modelToWorkflow(ctx, m); err == nil || !strings.Contains(err.Error(), "at least one team_id") {
+		t.Fatalf("expected team_id required error, got %v", err)
+	}
+
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	trigger := schemaResp.Schema.Attributes["trigger"].(schema.ListNestedAttribute)
+	mtc := trigger.NestedObject.Attributes["microsoft_teams_channel_created"].(schema.SingleNestedAttribute)
+	if !mtc.Attributes["team_ids"].(schema.ListAttribute).Required {
+		t.Fatal("microsoft_teams_channel_created.team_ids should be Required")
+	}
+}
+
+func TestSlackActionRespondInThreadIsDeprecated(t *testing.T) {
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+	action := schemaResp.Schema.Attributes["action"].(schema.ListNestedAttribute)
+	slack := action.NestedObject.Attributes["slack"].(schema.SingleNestedAttribute)
+	attr := slack.Attributes["respond_in_thread"].(schema.BoolAttribute)
+	if attr.DeprecationMessage == "" {
+		t.Fatal("slack.respond_in_thread should carry a DeprecationMessage")
+	}
+	if !attr.Optional || !attr.Computed {
+		t.Fatal("slack.respond_in_thread should stay Optional+Computed so existing configs keep working")
+	}
+}
+
 func TestDisabledDefaultToolsRoundTrip(t *testing.T) {
 	ctx := context.Background()
 
@@ -3118,6 +3175,38 @@ func TestTeamIDIsCarriedOverNotReadBack(t *testing.T) {
 	}
 	if got := dataSourceTeamID(types.Int64Null(), &v1.AutomationWithOwner{}); !got.IsNull() {
 		t.Fatalf("dataSourceTeamID(no team) = %v, want null", got)
+	}
+}
+
+func TestAutomationFromGetResponseRestrictedSummary(t *testing.T) {
+	_, err := automationFromGetResponse(&v1.GetAutomationResponse{
+		Result: &v1.GetAutomationResponse_RestrictedSummary{
+			RestrictedSummary: &v1.RestrictedAutomationSummary{
+				AutomationId: "abc",
+				Name:         "Private automation",
+				OwnerName:    "Jane",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for restricted summary")
+	}
+	for _, want := range []string{"abc", "Private automation", "Jane", "restricted summary"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err.Error(), want)
+		}
+	}
+
+	withOwner, err := automationFromGetResponse(&v1.GetAutomationResponse{
+		Result: &v1.GetAutomationResponse_Workflow{
+			Workflow: &v1.AutomationWithOwner{Workflow: &v1.Automation{AutomationId: "abc"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if withOwner.GetWorkflow().GetAutomationId() != "abc" {
+		t.Fatal("expected workflow variant to be returned unchanged")
 	}
 }
 

--- a/internal/provider/resource_platform_workflow_test.go
+++ b/internal/provider/resource_platform_workflow_test.go
@@ -7,10 +7,14 @@ import (
 	"testing"
 
 	v1 "github.com/cursor/terraform-provider-cursor/internal/proto/v1"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -3272,4 +3276,365 @@ func TestDataSourceSchemaMirrorsResourceSchema(t *testing.T) {
 			}
 		}
 	}
+}
+
+func modelSelectionParams(pairs ...string) []modelSelectionParameterModel {
+	var out []modelSelectionParameterModel
+	for i := 0; i+1 < len(pairs); i += 2 {
+		out = append(out, modelSelectionParameterModel{
+			ID:    types.StringValue(pairs[i]),
+			Value: types.StringValue(pairs[i+1]),
+		})
+	}
+	return out
+}
+
+func TestModelSelectionRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("model_to_proto_auto_cost", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			// Carried over from state via the plan modifier; must not be sent
+			// alongside the selection.
+			Model: types.StringValue("auto-smart"),
+			ModelSelection: &modelSelectionModel{
+				ModelID:    types.StringValue("auto-smart"),
+				Parameters: modelSelectionParams("optimize_for", "cost"),
+				MaxMode:    types.BoolNull(),
+			},
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}, UserAllowlist: types.ListNull(types.StringType)},
+			},
+		}
+
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.Model != nil {
+			t.Fatalf("model slug should not be sent with a selection, got %q", wf.GetModel())
+		}
+		sel := wf.GetModelSelection()
+		if sel == nil {
+			t.Fatal("expected model_selection in proto")
+		}
+		if sel.GetModelId() != "auto-smart" {
+			t.Fatalf("ModelId = %q", sel.GetModelId())
+		}
+		if len(sel.GetParameters()) != 1 || sel.GetParameters()[0].GetId() != "optimize_for" || sel.GetParameters()[0].GetValue() != "cost" {
+			t.Fatalf("Parameters = %v", sel.GetParameters())
+		}
+		if sel.MaxMode != nil {
+			t.Fatal("max_mode should be omitted when unset so the server applies its default")
+		}
+	})
+
+	t.Run("model_to_proto_without_selection_sends_slug", func(t *testing.T) {
+		m := &platformWorkflowModel{
+			Prompt: types.StringValue("review code"),
+			Model:  types.StringValue("gpt-5.5"),
+			Triggers: []triggerModel{
+				{Webhook: &webhookTriggerModel{}, UserAllowlist: types.ListNull(types.StringType)},
+			},
+		}
+		wf, err := modelToWorkflow(ctx, m)
+		if err != nil {
+			t.Fatalf("modelToWorkflow() error: %v", err)
+		}
+		if wf.GetModel() != "gpt-5.5" || wf.GetModelSelection() != nil {
+			t.Fatalf("unexpected model fields: model=%q selection=%v", wf.GetModel(), wf.GetModelSelection())
+		}
+	})
+
+	t.Run("model_to_proto_validation", func(t *testing.T) {
+		cases := map[string]*modelSelectionModel{
+			"empty_model_id":      {ModelID: types.StringValue(" ")},
+			"incomplete_param":    {ModelID: types.StringValue("auto-smart"), Parameters: modelSelectionParams("optimize_for", "")},
+			"duplicate_param":     {ModelID: types.StringValue("auto-smart"), Parameters: modelSelectionParams("optimize_for", "cost", "optimize_for", "balanced")},
+			"max_mode_false":      {ModelID: types.StringValue("auto-smart"), MaxMode: types.BoolValue(false)},
+			"max_mode_false_only": {ModelID: types.StringValue("gpt-5.5"), MaxMode: types.BoolValue(false)},
+		}
+		for name, sel := range cases {
+			if _, err := modelSelectionToProto(sel); err == nil {
+				t.Errorf("%s: expected error", name)
+			}
+		}
+
+		sel, err := modelSelectionToProto(&modelSelectionModel{
+			ModelID: types.StringValue(" auto-smart "),
+			Parameters: []modelSelectionParameterModel{
+				{ID: types.StringValue(" optimize_for "), Value: types.StringValue(" balanced ")},
+			},
+			MaxMode: types.BoolValue(true),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sel.GetModelId() != "auto-smart" || sel.GetParameters()[0].GetId() != "optimize_for" || sel.GetParameters()[0].GetValue() != "balanced" || sel.MaxMode == nil || !sel.GetMaxMode() {
+			t.Fatalf("unexpected trimmed selection: %v", sel)
+		}
+	})
+
+	t.Run("proto_to_model_set", func(t *testing.T) {
+		maxMode := true
+		model := "auto-smart"
+		out, err := protoToModel(ctx, &v1.AutomationWithOwner{
+			Workflow: &v1.Automation{
+				Workflow: &v1.Workflow{
+					Model: &model,
+					ModelSelection: &v1.AutomationModelSelection{
+						ModelId: "auto-smart",
+						Parameters: []*v1.AutomationModelSelection_ParameterValue{
+							{Id: "optimize_for", Value: "balanced"},
+						},
+						MaxMode: &maxMode,
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("protoToModel() error: %v", err)
+		}
+		if out.Model.ValueString() != "auto-smart" {
+			t.Fatalf("model = %q", out.Model.ValueString())
+		}
+		sel := out.ModelSelection
+		if sel == nil {
+			t.Fatal("expected model_selection in terraform model")
+		}
+		if sel.ModelID.ValueString() != "auto-smart" {
+			t.Fatalf("model_id = %q", sel.ModelID.ValueString())
+		}
+		if len(sel.Parameters) != 1 || sel.Parameters[0].ID.ValueString() != "optimize_for" || sel.Parameters[0].Value.ValueString() != "balanced" {
+			t.Fatalf("parameters = %+v", sel.Parameters)
+		}
+		if !sel.MaxMode.ValueBool() {
+			t.Fatal("expected max_mode=true")
+		}
+	})
+
+	t.Run("proto_to_model_null_when_absent_or_blank", func(t *testing.T) {
+		model := "gpt-5.5"
+		for name, wf := range map[string]*v1.Workflow{
+			"absent": {Model: &model},
+			"blank":  {Model: &model, ModelSelection: &v1.AutomationModelSelection{ModelId: " "}},
+		} {
+			out, err := protoToModel(ctx, &v1.AutomationWithOwner{Workflow: &v1.Automation{Workflow: wf}})
+			if err != nil {
+				t.Fatalf("%s: protoToModel() error: %v", name, err)
+			}
+			if out.ModelSelection != nil {
+				t.Fatalf("%s: expected null model_selection, got %+v", name, out.ModelSelection)
+			}
+			if out.Model.ValueString() != "gpt-5.5" {
+				t.Fatalf("%s: model = %q", name, out.Model.ValueString())
+			}
+		}
+	})
+}
+
+func TestPreserveEquivalentModelSelection(t *testing.T) {
+	t.Run("keeps_configured_order_and_whitespace", func(t *testing.T) {
+		state := platformWorkflowModel{ModelSelection: &modelSelectionModel{
+			ModelID:    types.StringValue("auto-smart"),
+			Parameters: modelSelectionParams("a", "1", "optimize_for", "cost"),
+			MaxMode:    types.BoolValue(true),
+		}}
+		reference := platformWorkflowModel{ModelSelection: &modelSelectionModel{
+			ModelID:    types.StringValue(" auto-smart"),
+			Parameters: modelSelectionParams("optimize_for", "cost ", "a", "1"),
+			MaxMode:    types.BoolNull(),
+		}}
+		preserveEquivalentModelSelection(&state, reference)
+		if state.ModelSelection.ModelID.ValueString() != " auto-smart" {
+			t.Fatalf("model_id = %q, want configured spelling", state.ModelSelection.ModelID.ValueString())
+		}
+		if !reflect.DeepEqual(state.ModelSelection.Parameters, reference.ModelSelection.Parameters) {
+			t.Fatalf("parameters = %+v, want configured order", state.ModelSelection.Parameters)
+		}
+		if !state.ModelSelection.MaxMode.ValueBool() {
+			t.Fatal("max_mode must keep the server value")
+		}
+	})
+
+	t.Run("keeps_server_values_when_different", func(t *testing.T) {
+		state := platformWorkflowModel{ModelSelection: &modelSelectionModel{
+			ModelID:    types.StringValue("auto-smart"),
+			Parameters: modelSelectionParams("optimize_for", "balanced"),
+		}}
+		reference := platformWorkflowModel{ModelSelection: &modelSelectionModel{
+			ModelID:    types.StringValue("auto-smart"),
+			Parameters: modelSelectionParams("optimize_for", "cost"),
+		}}
+		preserveEquivalentModelSelection(&state, reference)
+		if state.ModelSelection.Parameters[0].Value.ValueString() != "balanced" {
+			t.Fatal("differing parameters must not be overwritten with the configured ones")
+		}
+
+		// Server-populated defaults when the config omitted parameters.
+		state = platformWorkflowModel{ModelSelection: &modelSelectionModel{
+			ModelID:    types.StringValue("auto-smart"),
+			Parameters: modelSelectionParams("optimize_for", "balanced"),
+		}}
+		reference = platformWorkflowModel{ModelSelection: &modelSelectionModel{ModelID: types.StringValue("auto-smart")}}
+		preserveEquivalentModelSelection(&state, reference)
+		if len(state.ModelSelection.Parameters) != 1 {
+			t.Fatal("server default parameters must be kept when the config omitted them")
+		}
+	})
+
+	t.Run("noop_without_selection", func(t *testing.T) {
+		state := platformWorkflowModel{}
+		preserveEquivalentModelSelection(&state, platformWorkflowModel{ModelSelection: &modelSelectionModel{ModelID: types.StringValue("x")}})
+		if state.ModelSelection != nil {
+			t.Fatal("state without a selection must stay null")
+		}
+	})
+}
+
+func TestModelSelectionSchema(t *testing.T) {
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+
+	sel, ok := schemaResp.Schema.Attributes["model_selection"].(schema.SingleNestedAttribute)
+	if !ok || !sel.Optional || sel.Computed {
+		t.Fatalf("model_selection should be an Optional, non-Computed SingleNestedAttribute, got %#v", schemaResp.Schema.Attributes["model_selection"])
+	}
+	if modelID := sel.Attributes["model_id"].(schema.StringAttribute); !modelID.Required {
+		t.Fatal("model_selection.model_id should be Required")
+	}
+	params := sel.Attributes["parameters"].(schema.ListNestedAttribute)
+	if !params.Optional || !params.Computed || len(params.PlanModifiers) == 0 {
+		t.Fatal("model_selection.parameters should be Optional+Computed with a plan modifier (server fills default variant parameters)")
+	}
+	maxMode := sel.Attributes["max_mode"].(schema.BoolAttribute)
+	if !maxMode.Optional || !maxMode.Computed || len(maxMode.PlanModifiers) == 0 {
+		t.Fatal("model_selection.max_mode should be Optional+Computed with UseStateForUnknown (server defaults it to true)")
+	}
+	model := schemaResp.Schema.Attributes["model"].(schema.StringAttribute)
+	if !model.Optional || !model.Computed || len(model.PlanModifiers) != 1 {
+		t.Fatal("model should stay Optional+Computed with a single plan modifier")
+	}
+	if _, ok := model.PlanModifiers[0].(modelUseStateUnlessSelectionChanged); !ok {
+		t.Fatalf("model plan modifier = %T, want modelUseStateUnlessSelectionChanged", model.PlanModifiers[0])
+	}
+}
+
+// planStateForModelSelection builds tfsdk.Plan/State values holding just the
+// attributes the model plan modifiers read.
+func planStateForModelSelection(t *testing.T, model types.String, selection *modelSelectionModel, selectionUnknownParams bool) (tfsdk.Plan, tfsdk.State) {
+	t.Helper()
+	ctx := context.Background()
+
+	r := &platformWorkflowResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	// Zero-value lists/maps carry no element type, so give them typed nulls.
+	m := &platformWorkflowModel{
+		Model:                model,
+		ModelSelection:       selection,
+		DisabledDefaultTools: types.ListNull(types.StringType),
+	}
+	if diags := plan.Set(ctx, m); diags.HasError() {
+		t.Fatalf("set plan: %v", diags)
+	}
+	if selection != nil && selectionUnknownParams {
+		paramType := types.ObjectType{AttrTypes: map[string]attr.Type{"id": types.StringType, "value": types.StringType}}
+		if diags := plan.SetAttribute(ctx, path.Root("model_selection").AtName("parameters"), types.ListUnknown(paramType)); diags.HasError() {
+			t.Fatalf("set unknown parameters: %v", diags)
+		}
+	}
+	return plan, tfsdk.State{Schema: schemaResp.Schema, Raw: plan.Raw}
+}
+
+func TestModelPlanModifiersFollowSelectionChanges(t *testing.T) {
+	ctx := context.Background()
+	balanced := &modelSelectionModel{ModelID: types.StringValue("auto-smart"), Parameters: modelSelectionParams("optimize_for", "balanced"), MaxMode: types.BoolValue(true)}
+	cost := &modelSelectionModel{ModelID: types.StringValue("auto-smart"), Parameters: modelSelectionParams("optimize_for", "cost"), MaxMode: types.BoolValue(true)}
+	other := &modelSelectionModel{ModelID: types.StringValue("gpt-5.5"), MaxMode: types.BoolValue(true)}
+
+	_, state := planStateForModelSelection(t, types.StringValue("auto-smart"), balanced, false)
+
+	run := func(t *testing.T, plan tfsdk.Plan) (types.String, types.List) {
+		t.Helper()
+		strReq := planmodifier.StringRequest{Path: path.Root("model"), Plan: plan, State: state, PlanValue: types.StringUnknown(), StateValue: types.StringValue("auto-smart"), ConfigValue: types.StringNull()}
+		strResp := &planmodifier.StringResponse{PlanValue: strReq.PlanValue}
+		modelUseStateUnlessSelectionChanged{}.PlanModifyString(ctx, strReq, strResp)
+
+		var stateSel types.Object
+		state.GetAttribute(ctx, path.Root("model_selection"), &stateSel)
+		stateParams := stateSel.Attributes()["parameters"].(types.List)
+		listReq := planmodifier.ListRequest{Path: path.Root("model_selection").AtName("parameters"), Plan: plan, State: state, PlanValue: types.ListUnknown(stateParams.ElementType(ctx)), StateValue: stateParams, ConfigValue: types.ListNull(stateParams.ElementType(ctx))}
+		listResp := &planmodifier.ListResponse{PlanValue: listReq.PlanValue}
+		modelSelectionParametersUseStateUnlessModelChanged{}.PlanModifyList(ctx, listReq, listResp)
+		return strResp.PlanValue, listResp.PlanValue
+	}
+
+	t.Run("unchanged_selection_keeps_state", func(t *testing.T) {
+		plan, _ := planStateForModelSelection(t, types.StringUnknown(), balanced, false)
+		model, params := run(t, plan)
+		if model.IsUnknown() || model.ValueString() != "auto-smart" {
+			t.Fatalf("model = %v, want state value", model)
+		}
+		if params.IsUnknown() {
+			t.Fatal("parameters should be carried from state")
+		}
+	})
+
+	t.Run("unconfigured_parameters_keep_state", func(t *testing.T) {
+		plan, _ := planStateForModelSelection(t, types.StringUnknown(), balanced, true)
+		model, params := run(t, plan)
+		if model.IsUnknown() || params.IsUnknown() {
+			t.Fatalf("unknown parameters with the same model_id must not reset model (%v) or parameters (%v)", model, params)
+		}
+	})
+
+	t.Run("changed_parameters_reset_model", func(t *testing.T) {
+		plan, _ := planStateForModelSelection(t, types.StringUnknown(), cost, false)
+		model, _ := run(t, plan)
+		if !model.IsUnknown() {
+			t.Fatalf("model = %v, want unknown after a parameter change", model)
+		}
+	})
+
+	t.Run("changed_model_id_resets_both", func(t *testing.T) {
+		plan, _ := planStateForModelSelection(t, types.StringUnknown(), other, true)
+		model, params := run(t, plan)
+		if !model.IsUnknown() || !params.IsUnknown() {
+			t.Fatalf("model (%v) and parameters (%v) must be unknown after a model_id change", model, params)
+		}
+	})
+
+	t.Run("removed_selection_resets_model", func(t *testing.T) {
+		plan, _ := planStateForModelSelection(t, types.StringUnknown(), nil, false)
+		model, _ := run(t, plan)
+		if !model.IsUnknown() {
+			t.Fatalf("model = %v, want unknown after removing model_selection", model)
+		}
+	})
+}
+
+func TestValidateConfigRejectsModelWithModelSelection(t *testing.T) {
+	ctx := context.Background()
+	r := &platformWorkflowResource{}
+
+	check := func(t *testing.T, model types.String, selection *modelSelectionModel, wantErr bool) {
+		t.Helper()
+		plan, _ := planStateForModelSelection(t, model, selection, false)
+		resp := &resource.ValidateConfigResponse{}
+		r.ValidateConfig(ctx, resource.ValidateConfigRequest{Config: tfsdk.Config{Schema: plan.Schema, Raw: plan.Raw}}, resp)
+		if resp.Diagnostics.HasError() != wantErr {
+			t.Fatalf("model=%v selection=%v: HasError=%v, want %v (%v)", model, selection != nil, resp.Diagnostics.HasError(), wantErr, resp.Diagnostics)
+		}
+	}
+
+	sel := &modelSelectionModel{ModelID: types.StringValue("auto-smart"), MaxMode: types.BoolNull()}
+	check(t, types.StringValue("auto-smart"), sel, true)
+	check(t, types.StringNull(), sel, false)
+	check(t, types.StringValue("gpt-5.5"), nil, false)
+	check(t, types.StringNull(), nil, false)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings `cursor_platform_workflow` (resource + data source) back in sync with the current `aiserver.v1.AutomationsService` contract. Rebased onto `main` after #10 (`private_worker`) merged. Commits, in order:

### 1. Regenerate vendored API types
`internal/proto/v1/automations.pb.go` regenerated with everysphere's `scripts/regen-terraform-provider-cursor-proto.py` (unmodified; buf 1.66.1, remote plugins pinned to `protocolbuffers/go:v1.36.11` / `connectrpc/go:v1.19.1`). Re-running the script on the branch head is a no-op. `automations.connect.go` did not change. New on the wire: `slack_mention` / `slack_any_reaction_added` triggers, `Workflow.disabled_default_tools` + `AutomationDefaultTool`, `GetAutomationRequest.team_id`, plus other fields the provider does not map yet (`only_once`, `pr_number`, `pull_request_review_requested`, `issue_assigned`, sand ids). No field renumbering; `ErrorDetails` decoding untouched.

### 2. New schema surface (resource and data source)

Triggers (each a `SingleNestedAttribute`, one per `trigger` element):
- `slack_channel_created { channel_name_contains }`
- `slack_reaction_added { channel (req), emoji_name (req), block_unauthenticated_slack_users, only_owner_reactions }`
- `slack_mention { channel (req), block_unauthenticated_slack_users }`
- `slack_any_reaction_added { channel (req), block_unauthenticated_slack_users, only_owner_reactions }`
- `pagerduty { incident_triggered | incident_acknowledged | incident_resolved | incident_escalated | incident_any (exactly one, empty blocks), service_ids }`
- `sentry { issue_created | issue_resolved | issue_assigned | issue_archived | issue_unresolved | issue_any (exactly one), project_ids }`

Actions: `manage_check_run {}`, `approve_pr {}` (carries a `DeprecationMessage` pointing at `pr_comment.allow_approve`), `resolve_review_threads {}`.

Top-level: `description` (sent on Create; on Update only when changed, `""` clears), `team_id` (Int64; sent on `CreateAutomation` and `GetAutomation`), `disabled_default_tools` (list, `"open_git_pr"`).

Design notes:
- Slack channel fields follow the existing `slack` trigger: single `channel` only, false booleans read back as `null`. The server fills both `channel` and `channels`; `channels` is not exposed (same as the existing `slack` trigger).
- `emoji_name` must already be the canonical short name (`^[a-z0-9_+-]+$`, no colons). The server normalises `:ThumbsUp:` → `thumbsup`, which would otherwise be an inconsistent-result error.
- `team_id` is Optional (not Computed) on the resource and is **not** read back from `AutomationWithOwner.team_id`: the server sets it to the ambient team for every automation, and passing that back on `GetAutomation` breaks service-account tokens (`resolveAutomationTeamScopedAccessContext` requires a user). Changing it between two set values triggers `RequiresReplaceIf`; `null → X` (import/adopt) does not. The data source reports the server value when not configured.
- PagerDuty/Sentry event selection mirrors the `linear` pattern (exactly one empty nested block, validated in `triggerModelToProto`).

### 3. Contract drift fixes (overview §6)
- `slack.respond_in_thread`: `DeprecationMessage` added, still mapped so existing configs keep applying.
- `microsoft_teams_channel_created.team_ids`: now `Required` + runtime check (server rejects empty in `assertSupportedWorkflowForPersistence`).
- `microsoft_teams` action: rejects `respond_in_thread && post_as_thread` before the API does.
- `GetAutomation` `restricted_summary`: resource Read and data source now fail with a message naming the automation/owner instead of "automation response is empty".
- Data-source `scope` description lists all five scopes.

### 4. Docs and examples
`make docs` (tfplugindocs 0.25.0 generate + validate); `examples/resources/cursor_platform_workflow/resource.tf` gained Slack-reaction and PagerDuty/Sentry examples.

### 5. Second regen (Sand-only fields)
`Workflow.grok_bot_session_id` (20), `Workflow.grok_bot_creator_auth_id` (21), `Automation.sand_last_run_at_ms` (18) from everysphere `645bb3bfc5ef`. Server-managed and only set on Sand automations (cloud `GetAutomation` filters `executionRuntime: CLOUD`), so vendored but not exposed.

### 6. Third regen + `model_selection` (everysphere PR 1040035, CPROD-1894, landed as `a4618989fddc`)
Regenerated against everysphere `main` @ `b8a9a2023ea0` after the rebase; adds `Workflow.model_selection` (22), `Prompt.model_selection` (7), `AutomationModelSelection { model_id; parameters[] { id, value }; max_mode }`.

New attribute on the resource and data source (top-level only — the provider does not expose `Prompt.model`, so there is no per-prompt twin):

```hcl
model_selection = {
  model_id   = "auto-smart"
  parameters = [{ id = "optimize_for", value = "cost" }]   # "cost" | "balanced" | "intelligence"
  # max_mode defaults to true (server rejects false today)
}
```

Read-back strategy (from `backend/server/src/automations/workflowModelMigration.ts`, `workflowPreflight.ts`, `cloud-agent/externalUtils/cloudAgentDefaultModel.ts`, `cloud-agent/externalUtils/modelValidation.ts`):
- The server never back-fills `model_selection` from `model` (`normalizeWorkflowModelHolder` only fills `model` from the selection), so the block is plain **Optional**: an unset config reads back null, no drift. Blank `model_id` selections are read as null, matching the server dropping them.
- `stampAutomationModelSelections` overwrites `model` from the validated selection's legacy projection and replaces the selection with the canonical variant (`canonicalParams` come from the matched catalog variant; `maxMode` defaults to `true`). Hence:
  - `parameters` is Optional+Computed with a plan modifier that carries the state value while `model_id`/`max_mode` are unchanged (fresh defaults are unknown when `model_id` changes); `preserveEquivalentModelSelection` keeps the configured order/whitespace when the canonical echo is set-equal.
  - `max_mode` is Optional+Computed + `UseStateForUnknown`; `false` is rejected client-side, mirroring `validateStructuredModelSelectionForSave` ("Non-max structured default models are not supported yet").
  - `model` stays Optional+Computed, but its `UseStateForUnknown` now yields (stays unknown) when `model_selection` changed. `ValidateConfig` rejects `model` set together with `model_selection`, and the slug is not sent when a selection is present, so a state-carried slug never fights the server's projection.
- Client-side checks mirror `validateModelSelection`: non-empty `model_id`, no incomplete or duplicate parameters. Catalog checks (unknown model, blocked Auto tier, regional block, variant mismatch) remain apply-time `invalid_argument` errors.

## Testing
- `go build ./... && go vet ./... && go test ./...` pass (65 tests; 19 new since `main` beyond #10's, incl. 5 for `model_selection`: proto round-trip set/null/blank, trim + validation, preserve helper ordering, plan-modifier behaviour for unchanged/changed/removed selections, `ValidateConfig` conflict).
- `gofmt -l` clean, `go mod tidy` no diff, `tfplugindocs generate` committed, `tfplugindocs validate` passes.
- Rebase conflicts (both additive, kept both sides): `platformWorkflowModel` struct (`private_worker` + new fields), test import alias (`datasourceschema`), and appended tests at the end of `resource_platform_workflow_test.go`.
- Not run against the live API (per task). Backend semantics inferred from source rather than exercised: Slack reaction channel-name→ID resolution, PagerDuty/Sentry event requiredness (server does not validate; provider requires one), Sentry connection precondition, exact `legacyProjection` for non-Auto models with variants (affects only whether `model` shows "(known after apply)" on selection changes).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28b0cdb6-20b1-5017-9f78-d9bd4bd33a18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28b0cdb6-20b1-5017-9f78-d9bd4bd33a18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

